### PR TITLE
Turn homepage into a GitHub activity dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ The repo began as a visual project-management app built around projects, blocks,
 
 ## What is live now
 
-### Home — time-zone visualizer
+### Home — GitHub activity
 
-The homepage is an interactive time converter for comparing UTC, Eastern, Pacific, local time, and a selectable time zone across a full day.
+The homepage answers “what has Leo been up to?” with a cached view of recent GitHub contributions, featured public repositories, and merged pull requests.
+
+When `GITHUB_TOKEN` or `GITHUB_ACCESS_TOKEN` is available, the page uses GitHub GraphQL for the contribution calendar and exact totals. The token-free path falls back to public REST activity and public repository data. Both paths are cached for about ten minutes, so the page needs no webhook, cron job, or per-visit API storm.
+
+### Time machine — time-zone visualizer
+
+`/time` is an interactive time converter for comparing UTC, Eastern, Pacific, local time, and a selectable time zone across a full day. The current local time also appears as a ticking link in the site navigation.
 
 ### Space — personal reference and learning workspace
 
@@ -84,7 +90,7 @@ pnpm prettier:check
 pnpm build
 ```
 
-The public homepage can render without database credentials. Authentication, saved content, proxy reporting, AI features, and storage integrations require their corresponding environment variables and services.
+The public homepage can render without database credentials or a GitHub token. Authentication, saved content, exact contribution totals, proxy reporting, AI features, and storage integrations require their corresponding environment variables and services.
 
 ## Status
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,10 +32,13 @@ function formatDate(value: string | null): string {
   }).format(new Date(value));
 }
 
-function formatRelativeDate(value: string): string {
+function formatRelativeDate(value: string, referenceValue: string): string {
   const elapsedDays = Math.max(
     0,
-    Math.floor((Date.now() - new Date(value).getTime()) / 86_400_000),
+    Math.floor(
+      (new Date(referenceValue).getTime() - new Date(value).getTime()) /
+        86_400_000,
+    ),
   );
 
   if (elapsedDays === 0) return 'today';
@@ -251,7 +254,13 @@ export default async function Page() {
                   <span className="inline-flex items-center gap-1">
                     <GitFork size={13} /> {formatNumber(repository.forks)}
                   </span>
-                  <span>updated {formatRelativeDate(repository.updatedAt ?? activity.generatedAt)}</span>
+                  <span>
+                    updated{' '}
+                    {formatRelativeDate(
+                      repository.updatedAt ?? activity.generatedAt,
+                      activity.generatedAt,
+                    )}
+                  </span>
                 </div>
               </Link>
             ))}
@@ -295,7 +304,13 @@ export default async function Page() {
                           {pullRequest.repository}
                         </Link>
                         <span>#{pullRequest.number}</span>
-                        <span>merged {formatRelativeDate(pullRequest.mergedAt)}</span>
+                        <span>
+                          merged{' '}
+                          {formatRelativeDate(
+                            pullRequest.mergedAt,
+                            activity.generatedAt,
+                          )}
+                        </span>
                       </div>
 
                       <Link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,331 @@
-import SiteNav from "@/components/site-nav";
-import UTCTimeVisualizer from "@/components/time-conversion-visualizer";
-import { Metadata } from "next";
+import SiteNav from '@/components/site-nav';
+import { getGitHubHomeData, type ContributionDay } from '@/lib/github-home';
+import {
+  ArrowUpRight,
+  GitCommitHorizontal,
+  GitFork,
+  GitPullRequest,
+  Sparkles,
+  Star,
+} from 'lucide-react';
+import { Metadata } from 'next';
+import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Time Zone Converter Visualizer - Convert Time Across Global Time Zones',
-  description: 'Visualize time zone conversions. Convert time between UTC, EST, PST, CET and your local timezone. A visual interface for time conversion.',
+  title: 'What Leo has been up to',
+  description:
+    'Recent GitHub contributions, public repositories, and merged pull requests from teamleaderleo.',
 };
 
-export default function Page() {
+function formatNumber(value: number | null): string {
+  if (value === null) return '—';
+  return new Intl.NumberFormat('en-CA').format(value);
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return 'recently';
+
+  return new Intl.DateTimeFormat('en-CA', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(value));
+}
+
+function formatRelativeDate(value: string): string {
+  const elapsedDays = Math.max(
+    0,
+    Math.floor((Date.now() - new Date(value).getTime()) / 86_400_000),
+  );
+
+  if (elapsedDays === 0) return 'today';
+  if (elapsedDays === 1) return 'yesterday';
+  if (elapsedDays < 7) return `${elapsedDays} days ago`;
+
+  return formatDate(value);
+}
+
+function excerpt(value: string): string {
+  const cleaned = value
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/[`#>*_[\]()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!cleaned) return 'A recently merged piece of work.';
+  if (cleaned.length <= 220) return cleaned;
+  return `${cleaned.slice(0, 217).trimEnd()}…`;
+}
+
+function activityClass(day: ContributionDay, maximum: number): string {
+  if (day.count === 0) return 'bg-muted';
+
+  const ratio = maximum === 0 ? 0 : day.count / maximum;
+  if (ratio > 0.75) return 'bg-emerald-500';
+  if (ratio > 0.45) return 'bg-emerald-500/75';
+  if (ratio > 0.2) return 'bg-emerald-500/50';
+  return 'bg-emerald-500/25';
+}
+
+function dataSourceCopy(source: 'graphql' | 'public-rest' | 'unavailable'): string {
+  if (source === 'graphql') {
+    return 'GitHub contribution calendar · refreshed about every 10 minutes';
+  }
+
+  if (source === 'public-rest') {
+    return 'Public GitHub activity · refreshed about every 10 minutes';
+  }
+
+  return 'GitHub data is taking a nap';
+}
+
+export default async function Page() {
+  const activity = await getGitHubHomeData();
+  const maximumDay = Math.max(...activity.days.map((day) => day.count), 0);
+  const publicRepositoriesUrl = `https://github.com/${activity.username}?tab=repositories&type=public`;
+
   return (
-    <main className="flex flex-col min-h-screen bg-sidebar-background">
+    <main className="min-h-screen bg-sidebar-background text-foreground">
       <SiteNav />
-      <UTCTimeVisualizer />
+
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
+        <header className="mb-8 max-w-3xl sm:mb-10">
+          <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.22em] text-emerald-600 dark:text-emerald-400">
+            <Sparkles size={14} />
+            live from github
+          </div>
+          <h1 className="text-balance text-4xl font-black tracking-tight sm:text-5xl lg:text-6xl">
+            what has Leo been up to?
+          </h1>
+          <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+            Contributions climbing, agents running, pull requests landing. This is the
+            current trail of sparks.
+          </p>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-[1.15fr_0.85fr]">
+          <div className="overflow-hidden rounded-3xl border bg-background p-6 shadow-sm sm:p-8">
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">
+                  {activity.stats.label} today
+                </p>
+                <p className="mt-2 text-7xl font-black tabular-nums tracking-[-0.08em] sm:text-8xl">
+                  {formatNumber(activity.stats.today)}
+                </p>
+              </div>
+
+              <Link
+                href={`https://github.com/${activity.username}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-semibold text-muted-foreground transition hover:-translate-y-0.5 hover:bg-muted hover:text-foreground"
+              >
+                @{activity.username}
+                <ArrowUpRight size={14} />
+              </Link>
+            </div>
+
+            <div className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl bg-muted/60 p-4">
+                <p className="text-2xl font-bold tabular-nums">
+                  {formatNumber(activity.stats.lastSevenDays)}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">last 7 days</p>
+              </div>
+              <div className="rounded-2xl bg-muted/60 p-4">
+                <p className="text-2xl font-bold tabular-nums">
+                  {formatNumber(activity.stats.year)}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {activity.stats.year === null ? 'year total with token' : 'this year'}
+                </p>
+              </div>
+              <div className="col-span-2 rounded-2xl bg-muted/60 p-4 sm:col-span-1">
+                <p className="text-2xl font-bold tabular-nums">
+                  {activity.stats.streak}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">day streak</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border bg-background p-6 shadow-sm sm:p-8">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold">the last two weeks</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Every square wants to become greener.
+                </p>
+              </div>
+              <GitCommitHorizontal className="text-emerald-500" size={22} />
+            </div>
+
+            <div className="mt-8 grid grid-cols-7 gap-2" aria-label="Fourteen days of GitHub activity">
+              {activity.days.map((day) => (
+                <div
+                  key={day.date}
+                  className={`aspect-square rounded-md ${activityClass(day, maximumDay)}`}
+                  title={`${day.date}: ${day.count}`}
+                  aria-label={`${day.date}: ${day.count}`}
+                />
+              ))}
+            </div>
+
+            <div className="mt-6 flex items-center justify-between gap-4 text-xs text-muted-foreground">
+              <span>{dataSourceCopy(activity.source)}</span>
+              <span className="shrink-0 tabular-nums">
+                {formatDate(activity.generatedAt)}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-10 sm:mt-14">
+          <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                currently cooking
+              </p>
+              <h2 className="mt-1 text-2xl font-bold tracking-tight sm:text-3xl">
+                featured public repositories
+              </h2>
+            </div>
+            <Link
+              href={publicRepositoriesUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-semibold text-muted-foreground transition hover:text-foreground"
+            >
+              all public repositories
+              <ArrowUpRight size={14} />
+            </Link>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {activity.featuredRepositories.map((repository) => (
+              <Link
+                key={repository.nameWithOwner}
+                href={repository.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group rounded-3xl border bg-background p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {repository.nameWithOwner}
+                    </p>
+                    <h3 className="mt-1 text-2xl font-black tracking-tight group-hover:text-emerald-600 dark:group-hover:text-emerald-400">
+                      {repository.name}
+                    </h3>
+                  </div>
+                  <ArrowUpRight
+                    className="text-muted-foreground transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground"
+                    size={20}
+                  />
+                </div>
+
+                <p className="mt-4 min-h-12 text-sm leading-6 text-muted-foreground">
+                  {repository.description ??
+                    (repository.name === 'smolrunner'
+                      ? 'A careful little runner growing into serious host automation.'
+                      : 'Durable coordination and communication for agents doing real work.')}
+                </p>
+
+                {repository.latestCommitMessage && (
+                  <div className="mt-5 rounded-2xl bg-muted/60 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                      latest commit
+                    </p>
+                    <p className="mt-1 text-sm font-medium">
+                      {repository.latestCommitMessage}
+                    </p>
+                  </div>
+                )}
+
+                <div className="mt-5 flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+                  <span className="inline-flex items-center gap-1">
+                    <Star size={13} /> {formatNumber(repository.stars)}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    <GitFork size={13} /> {formatNumber(repository.forks)}
+                  </span>
+                  <span>updated {formatRelativeDate(repository.updatedAt ?? activity.generatedAt)}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-10 sm:mt-14">
+          <div className="mb-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              recently merged
+            </p>
+            <h2 className="mt-1 text-2xl font-bold tracking-tight sm:text-3xl">
+              the changelog, with a pulse
+            </h2>
+          </div>
+
+          {activity.recentPullRequests.length > 0 ? (
+            <div className="space-y-3">
+              {activity.recentPullRequests.map((pullRequest, index) => (
+                <article
+                  key={pullRequest.url}
+                  className="rounded-2xl border bg-background p-5 shadow-sm sm:p-6"
+                >
+                  <div className="flex gap-4">
+                    <div className="mt-0.5 hidden h-9 w-9 shrink-0 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-600 sm:flex dark:text-emerald-400">
+                      <GitPullRequest size={17} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                        {index < 2 && (
+                          <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 font-semibold text-emerald-700 dark:text-emerald-300">
+                            notable
+                          </span>
+                        )}
+                        <Link
+                          href={pullRequest.repositoryUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-semibold hover:text-foreground"
+                        >
+                          {pullRequest.repository}
+                        </Link>
+                        <span>#{pullRequest.number}</span>
+                        <span>merged {formatRelativeDate(pullRequest.mergedAt)}</span>
+                      </div>
+
+                      <Link
+                        href={pullRequest.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group mt-2 inline-flex items-start gap-2 text-lg font-bold leading-6 hover:text-emerald-600 dark:hover:text-emerald-400"
+                      >
+                        {pullRequest.title}
+                        <ArrowUpRight
+                          className="mt-1 shrink-0 text-muted-foreground transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+                          size={15}
+                        />
+                      </Link>
+
+                      <p className="mt-3 max-w-4xl text-sm leading-6 text-muted-foreground">
+                        {excerpt(pullRequest.body)}
+                      </p>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed bg-background p-8 text-center text-sm text-muted-foreground">
+              The PR feed is between refreshes. The repository links above are awake.
+            </div>
+          )}
+        </section>
+      </div>
     </main>
   );
 }

--- a/app/time/page.tsx
+++ b/app/time/page.tsx
@@ -1,0 +1,18 @@
+import SiteNav from '@/components/site-nav';
+import UTCTimeVisualizer from '@/components/time-conversion-visualizer';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Time machine',
+  description:
+    'Slide through the day and compare local time, UTC, Eastern, Pacific, and other time zones.',
+};
+
+export default function TimePage() {
+  return (
+    <main className="flex min-h-screen flex-col bg-sidebar-background">
+      <SiteNav />
+      <UTCTimeVisualizer />
+    </main>
+  );
+}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link';
 import type { ReactNode } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { Activity, Box, Brain, ChevronDown, Sparkles, Twitter } from 'lucide-react';
+import { Activity, Box, Brain, ChevronDown, Clock3, Sparkles, Twitter } from 'lucide-react';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { RedditIcon } from './icons/reddit-icon';
 import { GitHubIcon } from './icons/github-icon';
@@ -77,6 +77,44 @@ function InlineLink({ item }: { item: NavLinkItem }) {
     >
       <span className="shrink-0">{item.icon}</span>
       <span>{item.label}</span>
+    </Link>
+  );
+}
+
+function TimeLink() {
+  const [time, setTime] = useState({ compact: '--:--', full: '--:--:--' });
+
+  useEffect(() => {
+    function updateTime() {
+      const now = new Date();
+      setTime({
+        compact: new Intl.DateTimeFormat(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+        }).format(now),
+        full: new Intl.DateTimeFormat(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }).format(now),
+      });
+    }
+
+    updateTime();
+    const interval = window.setInterval(updateTime, 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  return (
+    <Link
+      href="/time"
+      className="group flex shrink-0 items-center gap-1.5 rounded-full border bg-muted/40 px-2 py-1 text-xs font-semibold text-muted-foreground shadow-sm transition hover:-translate-y-0.5 hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      title="Open the time machine"
+      aria-label={`Open the time machine. Local time ${time.full}`}
+    >
+      <Clock3 size={13} className="hidden transition-transform group-hover:-rotate-12 sm:block" />
+      <span className="font-mono tabular-nums lg:hidden">{time.compact}</span>
+      <span className="hidden font-mono tabular-nums lg:inline">{time.full}</span>
     </Link>
   );
 }
@@ -164,6 +202,10 @@ export default function SiteNav() {
           </Link>
 
           <div className="hidden min-w-0 items-center gap-5 lg:flex">
+            <TimeLink />
+
+            <div className="h-5 border-l" />
+
             <div className="flex items-center gap-4">
               {siteLinks.map((item) => (
                 <InlineLink key={item.label} item={item} />
@@ -184,6 +226,8 @@ export default function SiteNav() {
           </div>
 
           <div className="flex shrink-0 items-center gap-1 sm:gap-2 lg:hidden">
+            <TimeLink />
+
             <NavMenu label="site">
               {siteLinks.map((item) => (
                 <MenuLink key={item.label} item={item} />

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -1,0 +1,585 @@
+import { unstable_cache } from 'next/cache';
+
+const GITHUB_USERNAME = 'teamleaderleo';
+const FEATURED_REPOSITORIES = ['smolrunner', 'stensibly'] as const;
+const CACHE_SECONDS = 600;
+const PACIFIC_TIME_ZONE = 'America/Los_Angeles';
+
+export type GitHubActivitySource = 'graphql' | 'public-rest' | 'unavailable';
+
+export type ContributionDay = {
+  date: string;
+  count: number;
+};
+
+export type RepositorySummary = {
+  name: string;
+  nameWithOwner: string;
+  url: string;
+  description: string | null;
+  stars: number;
+  forks: number;
+  updatedAt: string | null;
+  latestCommitMessage: string | null;
+  latestCommitUrl: string | null;
+};
+
+export type PullRequestSummary = {
+  number: number;
+  title: string;
+  url: string;
+  body: string;
+  mergedAt: string;
+  repository: string;
+  repositoryUrl: string;
+};
+
+export type GitHubHomeData = {
+  username: string;
+  source: GitHubActivitySource;
+  generatedAt: string;
+  stats: {
+    today: number | null;
+    lastSevenDays: number | null;
+    year: number | null;
+    streak: number;
+    label: 'contributions' | 'public actions';
+  };
+  days: ContributionDay[];
+  featuredRepositories: RepositorySummary[];
+  recentPullRequests: PullRequestSummary[];
+};
+
+type GraphQLContributionDay = {
+  date: string;
+  contributionCount: number;
+};
+
+type GraphQLRepository = {
+  name: string;
+  nameWithOwner: string;
+  url: string;
+  description: string | null;
+  stargazerCount: number;
+  forkCount: number;
+  updatedAt: string;
+  defaultBranchRef: {
+    target: {
+      messageHeadline?: string;
+      committedDate?: string;
+      url?: string;
+    };
+  } | null;
+};
+
+type GraphQLPullRequest = {
+  number: number;
+  title: string;
+  url: string;
+  bodyText: string | null;
+  mergedAt: string | null;
+  repository: {
+    nameWithOwner: string;
+    url: string;
+    isPrivate: boolean;
+  };
+};
+
+type GraphQLResponse = {
+  data?: {
+    user: {
+      recent: {
+        contributionCalendar: {
+          totalContributions: number;
+          weeks: Array<{
+            contributionDays: GraphQLContributionDay[];
+          }>;
+        };
+      };
+      year: {
+        contributionCalendar: {
+          totalContributions: number;
+        };
+      };
+      pullRequests: {
+        nodes: GraphQLPullRequest[];
+      };
+    } | null;
+    smolrunner: GraphQLRepository | null;
+    stensibly: GraphQLRepository | null;
+  };
+  errors?: Array<{ message: string }>;
+};
+
+type RestEvent = {
+  type: string;
+  created_at: string | null;
+  payload?: {
+    action?: string;
+    size?: number;
+    distinct_size?: number;
+    pull_request?: {
+      merged?: boolean;
+    };
+  };
+};
+
+type RestRepository = {
+  name: string;
+  full_name: string;
+  html_url: string;
+  description: string | null;
+  stargazers_count: number;
+  forks_count: number;
+  updated_at: string;
+};
+
+type RestSearchPullRequest = {
+  number: number;
+  title: string;
+  html_url: string;
+  body: string | null;
+  updated_at: string;
+  closed_at: string | null;
+  repository_url: string;
+};
+
+type RestSearchResponse = {
+  items?: RestSearchPullRequest[];
+};
+
+const GRAPHQL_QUERY = `
+  query GitHubHomepage(
+    $login: String!
+    $recentFrom: DateTime!
+    $yearFrom: DateTime!
+    $to: DateTime!
+  ) {
+    user(login: $login) {
+      recent: contributionsCollection(from: $recentFrom, to: $to) {
+        contributionCalendar {
+          totalContributions
+          weeks {
+            contributionDays {
+              date
+              contributionCount
+            }
+          }
+        }
+      }
+      year: contributionsCollection(from: $yearFrom, to: $to) {
+        contributionCalendar {
+          totalContributions
+        }
+      }
+      pullRequests(
+        first: 24
+        states: [MERGED]
+        orderBy: { field: UPDATED_AT, direction: DESC }
+      ) {
+        nodes {
+          number
+          title
+          url
+          bodyText
+          mergedAt
+          repository {
+            nameWithOwner
+            url
+            isPrivate
+          }
+        }
+      }
+    }
+    smolrunner: repository(owner: $login, name: "smolrunner") {
+      ...RepositoryCard
+    }
+    stensibly: repository(owner: $login, name: "stensibly") {
+      ...RepositoryCard
+    }
+  }
+
+  fragment RepositoryCard on Repository {
+    name
+    nameWithOwner
+    url
+    description
+    stargazerCount
+    forkCount
+    updatedAt
+    defaultBranchRef {
+      target {
+        ... on Commit {
+          messageHeadline
+          committedDate
+          url
+        }
+      }
+    }
+  }
+`;
+
+function toDateKey(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: PACIFIC_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+function getRecentDateKeys(total: number): string[] {
+  const now = new Date();
+  const keys: string[] = [];
+
+  for (let offset = total - 1; offset >= 0; offset -= 1) {
+    keys.push(toDateKey(new Date(now.getTime() - offset * 86_400_000)));
+  }
+
+  return keys;
+}
+
+function calculateStreak(days: ContributionDay[]): number {
+  let streak = 0;
+
+  for (let index = days.length - 1; index >= 0; index -= 1) {
+    if (days[index].count <= 0) break;
+    streak += 1;
+  }
+
+  return streak;
+}
+
+function orderPullRequests(pullRequests: PullRequestSummary[]): PullRequestSummary[] {
+  const featured = FEATURED_REPOSITORIES.flatMap((repositoryName) => {
+    const match = pullRequests.find(
+      (pullRequest) => pullRequest.repository.split('/').at(-1) === repositoryName,
+    );
+    return match ? [match] : [];
+  });
+
+  const selectedUrls = new Set(featured.map((pullRequest) => pullRequest.url));
+  const remaining = pullRequests
+    .filter((pullRequest) => !selectedUrls.has(pullRequest.url))
+    .sort(
+      (left, right) =>
+        new Date(right.mergedAt).getTime() - new Date(left.mergedAt).getTime(),
+    );
+
+  return [...featured, ...remaining].slice(0, 8);
+}
+
+function graphQLRepositoryToSummary(
+  repository: GraphQLRepository | null,
+): RepositorySummary | null {
+  if (!repository) return null;
+
+  const target = repository.defaultBranchRef?.target;
+
+  return {
+    name: repository.name,
+    nameWithOwner: repository.nameWithOwner,
+    url: repository.url,
+    description: repository.description,
+    stars: repository.stargazerCount,
+    forks: repository.forkCount,
+    updatedAt: target?.committedDate ?? repository.updatedAt,
+    latestCommitMessage: target?.messageHeadline ?? null,
+    latestCommitUrl: target?.url ?? null,
+  };
+}
+
+async function loadFromGraphQL(token: string): Promise<GitHubHomeData> {
+  const now = new Date();
+  const recentFrom = new Date(now.getTime() - 20 * 86_400_000);
+  const yearFrom = new Date(Date.UTC(now.getUTCFullYear(), 0, 1));
+
+  const response = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'teamleaderleo-scrapbook',
+      'X-GitHub-Api-Version': '2026-03-10',
+    },
+    body: JSON.stringify({
+      query: GRAPHQL_QUERY,
+      variables: {
+        login: GITHUB_USERNAME,
+        recentFrom: recentFrom.toISOString(),
+        yearFrom: yearFrom.toISOString(),
+        to: now.toISOString(),
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL returned ${response.status}`);
+  }
+
+  const payload = (await response.json()) as GraphQLResponse;
+  const user = payload.data?.user;
+
+  if (!user || payload.errors?.length) {
+    throw new Error(payload.errors?.[0]?.message ?? 'GitHub user data was unavailable');
+  }
+
+  const dayMap = new Map<string, number>();
+  for (const week of user.recent.contributionCalendar.weeks) {
+    for (const day of week.contributionDays) {
+      dayMap.set(day.date, day.contributionCount);
+    }
+  }
+
+  const days = getRecentDateKeys(14).map((date) => ({
+    date,
+    count: dayMap.get(date) ?? 0,
+  }));
+  const todayKey = days.at(-1)?.date;
+  const today = todayKey ? (dayMap.get(todayKey) ?? 0) : 0;
+  const lastSevenDays = days.slice(-7).reduce((total, day) => total + day.count, 0);
+
+  const pullRequests = user.pullRequests.nodes
+    .filter(
+      (pullRequest): pullRequest is GraphQLPullRequest & { mergedAt: string } =>
+        !pullRequest.repository.isPrivate &&
+        pullRequest.repository.nameWithOwner.startsWith(`${GITHUB_USERNAME}/`) &&
+        Boolean(pullRequest.mergedAt),
+    )
+    .map((pullRequest) => ({
+      number: pullRequest.number,
+      title: pullRequest.title,
+      url: pullRequest.url,
+      body: pullRequest.bodyText ?? '',
+      mergedAt: pullRequest.mergedAt,
+      repository: pullRequest.repository.nameWithOwner,
+      repositoryUrl: pullRequest.repository.url,
+    }));
+
+  const featuredRepositories = [payload.data?.smolrunner, payload.data?.stensibly]
+    .map((repository) => graphQLRepositoryToSummary(repository ?? null))
+    .filter((repository): repository is RepositorySummary => Boolean(repository));
+
+  return {
+    username: GITHUB_USERNAME,
+    source: 'graphql',
+    generatedAt: now.toISOString(),
+    stats: {
+      today,
+      lastSevenDays,
+      year: user.year.contributionCalendar.totalContributions,
+      streak: calculateStreak(days),
+      label: 'contributions',
+    },
+    days,
+    featuredRepositories,
+    recentPullRequests: orderPullRequests(pullRequests),
+  };
+}
+
+function publicActionWeight(event: RestEvent): number {
+  if (event.type === 'PushEvent') {
+    return Math.max(event.payload?.distinct_size ?? event.payload?.size ?? 1, 1);
+  }
+
+  if (event.type === 'PullRequestEvent') {
+    const action = event.payload?.action;
+    if (action === 'opened' || action === 'closed' || action === 'reopened') return 1;
+  }
+
+  if (event.type === 'IssuesEvent' && event.payload?.action === 'opened') return 1;
+  if (event.type === 'PullRequestReviewEvent' && event.payload?.action === 'created') return 1;
+
+  return 0;
+}
+
+function repositoryNameFromApiUrl(repositoryUrl: string): string {
+  return repositoryUrl.replace('https://api.github.com/repos/', '');
+}
+
+async function publicGitHubFetch<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    cache: 'no-store',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'teamleaderleo-scrapbook',
+      'X-GitHub-Api-Version': '2026-03-10',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub REST returned ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function loadFromPublicRest(): Promise<GitHubHomeData> {
+  const encodedQuery = encodeURIComponent(
+    `author:${GITHUB_USERNAME} is:pr is:merged`,
+  );
+
+  const [eventsPageOne, eventsPageTwo, eventsPageThree, repositories, search] =
+    await Promise.all([
+      publicGitHubFetch<RestEvent[]>(
+        `https://api.github.com/users/${GITHUB_USERNAME}/events/public?per_page=100&page=1`,
+      ),
+      publicGitHubFetch<RestEvent[]>(
+        `https://api.github.com/users/${GITHUB_USERNAME}/events/public?per_page=100&page=2`,
+      ),
+      publicGitHubFetch<RestEvent[]>(
+        `https://api.github.com/users/${GITHUB_USERNAME}/events/public?per_page=100&page=3`,
+      ),
+      publicGitHubFetch<RestRepository[]>(
+        `https://api.github.com/users/${GITHUB_USERNAME}/repos?per_page=100&sort=updated&type=owner`,
+      ),
+      publicGitHubFetch<RestSearchResponse>(
+        `https://api.github.com/search/issues?q=${encodedQuery}&sort=updated&order=desc&per_page=24`,
+      ),
+    ]);
+
+  const events = [...eventsPageOne, ...eventsPageTwo, ...eventsPageThree];
+  const dayMap = new Map<string, number>();
+
+  for (const event of events) {
+    if (!event.created_at) continue;
+    const weight = publicActionWeight(event);
+    if (weight === 0) continue;
+
+    const date = toDateKey(new Date(event.created_at));
+    dayMap.set(date, (dayMap.get(date) ?? 0) + weight);
+  }
+
+  const days = getRecentDateKeys(14).map((date) => ({
+    date,
+    count: dayMap.get(date) ?? 0,
+  }));
+  const today = days.at(-1)?.count ?? 0;
+  const lastSevenDays = days.slice(-7).reduce((total, day) => total + day.count, 0);
+
+  const featuredRepositories = FEATURED_REPOSITORIES.map((repositoryName) => {
+    const repository = repositories.find((candidate) => candidate.name === repositoryName);
+
+    if (!repository) {
+      return {
+        name: repositoryName,
+        nameWithOwner: `${GITHUB_USERNAME}/${repositoryName}`,
+        url: `https://github.com/${GITHUB_USERNAME}/${repositoryName}`,
+        description: null,
+        stars: 0,
+        forks: 0,
+        updatedAt: null,
+        latestCommitMessage: null,
+        latestCommitUrl: null,
+      } satisfies RepositorySummary;
+    }
+
+    return {
+      name: repository.name,
+      nameWithOwner: repository.full_name,
+      url: repository.html_url,
+      description: repository.description,
+      stars: repository.stargazers_count,
+      forks: repository.forks_count,
+      updatedAt: repository.updated_at,
+      latestCommitMessage: null,
+      latestCommitUrl: null,
+    } satisfies RepositorySummary;
+  });
+
+  const pullRequests = (search.items ?? [])
+    .map((pullRequest) => {
+      const repository = repositoryNameFromApiUrl(pullRequest.repository_url);
+
+      return {
+        number: pullRequest.number,
+        title: pullRequest.title,
+        url: pullRequest.html_url,
+        body: pullRequest.body ?? '',
+        mergedAt: pullRequest.closed_at ?? pullRequest.updated_at,
+        repository,
+        repositoryUrl: `https://github.com/${repository}`,
+      } satisfies PullRequestSummary;
+    })
+    .filter((pullRequest) => pullRequest.repository.startsWith(`${GITHUB_USERNAME}/`));
+
+  return {
+    username: GITHUB_USERNAME,
+    source: 'public-rest',
+    generatedAt: new Date().toISOString(),
+    stats: {
+      today,
+      lastSevenDays,
+      year: null,
+      streak: calculateStreak(days),
+      label: 'public actions',
+    },
+    days,
+    featuredRepositories,
+    recentPullRequests: orderPullRequests(pullRequests),
+  };
+}
+
+function unavailableData(): GitHubHomeData {
+  const days = getRecentDateKeys(14).map((date) => ({ date, count: 0 }));
+
+  return {
+    username: GITHUB_USERNAME,
+    source: 'unavailable',
+    generatedAt: new Date().toISOString(),
+    stats: {
+      today: null,
+      lastSevenDays: null,
+      year: null,
+      streak: 0,
+      label: 'contributions',
+    },
+    days,
+    featuredRepositories: FEATURED_REPOSITORIES.map((name) => ({
+      name,
+      nameWithOwner: `${GITHUB_USERNAME}/${name}`,
+      url: `https://github.com/${GITHUB_USERNAME}/${name}`,
+      description: null,
+      stars: 0,
+      forks: 0,
+      updatedAt: null,
+      latestCommitMessage: null,
+      latestCommitUrl: null,
+    })),
+    recentPullRequests: [],
+  };
+}
+
+async function loadGitHubHomeData(): Promise<GitHubHomeData> {
+  const token = process.env.GITHUB_TOKEN ?? process.env.GITHUB_ACCESS_TOKEN;
+
+  if (token) {
+    try {
+      return await loadFromGraphQL(token);
+    } catch (error) {
+      console.error('GitHub GraphQL homepage fetch failed', error);
+    }
+  }
+
+  try {
+    return await loadFromPublicRest();
+  } catch (error) {
+    console.error('GitHub REST homepage fetch failed', error);
+    return unavailableData();
+  }
+}
+
+const getCachedGitHubHomeData = unstable_cache(
+  loadGitHubHomeData,
+  ['github-homepage-v1'],
+  { revalidate: CACHE_SECONDS },
+);
+
+export async function getGitHubHomeData(): Promise<GitHubHomeData> {
+  return getCachedGitHubHomeData();
+}


### PR DESCRIPTION
## Summary

- move the time-zone visualizer to `/time`
- add a ticking local-time pill to desktop and mobile navigation
- replace the homepage with cached GitHub contribution stats, featured repos, and merged PR excerpts
- prioritize recent work from `smolrunner` and `stensibly`
- use authenticated GraphQL when a GitHub token exists, with a public REST fallback
- cache results for ten minutes to avoid webhook/cron work and keep Vercel usage small
- keep server-rendered relative dates deterministic under Next.js Cache Components
- refresh README docs

## GitHub data behavior

`GITHUB_TOKEN` or `GITHUB_ACCESS_TOKEN` enables exact contribution-calendar totals. The token-free path uses public events, public repos, and public merged PR search, and labels the headline metric as public actions.

## Verification

- TypeScript syntax transpilation passed for the new and edited TS/TSX files
- final branch is six commits ahead of `main` with the expected five changed files
- full dependency-backed lint/build remains for CI because this environment could not clone or install the repository dependencies
