### PR TITLE
Make the GitHub homepage denser and lighter

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,12 +11,15 @@ export const metadata: Metadata = {
 };
 
 function activityClass(day: ContributionDay, maximum: number): string {
-  if (day.count === 0) return 'bg-slate-200/70 dark:bg-slate-800';
+  const base = 'ring-1 ring-inset ring-black/[0.035] dark:ring-white/[0.07]';
+  if (day.count === 0) return `${base} bg-[#d7d2dc]/60 dark:bg-[#332f38]`;
+
   const ratio = maximum === 0 ? 0 : day.count / maximum;
-  if (ratio > 0.75) return 'bg-violet-500/80';
-  if (ratio > 0.45) return 'bg-violet-400/70';
-  if (ratio > 0.2) return 'bg-violet-300/70 dark:bg-violet-500/45';
-  return 'bg-violet-200/80 dark:bg-violet-500/25';
+  if (ratio > 0.8) return `${base} bg-white dark:bg-[#f5f2f8]`;
+  if (ratio > 0.55) return `${base} bg-[#eeeaf2] dark:bg-[#c9c2d0]`;
+  if (ratio > 0.3) return `${base} bg-[#ddd7e3] dark:bg-[#92899d]`;
+  if (ratio > 0.12) return `${base} bg-[#cec7d6] dark:bg-[#686071]`;
+  return `${base} bg-[#beb6c8] dark:bg-[#504957]`;
 }
 
 function formatDay(date: string): string {
@@ -28,88 +31,139 @@ function formatDay(date: string): string {
   }).format(new Date(`${date}T00:00:00Z`));
 }
 
