### PR TITLE
Fix broken hotkey/page-reset and drop CDN dep on homepage slider

### DIFF
--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -46,7 +46,7 @@ export function SpaceView() {
   const totalPages = Math.ceil(items.length / ITEMS_PER_PAGE);
 
   // Reset to page 1 when filters change
-  useMemo(() => {
+  useEffect(() => {
     setPage(1);
   }, [tagsParam]);
 
@@ -54,8 +54,8 @@ export function SpaceView() {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const isMod = e.metaKey || e.ctrlKey;
+      if (!isMod || e.key.toLowerCase() !== "i") return;
 
-      // For other keys, check if typing
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       const role = target?.getAttribute?.("role");
@@ -66,11 +66,14 @@ export function SpaceView() {
         role === "textbox";
 
       if (isTyping) return;
+
+      e.preventDefault();
+      setEditorOpen(!editorOpen);
     };
 
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, []);
+  }, [editorOpen, setEditorOpen]);
 
   const onEnroll = useCallback(async (id: string) => {
     const { data: { user } } = await supabase.auth.getUser();

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -12,19 +12,20 @@ export default function UTCTimeVisualizer() {
   const [mounted, setMounted] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const sliderRef = useRef<HTMLInputElement>(null);
-  const gradientPosRef = useRef({ value: 0 });
+
+  // Move the day/night gradient under the thumb. The smoothing is a CSS
+  // transition on the element (see .slider-daynight), so no JS tween is needed.
+  const setSliderGradient = (minutes: number) => {
+    if (!sliderRef.current) return;
+    const targetPos = (minutes / 1439) * 100;
+    sliderRef.current.style.backgroundPosition = `${targetPos}% 50%`;
+  };
 
   // Check if DST is active for US timezones
   const useDST = isDSTActive('us');
 
   useEffect(() => {
     setMounted(true);
-    
-    // Load anime.js
-    const script = document.createElement('script');
-    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js';
-    script.async = true;
-    document.head.appendChild(script);
 
     // Detect user's timezone and set current time
     const now = new Date();
@@ -44,17 +45,7 @@ export default function UTCTimeVisualizer() {
     setUtcOffset(offsetStr);
 
     // Set initial gradient position
-    const initialPos = (minutesSinceMidnight / 1439) * 100;
-    gradientPosRef.current.value = initialPos;
-    if (sliderRef.current) {
-      sliderRef.current.style.backgroundPosition = `${initialPos}% 50%`;
-    }
-
-    return () => {
-      if (document.head.contains(script)) {
-        document.head.removeChild(script);
-      }
-    };
+    setSliderGradient(minutesSinceMidnight);
   }, []);
 
   const calculateUTC = () => {
@@ -75,46 +66,9 @@ export default function UTCTimeVisualizer() {
   const pacificOffset = useDST ? -7 : -8;
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTime = parseInt(e.target.value);
+    const newTime = parseInt(e.target.value, 10);
     setLocalTime(newTime);
-
-    const targetPos = (newTime / 1439) * 100;
-    if ((window as any).anime && sliderRef.current) {
-      (window as any).anime({
-        targets: gradientPosRef.current,
-        value: targetPos,
-        duration: 300,
-        easing: 'easeOutCubic',
-        update: () => {
-          if (sliderRef.current) {
-            sliderRef.current.style.backgroundPosition = `${gradientPosRef.current.value}% 50%`;
-          }
-        }
-      });
-    }
-  };
-
-  const handleSliderHover = (e: React.MouseEvent<HTMLInputElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const percentage = Math.max(0, Math.min(1, x / rect.width));
-    const newTime = Math.round(percentage * 1439);
-    setLocalTime(newTime);
-
-    const targetPos = (newTime / 1439) * 100;
-    if ((window as any).anime && sliderRef.current) {
-      (window as any).anime({
-        targets: gradientPosRef.current,
-        value: targetPos,
-        duration: 150,
-        easing: 'easeOutQuad',
-        update: () => {
-          if (sliderRef.current) {
-            sliderRef.current.style.backgroundPosition = `${gradientPosRef.current.value}% 50%`;
-          }
-        }
-      });
-    }
+    setSliderGradient(newTime);
   };
 
   const handleWrapperHover = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -125,21 +79,7 @@ export default function UTCTimeVisualizer() {
     const cappedPercentage = Math.max(0, Math.min(1, percentage));
     const newTime = Math.round(cappedPercentage * 1439);
     setLocalTime(newTime);
-
-    const targetPos = (newTime / 1439) * 100;
-    if ((window as any).anime && sliderRef.current) {
-      (window as any).anime({
-        targets: gradientPosRef.current,
-        value: targetPos,
-        duration: 150,
-        easing: 'easeOutQuad',
-        update: () => {
-          if (sliderRef.current) {
-            sliderRef.current.style.backgroundPosition = `${gradientPosRef.current.value}% 50%`;
-          }
-        }
-      });
-    }
+    setSliderGradient(newTime);
   };
 
   const formatTime = (hours: number, minutes: number) => {
@@ -157,20 +97,7 @@ export default function UTCTimeVisualizer() {
 
   const jumpToCurrentTime = () => {
     setLocalTime(currentTime);
-    const targetPos = (currentTime / 1439) * 100;
-    if ((window as any).anime && sliderRef.current) {
-      (window as any).anime({
-        targets: gradientPosRef.current,
-        value: targetPos,
-        duration: 500,
-        easing: 'easeOutCubic',
-        update: () => {
-          if (sliderRef.current) {
-            sliderRef.current.style.backgroundPosition = `${gradientPosRef.current.value}% 50%`;
-          }
-        }
-      });
-    }
+    setSliderGradient(currentTime);
   };
 
   const getTimeOfDay = () => {
@@ -230,6 +157,12 @@ export default function UTCTimeVisualizer() {
           );
           background-size: 200% 100%;
           background-position: 0% 50%;
+          transition: background-position 0.2s ease-out;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .slider-daynight {
+            transition: none;
+          }
         }
         .slider-daynight::-webkit-slider-thumb {
           appearance: none;
@@ -273,20 +206,7 @@ export default function UTCTimeVisualizer() {
           {/* Header */}
           <CurrentTimeDisplay onJumpToTime={(minutes) => {
             setLocalTime(minutes);
-            const targetPos = (minutes / 1439) * 100;
-            if ((window as any).anime && sliderRef.current) {
-              (window as any).anime({
-                targets: gradientPosRef.current,
-                value: targetPos,
-                duration: 500,
-                easing: 'easeOutCubic',
-                update: () => {
-                  if (sliderRef.current) {
-                    sliderRef.current.style.backgroundPosition = `${gradientPosRef.current.value}% 50%`;
-                  }
-                }
-              });
-            }
+            setSliderGradient(minutes);
           }} />
 
           {/* Slider */}
@@ -308,7 +228,8 @@ export default function UTCTimeVisualizer() {
                   step="1"
                   value={localTime}
                   onChange={handleSliderChange}
-                  onMouseMove={handleSliderHover}
+                  aria-label="Local time of day"
+                  aria-valuetext={`${formatTime(localHours, localMinutes)} ${getTimeOfDay()}`}
                   className="w-full h-16 rounded-full appearance-none cursor-pointer slider-daynight"
                 />
               </div>


### PR DESCRIPTION
space-view:
- Implement the Cmd/Ctrl+I editor toggle. The keydown handler existed
  but did nothing (computed isTyping then returned), so the documented
  hotkey never worked.
- Reset pagination via useEffect instead of calling setState inside a
  useMemo, which is a render-phase side effect.

time-conversion-visualizer (homepage):
- Remove the runtime <script> injection of anime.js from an external
  CDN; smooth the day/night gradient with a CSS transition instead. No
  external network dependency, and the animation no longer silently
  no-ops when the CDN is blocked.
- Honor prefers-reduced-motion, add aria-label/aria-valuetext to the
  range slider, and drop the duplicate hover handler on the input
  (the wrapper already scrubs).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EkC4vPAn8ew5PCEn2W2jeV