### PR TITLE
Prevent white flash when loading dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import '@/app/globals.css';
 import { inter } from '@/components/ui/assets/fonts';
 import { Metadata } from 'next';
+import { Suspense } from 'react';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { Analytics } from '@vercel/analytics/next';
@@ -61,17 +62,19 @@ export default function RootLayout({
         <link rel="dns-prefetch" href="https://vitals.vercel-insights.com" />
       </head>
       <body className={`${inter.className} antialiased`}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          {children}
-          <Toaster />
-          <Analytics />
-          <SpeedInsights />
-        </ThemeProvider>
+        <Suspense fallback={null}>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            {children}
+            <Toaster />
+            <Analytics />
+            <SpeedInsights />
+          </ThemeProvider>
+        </Suspense>
         <DeferredScripts />
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,11 +2,27 @@ import '@/app/globals.css';
 import { inter } from '@/components/ui/assets/fonts';
 import { Metadata } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';
-import { Toaster } from "@/components/ui/sonner"
-import { Analytics } from "@vercel/analytics/next"
+import { Toaster } from '@/components/ui/sonner';
+import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { DeferredScripts } from './deferred-scripts';
-import { Suspense } from 'react';
+
+const themeInitScript = `
+  (() => {
+    try {
+      const savedTheme = localStorage.getItem('theme');
+      const theme =
+        savedTheme === 'light' || savedTheme === 'dark'
+          ? savedTheme
+          : window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+
+      document.documentElement.classList.toggle('dark', theme === 'dark');
+      document.documentElement.style.colorScheme = theme;
+    } catch {}
+  })();
+`;
 
 export const metadata: Metadata = {
   title: {
@@ -16,8 +32,8 @@ export const metadata: Metadata = {
   description: 'teamleaderleo.',
   metadataBase: new URL('https://teamleaderleo.com'),
   alternates: {
-    canonical: 'https://teamleaderleo.com'
-  }
+    canonical: 'https://teamleaderleo.com',
+  },
 };
 
 export default function RootLayout({
@@ -28,24 +44,34 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <style>{`
+          html {
+            background-color: #ffffff;
+            color-scheme: light;
+          }
+
+          html.dark {
+            background-color: #0e0e16;
+            color-scheme: dark;
+          }
+        `}</style>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         {/* Preconnect to external domains to speed up third-party resources */}
         <link rel="preconnect" href="https://vitals.vercel-insights.com" />
         <link rel="dns-prefetch" href="https://vitals.vercel-insights.com" />
       </head>
       <body className={`${inter.className} antialiased`}>
-        <Suspense fallback={null}>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            {children}
-            <Toaster />
-            <Analytics />
-            <SpeedInsights />
-          </ThemeProvider>
-        </Suspense>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {children}
+          <Toaster />
+          <Analytics />
+          <SpeedInsights />
+        </ThemeProvider>
         <DeferredScripts />
       </body>
     </html>


### PR DESCRIPTION
## What changed
- apply the saved `next-themes` preference in `<head>` before first paint
- give the document an immediate dark background while the main stylesheet loads
- keep system-theme fallback behavior
- render the theme provider directly instead of behind a Suspense boundary

## Why
Refreshing while dark mode is selected briefly painted the light `:root` background before the `dark` class was restored. This makes the initial paint match the saved theme.