+function Metric({ label, value, suffix }: { label: string; value: number; suffix?: string }) {
+  return (
+    <div className="rounded-xl border border-[#ddd8e4]/80 bg-white/45 px-3 py-2.5 dark:border-[#3b3542] dark:bg-white/[0.035]">
+      <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
+      <p className="mt-1 text-xl font-semibold tabular-nums tracking-tight">
+        {value}
+        {suffix ? <span className="ml-1 text-xs font-normal text-muted-foreground">{suffix}</span> : null}
+      </p>
+    </div>
+  );
+}
+
 export default async function Page() {
   const activity = await getGitHubHomeData();
   const maximum = Math.max(...activity.days.map((day) => day.count), 0);
 
   return (
     <ViewportPageShell
-      scroll="locked"
-      className="bg-sidebar-background text-foreground"
-      contentClassName="text-foreground"
+      className="relative bg-[#f7f6f9] text-foreground dark:bg-[#17151b]"
+      contentClassName="relative text-foreground"
     >
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="absolute -left-24 top-10 h-72 w-72 rounded-full bg-[#ddd7e7]/65 blur-3xl dark:bg-[#403948]/35" />
+        <div className="absolute -right-20 bottom-0 h-80 w-80 rounded-full bg-[#eeeaf3]/90 blur-3xl dark:bg-[#2d2933]/60" />
+      </div>
+
       <div
-        className="mx-auto flex h-full w-full max-w-4xl flex-col justify-center px-4 py-4 sm:px-6 sm:py-6"
+        className="relative mx-auto flex min-h-full w-full max-w-5xl flex-col justify-center px-4 py-5 sm:px-6 sm:py-7"
         style={{
           fontFamily:
             'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
         }}
       >
-        <div className="flex max-h-full flex-col gap-5 sm:gap-6">
+        <div className="flex w-full flex-col gap-4 sm:gap-5">
           <header className="flex items-end justify-between gap-4">
             <div>
               <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">GitHub activity</h1>
-              <p className="mt-1 text-sm text-muted-foreground">Last seven days.</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Year-to-date totals and the last 35 days.
+              </p>
             </div>
             <Link
               href={`https://github.com/${activity.username}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex shrink-0 items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+              className="inline-flex shrink-0 items-center gap-1 text-sm text-muted-foreground transition hover:text-foreground"
             >
               @{activity.username}
               <ArrowUpRight size={14} />
             </Link>
           </header>
 
-          <section className="rounded-2xl border bg-background/80 p-4 sm:p-5">
-            <div className="flex items-baseline gap-3">
-              <span className="text-4xl font-semibold tabular-nums tracking-tight sm:text-5xl">
-                {activity.total ?? '—'}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                {activity.source === 'public-profile' ? 'contributions' : 'public actions'}
-              </span>
-            </div>
-
-            <div className="mt-4 grid grid-cols-7 gap-2" aria-label="Seven days of GitHub activity">
-              {activity.days.map((day) => (
-                <div key={day.date} className="min-w-0">
-                  <div
-                    className={`aspect-square rounded-lg ${activityClass(day, maximum)}`}
-                    title={`${formatDay(day.date)}: ${day.count}`}
-                    aria-label={`${formatDay(day.date)}: ${day.count}`}
-                  />
-                  <p className="mt-1.5 truncate text-center text-[11px] text-muted-foreground">
-                    {new Intl.DateTimeFormat('en-US', {
-                      weekday: 'narrow',
-                      timeZone: 'UTC',
-                    }).format(new Date(`${day.date}T00:00:00Z`))}
-                  </p>
-                  <p className="text-center text-xs font-medium tabular-nums">{day.count}</p>
+          <section className="overflow-hidden rounded-[1.75rem] border border-[#ddd8e4] bg-white/55 shadow-[0_20px_60px_rgba(70,60,82,0.08)] backdrop-blur-sm dark:border-[#39333f] dark:bg-[#211e26]/85 dark:shadow-none">
+            <div className="grid lg:grid-cols-[0.9fr_1.1fr]">
+              <div className="p-5 sm:p-6">
+                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                  {activity.periodLabel}
+                </p>
+                <div className="mt-2 flex items-end gap-3">
+                  <span className="text-5xl font-semibold tabular-nums tracking-[-0.055em] sm:text-6xl">
+                    {activity.total ?? '—'}
+                  </span>
+                  <span className="pb-1.5 text-sm text-muted-foreground">
+                    {activity.source === 'public-events' ? 'public actions' : 'contributions'}
+                  </span>
                 </div>
-              ))}
+
+                <div className="mt-5 grid grid-cols-2 gap-2.5">
+                  <Metric label="Today" value={activity.today} />
+                  <Metric label="Last 7 days" value={activity.weekTotal} />
+                  <Metric label="Active days" value={activity.activeDays} />
+                  <Metric
+                    label="Current streak"
+                    value={activity.currentStreak}
+                    suffix={activity.currentStreak === 1 ? 'day' : 'days'}
+                  />
+                </div>
+              </div>
+
+              <div className="border-t border-[#ddd8e4] bg-[#efecf3]/55 p-5 sm:p-6 lg:border-l lg:border-t-0 dark:border-[#39333f] dark:bg-[#1c1920]/65">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                    Last 35 days
+                  </p>
+                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+                    <span>less</span>
+                    <span className="h-2.5 w-2.5 rounded-[3px] bg-[#beb6c8] dark:bg-[#504957]" />
+                    <span className="h-2.5 w-2.5 rounded-[3px] bg-[#ddd7e3] dark:bg-[#92899d]" />
+                    <span className="h-2.5 w-2.5 rounded-[3px] bg-white ring-1 ring-inset ring-black/[0.04] dark:bg-[#f5f2f8]" />
+                    <span>more</span>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid grid-cols-7 gap-2 sm:gap-2.5" aria-label="35 days of GitHub activity">
+                  {activity.days.map((day) => (
+                    <div
+                      key={day.date}
+                      className={`aspect-square rounded-[0.55rem] transition-transform duration-150 hover:-translate-y-0.5 ${activityClass(day, maximum)}`}
+                      title={`${formatDay(day.date)}: ${day.count}`}
+                      aria-label={`${formatDay(day.date)}: ${day.count}`}
+                    />
+                  ))}
+                </div>
+
+                <div className="mt-3 flex justify-between text-[11px] text-muted-foreground">
+                  <span>{formatDay(activity.days[0]?.date ?? '')}</span>
+                  <span>{formatDay(activity.days.at(-1)?.date ?? '')}</span>
+                </div>
+              </div>
             </div>
           </section>
 
-          <section>
-            <div className="grid grid-cols-2 gap-3">
-              {activity.repositories.map((repository) => (
-                <Link
-                  key={repository.name}
-                  href={repository.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center justify-between gap-3 rounded-xl border bg-background/80 px-4 py-3 transition hover:border-violet-300 dark:hover:border-violet-500/50"
-                >
-                  <span className="min-w-0 truncate font-medium">{repository.name}</span>
-                  <ArrowUpRight
-                    size={15}
-                    className="shrink-0 text-muted-foreground transition group-hover:text-violet-500"
-                  />
-                </Link>
-              ))}
-            </div>
+          <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {activity.repositories.map((repository) => (
+              <Link
+                key={repository.name}
+                href={repository.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex min-w-0 items-center justify-between gap-4 rounded-2xl border border-[#ddd8e4] bg-white/45 px-4 py-3.5 transition hover:border-[#c9c1d2] hover:bg-white/70 dark:border-[#39333f] dark:bg-[#211e26]/65 dark:hover:border-[#5b5363] dark:hover:bg-[#25212a]"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">{repository.name}</span>
+                  <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                    {repository.description ?? `github.com/${activity.username}/${repository.name}`}
+                  </span>
+                </span>
+                <ArrowUpRight
+                  size={15}
+                  className="shrink-0 text-[#958c9f] transition group-hover:text-[#6f6678] dark:text-[#aaa2b2] dark:group-hover:text-[#d8d2df]"
+                />
+              </Link>
+            ))}
           </section>
 
           <p className="text-xs text-muted-foreground">
@@ -118,7 +172,7 @@ export default async function Page() {
               : activity.source === 'public-events'
                 ? 'Public GitHub events fallback'
                 : 'GitHub data unavailable'}
-            {' · '}five-minute cache
+            {' · '}updated every five minutes
           </p>
         </div>
       </div>

--- a/lib/github-activity-utils.ts
+++ b/lib/github-activity-utils.ts
@@ -11,13 +11,14 @@ export function dateKeyInTimeZone(date: Date, timeZone = DISPLAY_TIME_ZONE): str
   return `${values.year}-${values.month}-${values.day}`;
 }
 
-export function getRecentDateKeys(now = new Date()): string[] {
+export function getRecentDateKeys(now = new Date(), length = 7): string[] {
+  const safeLength = Number.isFinite(length) ? Math.max(1, Math.floor(length)) : 7;
   const [year, month, day] = dateKeyInTimeZone(now)
     .split('-')
     .map(Number);
 
-  return Array.from({ length: 7 }, (_, index) => {
-    const date = new Date(Date.UTC(year, month - 1, day - (6 - index)));
+  return Array.from({ length: safeLength }, (_, index) => {
+    const date = new Date(Date.UTC(year, month - 1, day - (safeLength - 1 - index)));
     return date.toISOString().slice(0, 10);
   });
 }

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -39,4 +39,11 @@ describe('getRecentDateKeys', () => {
     const days = getRecentDateKeys(new Date('2026-07-25T07:30:00Z'));
     expect(days.at(-1)).toBe('2026-07-25');
   });
+
+  it('supports the 35-day homepage window', () => {
+    const days = getRecentDateKeys(new Date('2026-07-25T07:30:00Z'), 35);
+    expect(days).toHaveLength(35);
+    expect(days[0]).toBe('2026-06-21');
+    expect(days.at(-1)).toBe('2026-07-25');
+  });
 });

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -8,6 +8,7 @@ import {
 const GITHUB_USERNAME = 'teamleaderleo';
 const FEATURED_REPOSITORIES = ['smolrunner', 'stensibly'] as const;
 const CACHE_SECONDS = 300;
+const HOME_WINDOW_DAYS = 35;
 
 export type ContributionDay = {
   date: string;
@@ -19,6 +20,11 @@ export type GitHubHomeData = {
   source: 'public-profile' | 'public-events' | 'unavailable';
   generatedAt: string;
   total: number | null;
+  periodLabel: 'this year' | 'last 35 days';
+  today: number;
+  weekTotal: number;
+  activeDays: number;
+  currentStreak: number;
   days: ContributionDay[];
   repositories: Array<{
     name: string;
@@ -43,7 +49,50 @@ type RestRepository = {
   description: string | null;
 };
 
-async function fetchPublicProfileDays(): Promise<ContributionDay[]> {
+type ActivitySource = GitHubHomeData['source'];
+
+function daysFromCounts(counts: Map<string, number>, now: Date, length = HOME_WINDOW_DAYS) {
+  return getRecentDateKeys(now, length).map((date) => ({ date, count: counts.get(date) ?? 0 }));
+}
+
+function countCurrentStreak(days: ContributionDay[]): number {
+  let index = days.length - 1;
+
+  // Keep yesterday's streak visible until the current day has activity.
+  if (days[index]?.count === 0) index -= 1;
+
+  let streak = 0;
+  while (index >= 0 && days[index].count > 0) {
+    streak += 1;
+    index -= 1;
+  }
+
+  return streak;
+}
+
+function summarizeCounts(counts: Map<string, number>, source: ActivitySource, now = new Date()) {
+  const days = daysFromCounts(counts, now);
+  const today = dateKeyInTimeZone(now);
+  const periodLabel = source === 'public-profile' ? 'this year' : 'last 35 days';
+  const periodEntries =
+    source === 'public-profile'
+      ? [...counts.entries()].filter(([date]) => date.startsWith(today.slice(0, 4)) && date <= today)
+      : days.map((day) => [day.date, day.count] as const);
+  const streakDays =
+    source === 'public-profile' ? daysFromCounts(counts, now, 366) : days;
+
+  return {
+    total: periodEntries.reduce((sum, [, count]) => sum + count, 0),
+    periodLabel,
+    today: days.at(-1)?.count ?? 0,
+    weekTotal: days.slice(-7).reduce((sum, day) => sum + day.count, 0),
+    activeDays: periodEntries.filter(([, count]) => count > 0).length,
+    currentStreak: countCurrentStreak(streakDays),
+    days,
+  };
+}
+
+async function fetchPublicProfileCounts(): Promise<Map<string, number>> {
   const response = await fetch(`https://github.com/users/${GITHUB_USERNAME}/contributions`, {
     cache: 'no-store',
     headers: {
@@ -57,7 +106,7 @@ async function fetchPublicProfileDays(): Promise<ContributionDay[]> {
   const counts = parsePublicContributionHtml(await response.text());
   if (counts.size === 0) throw new Error('GitHub contribution page could not be parsed');
 
-  return getRecentDateKeys().map((date) => ({ date, count: counts.get(date) ?? 0 }));
+  return counts;
 }
 
 function eventWeight(event: RestEvent): number {
@@ -84,7 +133,7 @@ async function githubJson<T>(url: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-async function fetchPublicEventDays(): Promise<ContributionDay[]> {
+async function fetchPublicEventCounts(): Promise<Map<string, number>> {
   const events = await githubJson<RestEvent[]>(
     `https://api.github.com/users/${GITHUB_USERNAME}/events/public?per_page=100`,
   );
@@ -98,7 +147,7 @@ async function fetchPublicEventDays(): Promise<ContributionDay[]> {
     counts.set(key, (counts.get(key) ?? 0) + weight);
   }
 
-  return getRecentDateKeys().map((date) => ({ date, count: counts.get(date) ?? 0 }));
+  return counts;
 }
 
 async function fetchRepositories() {
@@ -128,13 +177,12 @@ async function loadGitHubHomeData(): Promise<GitHubHomeData> {
   const repositoriesPromise = fetchRepositories();
 
   try {
-    const days = await fetchPublicProfileDays();
+    const summary = summarizeCounts(await fetchPublicProfileCounts(), 'public-profile');
     return {
       username: GITHUB_USERNAME,
       source: 'public-profile',
       generatedAt: new Date().toISOString(),
-      total: days.reduce((sum, day) => sum + day.count, 0),
-      days,
+      ...summary,
       repositories: await repositoriesPromise,
     };
   } catch (profileError) {
@@ -142,24 +190,23 @@ async function loadGitHubHomeData(): Promise<GitHubHomeData> {
   }
 
   try {
-    const days = await fetchPublicEventDays();
+    const summary = summarizeCounts(await fetchPublicEventCounts(), 'public-events');
     return {
       username: GITHUB_USERNAME,
       source: 'public-events',
       generatedAt: new Date().toISOString(),
-      total: days.reduce((sum, day) => sum + day.count, 0),
-      days,
+      ...summary,
       repositories: await repositoriesPromise,
     };
   } catch (eventError) {
     console.error('GitHub public event fetch failed', eventError);
-    const days = getRecentDateKeys().map((date) => ({ date, count: 0 }));
+    const summary = summarizeCounts(new Map(), 'unavailable');
     return {
       username: GITHUB_USERNAME,
       source: 'unavailable',
       generatedAt: new Date().toISOString(),
+      ...summary,
       total: null,
-      days,
       repositories: await repositoriesPromise,
     };
   }
@@ -167,7 +214,7 @@ async function loadGitHubHomeData(): Promise<GitHubHomeData> {
 
 const getCachedGitHubHomeData = unstable_cache(
   loadGitHubHomeData,
-  ['github-homepage-v3'],
+  ['github-homepage-v4'],
   { revalidate: CACHE_SECONDS },
 );
 

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -50,6 +50,10 @@ type RestRepository = {
 };
 
 type ActivitySource = GitHubHomeData['source'];
+type ActivitySummary = Pick<
+  GitHubHomeData,
+  'total' | 'periodLabel' | 'today' | 'weekTotal' | 'activeDays' | 'currentStreak' | 'days'
+>;
 
 function daysFromCounts(counts: Map<string, number>, now: Date, length = HOME_WINDOW_DAYS) {
   return getRecentDateKeys(now, length).map((date) => ({ date, count: counts.get(date) ?? 0 }));
@@ -70,10 +74,15 @@ function countCurrentStreak(days: ContributionDay[]): number {
   return streak;
 }
 
-function summarizeCounts(counts: Map<string, number>, source: ActivitySource, now = new Date()) {
+function summarizeCounts(
+  counts: Map<string, number>,
+  source: ActivitySource,
+  now = new Date(),
+): ActivitySummary {
   const days = daysFromCounts(counts, now);
   const today = dateKeyInTimeZone(now);
-  const periodLabel = source === 'public-profile' ? 'this year' : 'last 35 days';
+  const periodLabel: GitHubHomeData['periodLabel'] =
+    source === 'public-profile' ? 'this year' : 'last 35 days';
   const periodEntries =
     source === 'public-profile'
       ? [...counts.entries()].filter(([date]) => date.startsWith(today.slice(0, 4)) && date <= today)


### PR DESCRIPTION
## Summary
- replace the seven-day-only total with a year-to-date contribution count
- add today, seven-day, active-day, and current-streak metrics
- expand the contribution display to a cached 35-day square field
- use a desaturated lavender scale that becomes lighter with higher activity
- add subtle background depth and repository descriptions without extra client JavaScript

## Verification
- existing GitHub Actions checks: lint, typecheck, unit tests, production build
- existing homepage viewport smoke test