### PR TITLE
Desaturate the remaining lavender nav accents

### DIFF
--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -82,14 +82,17 @@ async function copyDiscord() {
   toast.success('Discord username copied', { description: 'teamleaderleo' });
 }
 
+const discordHover =
+  'hover:text-[#91889b] focus:text-[#91889b] dark:hover:text-[#cbc4d2] dark:focus:text-[#cbc4d2]';
+
 export function DiscordButton({ menu = false }: { menu?: boolean }) {
   return (
     <button
       onClick={() => void copyDiscord()}
       className={
         menu
-          ? 'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-indigo-500 focus:bg-muted focus:text-indigo-500 focus:outline-none'
-          : 'flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-indigo-500 focus:text-indigo-500 focus:outline-none'
+          ? `flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted focus:bg-muted focus:outline-none ${discordHover}`
+          : `flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors focus:outline-none ${discordHover}`
       }
       type="button"
     >

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -1,5 +1,4 @@
 import { DiscordButton, NavMenu, NavThemeToggle, TimeLink } from '@/components/site-nav-interactive';
-import { DiscordIcon } from '@/components/icons/discord-icon';
 import { GitHubIcon } from '@/components/icons/github-icon';
 import { RedditIcon } from '@/components/icons/reddit-icon';
 import { Activity, Box, Brain, Sparkles, Twitter } from 'lucide-react';
@@ -14,6 +13,9 @@ type NavLinkItem = {
   external?: boolean;
 };
 
+const lavenderHover =
+  'hover:text-[#91889b] focus:text-[#91889b] dark:hover:text-[#cbc4d2] dark:focus:text-[#cbc4d2]';
+
 const siteLinks: NavLinkItem[] = [
   {
     href: '/proxy-dashboard',
@@ -25,7 +27,7 @@ const siteLinks: NavLinkItem[] = [
     href: '/space',
     label: 'space',
     icon: <Brain size={15} />,
-    hoverClass: 'hover:text-[hsl(238,45%,58%)] focus:text-[hsl(238,45%,58%)]',
+    hoverClass: lavenderHover,
   },
   {
     href: '/gallery',
@@ -37,7 +39,7 @@ const siteLinks: NavLinkItem[] = [
     href: 'https://glossless.app/',
     label: 'glossless',
     icon: <Sparkles size={15} />,
-    hoverClass: 'hover:text-purple-500 focus:text-purple-500',
+    hoverClass: lavenderHover,
     external: true,
   },
 ];


### PR DESCRIPTION
## Summary
- replace the saturated purple and indigo navigation hover colours
- use the same muted lavender range as the homepage
- remove an unused navigation import

## Verification
- existing lint, typecheck, unit test, and production build checks