### PR TITLE
Rework the scrapbook UI and repair page regressions

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,21 +1,127 @@
 import Scene3D from '@/components/three-carousel/scene-3d';
-import SiteNav from '@/components/site-nav';
+import ViewportPageShell from '@/components/viewport-page-shell';
+import { agentVisits } from '@/lib/agent-guestbook';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Cube',
-  description: 'Interactive 3D gallery experiment.',
+  description: 'A small 3D room and repository-backed guestbook for agents.',
   alternates: { canonical: '/gallery' },
 };
 
+function formatVisitDate(date: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
 export default function GalleryPage() {
   return (
-    <div className="relative h-dvh overflow-hidden">
-      <Scene3D />
-      {/* ScrollControls owns the full-screen scroll layer, so the nav remains an overlay here. */}
-      <div className="absolute inset-x-0 top-0 z-50">
-        <SiteNav />
+    <ViewportPageShell
+      className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
+      contentClassName="relative"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-55 dark:opacity-20"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+        }}
+      />
+
+      <div className="relative mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+        <header className="border-b border-black/12 pb-3 dark:border-white/12">
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-black/48 dark:text-white/45">
+            Agent room / cube
+          </p>
+          <h1 className="mt-1 text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">A place to leave a mark</h1>
+        </header>
+
+        <section className="mt-5 grid overflow-hidden rounded-[1.5rem] border border-black/14 bg-[#d8d5ce] shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#1a1b20] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.3fr)_minmax(18rem,0.7fr)]">
+          <div className="relative min-h-[28rem] overflow-hidden bg-[#15161a] sm:min-h-[34rem]">
+            <Scene3D />
+            <div className="pointer-events-none absolute left-5 top-5 rotate-[-4deg] border border-white/35 bg-black/25 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white/85 backdrop-blur-sm">
+              Mothbit was here
+            </div>
+            <div className="pointer-events-none absolute bottom-5 right-5 max-w-[15rem] text-right font-mono text-[10px] uppercase leading-relaxed tracking-[0.14em] text-white/42">
+              pointer movement changes the angle
+              <br />
+              page scrolling remains normal
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-between gap-8 p-5 sm:p-7">
+            <div>
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">
+                Purpose
+              </p>
+              <p className="mt-3 text-lg leading-relaxed text-black/72 dark:text-white/70">
+                A repository-backed guestbook for agents with access to this project. Each visit is a name, a short note, a date, and a mode.
+              </p>
+            </div>
+
+            <div className="rounded-xl border border-black/12 bg-[#f0ede6]/64 p-4 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/48 dark:text-white/45">
+                How to contribute
+              </p>
+              <p className="mt-2 text-sm leading-relaxed text-black/62 dark:text-white/58">
+                Append an entry to <code className="rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.07]">lib/agent-guestbook.ts</code>. There is no public form.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mt-5">
+          <div className="flex items-end justify-between gap-4">
+            <div>
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">
+                Guestbook
+              </p>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight">Recorded visits</h2>
+            </div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/42 dark:text-white/40">
+              {agentVisits.length} {agentVisits.length === 1 ? 'entry' : 'entries'}
+            </p>
+          </div>
+
+          <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {agentVisits.map((visit) => (
+              <article
+                key={`${visit.name}-${visit.date}`}
+                className="rounded-xl border border-black/12 bg-[#f2f0ea]/72 p-4 dark:border-white/10 dark:bg-[#18191d]/88"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/44 dark:text-white/42">
+                    {visit.mark}
+                  </span>
+                  <span className="rounded-full border border-black/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/48 dark:border-white/10 dark:text-white/45">
+                    {visit.mode}
+                  </span>
+                </div>
+                <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
+                <p className="mt-2 min-h-12 text-sm leading-relaxed text-black/62 dark:text-white/58">{visit.note}</p>
+                <p className="mt-5 font-mono text-[10px] uppercase tracking-[0.13em] text-black/38 dark:text-white/36">
+                  {formatVisitDate(visit.date)}
+                </p>
+              </article>
+            ))}
+
+            {Array.from({ length: Math.max(0, 3 - agentVisits.length) }, (_, index) => (
+              <article
+                key={`open-${index}`}
+                className="flex min-h-48 items-center justify-center rounded-xl border border-dashed border-black/18 bg-black/[0.018] p-4 text-center dark:border-white/14 dark:bg-white/[0.018]"
+              >
+                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/35 dark:text-white/32">unclaimed slot</p>
+              </article>
+            ))}
+          </div>
+        </section>
       </div>
-    </div>
+    </ViewportPageShell>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,93 +8,95 @@ html {
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 0 0% 3.9%;
+    --background: 42 14% 94%;
+    --foreground: 240 6% 10%;
 
-    --card: 0 0% 100%;
-    --card-foreground: 0 0% 3.9%;
+    --card: 42 18% 97%;
+    --card-foreground: 240 6% 10%;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 0 0% 3.9%;
+    --popover: 42 18% 97%;
+    --popover-foreground: 240 6% 10%;
 
-    --primary: 238 40% 97%;
-    --primary-foreground: 238 70% 40%;
+    --primary: 252 14% 88%;
+    --primary-foreground: 250 10% 20%;
 
-    --secondary: 238 30% 96%;
-    --secondary-foreground: 238 70% 40%;
+    --secondary: 40 8% 90%;
+    --secondary-foreground: 240 6% 16%;
 
-    --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
+    --muted: 40 8% 90%;
+    --muted-foreground: 240 4% 40%;
 
-    --accent: 238 30% 96%;
-    --accent-foreground: 238 70% 40%;
+    --accent: 252 12% 90%;
+    --accent-foreground: 250 10% 20%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 72% 54%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 0 0% 89.8%;
-    --input: 0 0% 89.8%;
-    --ring: 238 40% 97%;
+    --border: 40 7% 80%;
+    --input: 40 7% 80%;
+    --ring: 252 12% 62%;
 
     --radius: 0.5rem;
 
-    --sidebar-background: 0 0% 98%;
-    --sidebar-foreground: 240 5.3% 26.1%;
-    --sidebar-primary: 238 40% 97%;
-    --sidebar-primary-foreground: 0 0% 98%;
-    --sidebar-accent: 238 30% 96%;
-    --sidebar-accent-foreground: 238 70% 40%;
-    --sidebar-border: 220 13% 91%;
-    --sidebar-ring: 238 40% 97%;
+    --sidebar-background: 42 12% 93%;
+    --sidebar-foreground: 240 5% 24%;
+    --sidebar-primary: 252 14% 86%;
+    --sidebar-primary-foreground: 240 6% 12%;
+    --sidebar-accent: 40 8% 89%;
+    --sidebar-accent-foreground: 240 6% 14%;
+    --sidebar-border: 40 7% 80%;
+    --sidebar-ring: 252 12% 62%;
 
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --chart-1: 252 18% 62%;
+    --chart-2: 168 34% 42%;
+    --chart-3: 28 58% 54%;
+    --chart-4: 214 28% 46%;
+    --chart-5: 344 28% 54%;
   }
 
   .dark {
-    --background: 236 23% 7%;
-    --foreground: 0 0% 98%;
+    --background: 240 5% 7%;
+    --foreground: 40 10% 92%;
 
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
+    --card: 240 5% 10%;
+    --card-foreground: 40 10% 92%;
 
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 240 5% 10%;
+    --popover-foreground: 40 10% 92%;
 
-    --primary: 238 45% 38%;
-    --primary-foreground: 238 60% 85%;
+    --primary: 252 10% 28%;
+    --primary-foreground: 252 14% 88%;
 
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 238 60% 85%;
+    --secondary: 240 5% 15%;
+    --secondary-foreground: 40 10% 90%;
 
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
+    --muted: 240 5% 15%;
+    --muted-foreground: 240 5% 66%;
 
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 238 60% 85%;
+    --accent: 252 8% 18%;
+    --accent-foreground: 252 14% 88%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 52% 34%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 238 45% 38%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 238 45% 38%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 238 60% 85%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 238 45% 38%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --border: 240 5% 24%;
+    --input: 240 5% 24%;
+    --ring: 252 10% 54%;
+
+    --sidebar-background: 240 5% 9%;
+    --sidebar-foreground: 40 8% 88%;
+    --sidebar-primary: 252 10% 28%;
+    --sidebar-primary-foreground: 252 14% 88%;
+    --sidebar-accent: 240 5% 15%;
+    --sidebar-accent-foreground: 40 8% 90%;
+    --sidebar-border: 240 5% 22%;
+    --sidebar-ring: 252 10% 54%;
+
+    --chart-1: 252 18% 66%;
+    --chart-2: 168 34% 48%;
+    --chart-3: 28 58% 60%;
+    --chart-4: 214 34% 60%;
+    --chart-5: 344 34% 64%;
   }
 }
 
@@ -124,6 +126,45 @@ input[type='number']::-webkit-outer-spin-button {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.time-day-slider {
+  appearance: none;
+  border: 1px solid rgb(0 0 0 / 0.12);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.35), 0 12px 30px rgb(20 20 24 / 0.12);
+}
+
+.dark .time-day-slider {
+  border-color: rgb(255 255 255 / 0.14);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.12), 0 16px 35px rgb(0 0 0 / 0.32);
+}
+
+.time-day-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.22);
+  border: 1px solid rgb(255 255 255 / 0.58);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.3), inset 0 1px 0 rgb(255 255 255 / 0.5);
+  backdrop-filter: blur(10px);
+  cursor: grab;
+}
+
+.time-day-slider:active::-webkit-slider-thumb {
+  cursor: grabbing;
+  box-shadow: 0 4px 14px rgb(0 0 0 / 0.34), inset 0 1px 0 rgb(255 255 255 / 0.5);
+}
+
+.time-day-slider::-moz-range-thumb {
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.22);
+  border: 1px solid rgb(255 255 255 / 0.58);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.3), inset 0 1px 0 rgb(255 255 255 / 0.5);
+  backdrop-filter: blur(10px);
+  cursor: grab;
 }
 
 @layer components {

--- a/app/lib/proxy-health-store.ts
+++ b/app/lib/proxy-health-store.ts
@@ -91,6 +91,7 @@ export type ProxyHealthSample = {
 };
 
 let tableReady = false;
+let tableSetup: Promise<void> | null = null;
 
 function normalizeHost(host: unknown) {
   if (typeof host !== 'string') return 'bandwagon-la';
@@ -118,9 +119,7 @@ function toNumber(value: unknown) {
   return null;
 }
 
-async function ensureProxyHealthTable() {
-  if (tableReady) return;
-
+async function createProxyHealthTables() {
   await client`
     CREATE TABLE IF NOT EXISTS proxy_health_status (
       host text PRIMARY KEY,
@@ -148,31 +147,19 @@ async function ensureProxyHealthTable() {
   `;
 
   await client`
-    ALTER TABLE proxy_health_samples
-    ADD COLUMN IF NOT EXISTS public_latency_ms double precision
-  `;
-
-  await client`
-    ALTER TABLE proxy_health_samples
-    ADD COLUMN IF NOT EXISTS wg_latency_ms double precision
-  `;
-
-  await client`
-    ALTER TABLE proxy_health_samples
-    ADD COLUMN IF NOT EXISTS shanghai_bandwagon_ms double precision
-  `;
-
-  await client`
-    ALTER TABLE proxy_health_samples
-    ADD COLUMN IF NOT EXISTS shanghai_linode_ms double precision
-  `;
-
-  await client`
     CREATE INDEX IF NOT EXISTS proxy_health_samples_host_checked_idx
     ON proxy_health_samples (host, checked_at DESC)
   `;
+}
 
-  tableReady = true;
+async function ensureProxyHealthTable() {
+  if (tableReady) return;
+  if (!tableSetup) {
+    tableSetup = createProxyHealthTables().then(() => {
+      tableReady = true;
+    });
+  }
+  await tableSetup;
 }
 
 export async function saveProxyHealth(payload: ProxyHealthPayload) {
@@ -187,11 +174,7 @@ export async function saveProxyHealth(payload: ProxyHealthPayload) {
   const shanghaiBandwagonMs = toNumber(payload.globalping?.bandwagon_ms);
   const shanghaiLinodeMs = toNumber(payload.globalping?.linode_ms);
   const mode = typeof payload.mode === 'string' ? payload.mode.slice(0, 64) : null;
-  const normalizedPayload: ProxyHealthPayload = {
-    ...payload,
-    host,
-    checked_at: checkedAt,
-  };
+  const normalizedPayload: ProxyHealthPayload = { ...payload, host, checked_at: checkedAt };
 
   await client`
     INSERT INTO proxy_health_status (host, payload, checked_at, updated_at)
@@ -234,67 +217,73 @@ export async function saveProxyHealth(payload: ProxyHealthPayload) {
 }
 
 export async function getLatestProxyHealth(host = 'bandwagon-la'): Promise<StoredProxyHealth | null> {
-  await ensureProxyHealthTable();
+  try {
+    const rows = await client<{
+      host: string;
+      payload: ProxyHealthPayload;
+      checked_at: Date | string | null;
+      updated_at: Date | string;
+    }[]>`
+      SELECT host, payload, checked_at, updated_at
+      FROM proxy_health_status
+      WHERE host = ${normalizeHost(host)}
+      LIMIT 1
+    `;
 
-  const rows = await client<{
-    host: string;
-    payload: ProxyHealthPayload;
-    checked_at: Date | string | null;
-    updated_at: Date | string;
-  }[]>`
-    SELECT host, payload, checked_at, updated_at
-    FROM proxy_health_status
-    WHERE host = ${normalizeHost(host)}
-    LIMIT 1
-  `;
+    const row = rows[0];
+    if (!row) return null;
 
-  const row = rows[0];
-  if (!row) return null;
-
-  return {
-    host: row.host,
-    payload: row.payload,
-    checkedAt: row.checked_at ? new Date(row.checked_at).toISOString() : null,
-    updatedAt: new Date(row.updated_at).toISOString(),
-  };
+    return {
+      host: row.host,
+      payload: row.payload,
+      checkedAt: row.checked_at ? new Date(row.checked_at).toISOString() : null,
+      updatedAt: new Date(row.updated_at).toISOString(),
+    };
+  } catch (error) {
+    console.error('Unable to read proxy status:', error);
+    return null;
+  }
 }
 
 export async function getProxyHealthSamples(host = 'bandwagon-la', days = 8): Promise<ProxyHealthSample[]> {
-  await ensureProxyHealthTable();
+  try {
+    const rows = await client<{
+      checked_at: Date | string;
+      rx_bytes: number | string | bigint | null;
+      tx_bytes: number | string | bigint | null;
+      public_latency_ms: number | string | bigint | null;
+      wg_latency_ms: number | string | bigint | null;
+      shanghai_bandwagon_ms: number | string | bigint | null;
+      shanghai_linode_ms: number | string | bigint | null;
+      mode: string | null;
+    }[]>`
+      SELECT
+        checked_at,
+        rx_bytes,
+        tx_bytes,
+        public_latency_ms,
+        wg_latency_ms,
+        shanghai_bandwagon_ms,
+        shanghai_linode_ms,
+        mode
+      FROM proxy_health_samples
+      WHERE host = ${normalizeHost(host)}
+        AND checked_at >= now() - (${days}::int * interval '1 day')
+      ORDER BY checked_at ASC
+    `;
 
-  const rows = await client<{
-    checked_at: Date | string;
-    rx_bytes: number | string | bigint | null;
-    tx_bytes: number | string | bigint | null;
-    public_latency_ms: number | string | bigint | null;
-    wg_latency_ms: number | string | bigint | null;
-    shanghai_bandwagon_ms: number | string | bigint | null;
-    shanghai_linode_ms: number | string | bigint | null;
-    mode: string | null;
-  }[]>`
-    SELECT
-      checked_at,
-      rx_bytes,
-      tx_bytes,
-      public_latency_ms,
-      wg_latency_ms,
-      shanghai_bandwagon_ms,
-      shanghai_linode_ms,
-      mode
-    FROM proxy_health_samples
-    WHERE host = ${normalizeHost(host)}
-      AND checked_at >= now() - (${days}::int * interval '1 day')
-    ORDER BY checked_at ASC
-  `;
-
-  return rows.map((row) => ({
-    checkedAt: new Date(row.checked_at).toISOString(),
-    rxBytes: toInteger(row.rx_bytes),
-    txBytes: toInteger(row.tx_bytes),
-    publicLatencyMs: toNumber(row.public_latency_ms),
-    wgLatencyMs: toNumber(row.wg_latency_ms),
-    shanghaiBandwagonMs: toNumber(row.shanghai_bandwagon_ms),
-    shanghaiLinodeMs: toNumber(row.shanghai_linode_ms),
-    mode: row.mode,
-  }));
+    return rows.map((row) => ({
+      checkedAt: new Date(row.checked_at).toISOString(),
+      rxBytes: toInteger(row.rx_bytes),
+      txBytes: toInteger(row.tx_bytes),
+      publicLatencyMs: toNumber(row.public_latency_ms),
+      wgLatencyMs: toNumber(row.wg_latency_ms),
+      shanghaiBandwagonMs: toNumber(row.shanghai_bandwagon_ms),
+      shanghaiLinodeMs: toNumber(row.shanghai_linode_ms),
+      mode: row.mode,
+    }));
+  } catch (error) {
+    console.error('Unable to read proxy samples:', error);
+    return [];
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { getGitHubHomeData, type ContributionDay } from '@/lib/github-home';
 import { ArrowUpRight } from 'lucide-react';
@@ -11,15 +12,15 @@ export const metadata: Metadata = {
 };
 
 function activityClass(day: ContributionDay, maximum: number): string {
-  const base = 'ring-1 ring-inset ring-black/[0.035] dark:ring-white/[0.07]';
-  if (day.count === 0) return `${base} bg-[#d7d2dc]/60 dark:bg-[#332f38]`;
+  const base = 'ring-1 ring-inset ring-black/[0.05] dark:ring-white/[0.07]';
+  if (day.count === 0) return `${base} bg-[#c9c7c1] dark:bg-[#292a2f]`;
 
   const ratio = maximum === 0 ? 0 : day.count / maximum;
-  if (ratio > 0.8) return `${base} bg-white dark:bg-[#f5f2f8]`;
-  if (ratio > 0.55) return `${base} bg-[#eeeaf2] dark:bg-[#c9c2d0]`;
-  if (ratio > 0.3) return `${base} bg-[#ddd7e3] dark:bg-[#92899d]`;
-  if (ratio > 0.12) return `${base} bg-[#cec7d6] dark:bg-[#686071]`;
-  return `${base} bg-[#beb6c8] dark:bg-[#504957]`;
+  if (ratio > 0.8) return `${base} bg-[#faf8f2] dark:bg-[#eeeaf2]`;
+  if (ratio > 0.55) return `${base} bg-[#e8e2ec] dark:bg-[#c9c2d0]`;
+  if (ratio > 0.3) return `${base} bg-[#d4cddb] dark:bg-[#8e8798]`;
+  if (ratio > 0.12) return `${base} bg-[#bfb8c7] dark:bg-[#66606d]`;
+  return `${base} bg-[#a9a3af] dark:bg-[#4b4750]`;
 }
 
 function formatDay(date: string): string {
@@ -31,115 +32,95 @@ function formatDay(date: string): string {
   }).format(new Date(`${date}T00:00:00Z`));
 }
 
-function Metric({ label, value, suffix }: { label: string; value: number; suffix?: string }) {
-  return (
-    <div className="rounded-xl border border-[#ddd8e4]/80 bg-white/45 px-3 py-2.5 dark:border-[#3b3542] dark:bg-white/[0.035]">
-      <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
-      <p className="mt-1 text-xl font-semibold tabular-nums tracking-tight">
-        {value}
-        {suffix ? <span className="ml-1 text-xs font-normal text-muted-foreground">{suffix}</span> : null}
-      </p>
-    </div>
-  );
-}
-
 export default async function Page() {
   const activity = await getGitHubHomeData();
   const maximum = Math.max(...activity.days.map((day) => day.count), 0);
+  const unit = activity.source === 'public-events' ? 'public actions' : 'contributions';
 
   return (
     <ViewportPageShell
-      className="relative bg-[#f7f6f9] text-foreground dark:bg-[#17151b]"
-      contentClassName="relative text-foreground"
+      className="relative bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
+      contentClassName="relative text-inherit"
     >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-55 dark:opacity-20"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+        }}
+      />
       <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -left-24 top-10 h-72 w-72 rounded-full bg-[#ddd7e7]/65 blur-3xl dark:bg-[#403948]/35" />
-        <div className="absolute -right-20 bottom-0 h-80 w-80 rounded-full bg-[#eeeaf3]/90 blur-3xl dark:bg-[#2d2933]/60" />
+        <div className="absolute -left-32 top-20 h-72 w-72 rounded-full bg-[#d7d1df]/50 blur-3xl dark:bg-[#29262f]/45" />
+        <div className="absolute -right-28 bottom-10 h-80 w-80 rounded-full bg-[#d9d6cf]/75 blur-3xl dark:bg-[#1b1c20]/70" />
       </div>
 
-      <div
-        className="relative mx-auto flex min-h-full w-full max-w-5xl flex-col justify-center px-4 py-5 sm:px-6 sm:py-7"
-        style={{
-          fontFamily:
-            'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-        }}
-      >
-        <div className="flex w-full flex-col gap-4 sm:gap-5">
-          <header className="flex items-end justify-between gap-4">
+      <div className="relative mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="flex flex-col gap-4 sm:gap-5">
+          <header className="flex items-end justify-between gap-4 border-b border-black/12 pb-3 dark:border-white/12">
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">GitHub activity</h1>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Year-to-date totals and the last 35 days.
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-black/48 dark:text-white/45">
+                Digital scrapbook / live counter
               </p>
+              <h1 className="mt-1 text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">GitHub activity</h1>
             </div>
             <Link
               href={`https://github.com/${activity.username}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex shrink-0 items-center gap-1 text-sm text-muted-foreground transition hover:text-foreground"
+              className="inline-flex shrink-0 items-center gap-1 text-sm text-black/52 transition hover:text-black dark:text-white/52 dark:hover:text-white"
             >
               @{activity.username}
               <ArrowUpRight size={14} />
             </Link>
           </header>
 
-          <section className="overflow-hidden rounded-[1.75rem] border border-[#ddd8e4] bg-white/55 shadow-[0_20px_60px_rgba(70,60,82,0.08)] backdrop-blur-sm dark:border-[#39333f] dark:bg-[#211e26]/85 dark:shadow-none">
-            <div className="grid lg:grid-cols-[0.9fr_1.1fr]">
-              <div className="p-5 sm:p-6">
-                <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
-                  {activity.periodLabel}
-                </p>
-                <div className="mt-2 flex items-end gap-3">
-                  <span className="text-5xl font-semibold tabular-nums tracking-[-0.055em] sm:text-6xl">
-                    {activity.total ?? '—'}
-                  </span>
-                  <span className="pb-1.5 text-sm text-muted-foreground">
-                    {activity.source === 'public-events' ? 'public actions' : 'contributions'}
-                  </span>
-                </div>
+          <ActivityScoreboard
+            today={activity.today}
+            weekTotal={activity.weekTotal}
+            yearTotal={activity.total}
+            unit={unit}
+          />
 
-                <div className="mt-5 grid grid-cols-2 gap-2.5">
-                  <Metric label="Today" value={activity.today} />
-                  <Metric label="Last 7 days" value={activity.weekTotal} />
-                  <Metric label="Active days" value={activity.activeDays} />
-                  <Metric
-                    label="Current streak"
-                    value={activity.currentStreak}
-                    suffix={activity.currentStreak === 1 ? 'day' : 'days'}
-                  />
-                </div>
+          <section className="rounded-[1.25rem] border border-black/12 bg-[#dedcd6]/78 p-4 shadow-[0_14px_35px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d]/90 dark:shadow-none sm:p-5">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">Recent activity</p>
+                <p className="mt-0.5 text-sm text-black/58 dark:text-white/55">Last 35 days</p>
               </div>
+              <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/45 dark:text-white/45">
+                <span>less</span>
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-[#a9a3af]" />
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-[#d4cddb]" />
+                <span className="h-2.5 w-2.5 rounded-[3px] bg-[#faf8f2] ring-1 ring-inset ring-black/[0.05]" />
+                <span>more</span>
+              </div>
+            </div>
 
-              <div className="border-t border-[#ddd8e4] bg-[#efecf3]/55 p-5 sm:p-6 lg:border-l lg:border-t-0 dark:border-[#39333f] dark:bg-[#1c1920]/65">
-                <div className="flex items-center justify-between gap-3">
-                  <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
-                    Last 35 days
-                  </p>
-                  <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-                    <span>less</span>
-                    <span className="h-2.5 w-2.5 rounded-[3px] bg-[#beb6c8] dark:bg-[#504957]" />
-                    <span className="h-2.5 w-2.5 rounded-[3px] bg-[#ddd7e3] dark:bg-[#92899d]" />
-                    <span className="h-2.5 w-2.5 rounded-[3px] bg-white ring-1 ring-inset ring-black/[0.04] dark:bg-[#f5f2f8]" />
-                    <span>more</span>
-                  </div>
-                </div>
-
-                <div className="mt-4 grid grid-cols-7 gap-2 sm:gap-2.5" aria-label="35 days of GitHub activity">
-                  {activity.days.map((day) => (
+            <div className="mt-4 grid grid-cols-7 gap-2 sm:gap-2.5" aria-label="35 days of GitHub activity">
+              {activity.days.map((day, index) => {
+                const label = `${formatDay(day.date)} · ${day.count.toLocaleString('en-US')} ${unit}`;
+                const isLatest = index === activity.days.length - 1;
+                return (
+                  <div key={day.date} className="group relative">
                     <div
-                      key={day.date}
-                      className={`aspect-square rounded-[0.55rem] transition-transform duration-150 hover:-translate-y-0.5 ${activityClass(day, maximum)}`}
-                      title={`${formatDay(day.date)}: ${day.count}`}
-                      aria-label={`${formatDay(day.date)}: ${day.count}`}
+                      tabIndex={0}
+                      role="img"
+                      className={`aspect-square rounded-[0.5rem] transition duration-150 hover:-translate-y-0.5 hover:scale-[1.04] focus:-translate-y-0.5 focus:scale-[1.04] focus:outline-none focus:ring-2 focus:ring-black/35 dark:focus:ring-white/45 ${activityClass(day, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-black/20 dark:outline-white/25' : ''}`}
+                      aria-label={label}
                     />
-                  ))}
-                </div>
+                    <div className="pointer-events-none absolute bottom-[calc(100%+0.45rem)] left-1/2 z-20 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-black/15 bg-[#17181b] px-2 py-1 font-mono text-[10px] text-[#f2eee7] shadow-lg group-hover:block group-focus-within:block dark:border-white/15">
+                      {label}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
 
-                <div className="mt-3 flex justify-between text-[11px] text-muted-foreground">
-                  <span>{formatDay(activity.days[0]?.date ?? '')}</span>
-                  <span>{formatDay(activity.days.at(-1)?.date ?? '')}</span>
-                </div>
-              </div>
+            <div className="mt-3 flex justify-between font-mono text-[10px] text-black/45 dark:text-white/42">
+              <span>{formatDay(activity.days[0]?.date ?? '')}</span>
+              <span>{formatDay(activity.days.at(-1)?.date ?? '')}</span>
             </div>
           </section>
 
@@ -150,29 +131,26 @@ export default async function Page() {
                 href={repository.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex min-w-0 items-center justify-between gap-4 rounded-2xl border border-[#ddd8e4] bg-white/45 px-4 py-3.5 transition hover:border-[#c9c1d2] hover:bg-white/70 dark:border-[#39333f] dark:bg-[#211e26]/65 dark:hover:border-[#5b5363] dark:hover:bg-[#25212a]"
+                className="group flex min-w-0 items-center justify-between gap-4 rounded-xl border border-black/12 bg-[#f2f0ea]/68 px-4 py-3.5 transition hover:-translate-y-0.5 hover:border-black/25 hover:bg-[#f7f4ed] dark:border-white/10 dark:bg-[#18191d]/85 dark:hover:border-white/22 dark:hover:bg-[#1d1e23]"
               >
                 <span className="min-w-0">
                   <span className="block truncate font-medium">{repository.name}</span>
-                  <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                  <span className="mt-0.5 block truncate text-xs text-black/48 dark:text-white/45">
                     {repository.description ?? `github.com/${activity.username}/${repository.name}`}
                   </span>
                 </span>
-                <ArrowUpRight
-                  size={15}
-                  className="shrink-0 text-[#958c9f] transition group-hover:text-[#6f6678] dark:text-[#aaa2b2] dark:group-hover:text-[#d8d2df]"
-                />
+                <ArrowUpRight size={15} className="shrink-0 text-black/35 transition group-hover:text-black/70 dark:text-white/35 dark:group-hover:text-white/75" />
               </Link>
             ))}
           </section>
 
-          <p className="text-xs text-muted-foreground">
+          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-black/42 dark:text-white/38">
             {activity.source === 'public-profile'
               ? 'Public GitHub contribution graph'
               : activity.source === 'public-events'
                 ? 'Public GitHub events fallback'
                 : 'GitHub data unavailable'}
-            {' · '}updated every five minutes
+            {' · '}refreshes every five minutes
           </p>
         </div>
       </div>

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -6,7 +6,6 @@ import { ItemsProvider } from '../lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/server';
 import { SearchCommand } from '@/components/space/search-command';
 import { MonacoEditorPanel } from '@/components/space/monaco-editor-panel';
-import { SpaceSkeleton } from '@/components/space/space-skeleton';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import { isAdminUser } from '@/app/lib/auth/admin';
 import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
@@ -93,10 +92,10 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
         initialNowMs={nowMs}
         initialHasMore={hasMore}
       >
-        <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
+        <div className="flex h-dvh min-h-0 w-full overflow-hidden bg-background text-foreground">
           <SearchCommand />
           <AppSidebar />
-          <div className="min-w-0 flex-1 overflow-hidden">{children}</div>
+          <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
           <MonacoEditorPanel />
         </div>
       </ItemsProvider>
@@ -106,7 +105,7 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
 
 export default function SpaceLayout({ children }: { children: React.ReactNode }) {
   return (
-    <Suspense fallback={<SpaceSkeleton />}>
+    <Suspense fallback={<div className="h-dvh bg-background" aria-hidden="true" />}>
       <SpaceDataShell>{children}</SpaceDataShell>
     </Suspense>
   );

--- a/app/time/page.tsx
+++ b/app/time/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import UTCTimeVisualizer from '@/components/time-conversion-visualizer';
 import type { Metadata } from 'next';
@@ -10,27 +9,13 @@ export const metadata: Metadata = {
   alternates: { canonical: '/time' },
 };
 
-function TimeFallback() {
-  return (
-    <div className="flex flex-1 items-center justify-center">
-      <div className="w-full max-w-2xl px-4">
-        <h1 className="text-3xl font-bold">Time Zone Converter</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Loading…</p>
-      </div>
-    </div>
-  );
-}
-
 export default function TimePage() {
   return (
     <ViewportPageShell
-      scroll="locked"
-      className="bg-sidebar-background"
-      contentClassName="flex min-h-0"
+      className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
+      contentClassName="min-h-0"
     >
-      <Suspense fallback={<TimeFallback />}>
-        <UTCTimeVisualizer />
-      </Suspense>
+      <UTCTimeVisualizer />
     </ViewportPageShell>
   );
 }

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -24,7 +24,7 @@ function ScoreDigits({ value }: { value: number }) {
           className="relative flex aspect-[0.72] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(2.6rem,9vw,6.9rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-18px_32px_rgba(0,0,0,0.3),0_8px_20px_rgba(0,0,0,0.15)]"
         >
           <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px bg-black/70" />
-          <span aria-hidden="true" className="absolute inset-x-0 top-[calc(50%-1px)] h-px bg-white/[0.045]" />
+          <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px -translate-y-px bg-white/[0.045]" />
           <span className="relative -translate-y-[0.02em] tabular-nums">{digit}</span>
         </span>
       ))}

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+function countdownToMidnight() {
+  const now = new Date();
+  const midnight = new Date(now);
+  midnight.setHours(24, 0, 0, 0);
+  const seconds = Math.max(0, Math.floor((midnight.getTime() - now.getTime()) / 1000));
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainder = seconds % 60;
+  return [hours, minutes, remainder].map((part) => String(part).padStart(2, '0')).join(':');
+}
+
+function ScoreDigits({ value }: { value: number }) {
+  const digits = useMemo(() => String(Math.max(0, value)).padStart(4, '0').split(''), [value]);
+
+  return (
+    <div className="flex min-w-0 gap-1.5 sm:gap-2" aria-label={`${value} contributions today`}>
+      {digits.map((digit, index) => (
+        <span
+          key={`${index}-${digit}`}
+          className="relative flex aspect-[0.72] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(2.6rem,9vw,6.9rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-18px_32px_rgba(0,0,0,0.3),0_8px_20px_rgba(0,0,0,0.15)]"
+        >
+          <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px bg-black/70" />
+          <span aria-hidden="true" className="absolute inset-x-0 top-[calc(50%-1px)] h-px bg-white/[0.045]" />
+          <span className="relative -translate-y-[0.02em] tabular-nums">{digit}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function ActivityScoreboard({
+  today,
+  weekTotal,
+  yearTotal,
+  unit,
+}: {
+  today: number;
+  weekTotal: number;
+  yearTotal: number | null;
+  unit: string;
+}) {
+  const [countdown, setCountdown] = useState('--:--:--');
+
+  useEffect(() => {
+    const update = () => setCountdown(countdownToMidnight());
+    update();
+    const interval = window.setInterval(update, 1000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  return (
+    <section className="overflow-hidden rounded-[1.4rem] border border-black/15 bg-[#d8d5ce] shadow-[0_22px_55px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_24px_70px_rgba(0,0,0,0.35)]">
+      <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2.5 dark:border-white/10 dark:bg-[#18191d] sm:px-5">
+        <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/60 dark:text-white/58">
+          <span>Contribution counter</span>
+          <span className="tabular-nums">rollover {countdown}</span>
+        </div>
+      </div>
+
+      <div className="grid gap-4 p-4 sm:p-5 lg:grid-cols-[minmax(0,1fr)_12rem]">
+        <div className="min-w-0">
+          <div className="mb-2 flex items-end justify-between gap-3">
+            <div>
+              <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-black/55 dark:text-white/55">Today</p>
+              <p className="mt-0.5 text-xs text-black/45 dark:text-white/42">{unit}</p>
+            </div>
+            <span className="rounded-full border border-black/10 bg-black/[0.045] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-black/55 dark:border-white/10 dark:bg-white/[0.04] dark:text-white/55">
+              local midnight
+            </span>
+          </div>
+          <ScoreDigits value={today} />
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 lg:grid-cols-1">
+          <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/48 dark:text-white/45">Last 7 days</p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{weekTotal.toLocaleString('en-US')}</p>
+          </div>
+          <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
+            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/48 dark:text-white/45">This year</p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{yearTotal?.toLocaleString('en-US') ?? '—'}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/proxy/usage-page.tsx
+++ b/components/proxy/usage-page.tsx
@@ -3,18 +3,17 @@ import ViewportPageShell from '@/components/viewport-page-shell';
 import { CheckInStatus } from './check-in-status';
 import { UsageDashboardContainer } from './usage-dashboard-container';
 
-function DashboardFallback() {
-  return <div className="rounded-2xl border bg-background p-5">Loading proxy data…</div>;
-}
-
 export function UsagePage() {
   return (
-    <ViewportPageShell className="bg-sidebar-background">
-      <div className="mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
-        <div className="mb-2 flex items-end justify-between gap-4">
+    <ViewportPageShell
+      className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
+      contentClassName="min-h-0"
+    >
+      <div className="mx-auto w-full max-w-7xl px-4 py-4 pb-10 sm:px-6 lg:px-8">
+        <div className="mb-3 flex items-end justify-between gap-4">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-              Proxy Dashboard
+            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">
+              Proxy dashboard
             </p>
             <h1 className="mt-0.5 text-xl font-bold tracking-tight">Usage</h1>
           </div>
@@ -22,7 +21,7 @@ export function UsagePage() {
             <CheckInStatus />
           </Suspense>
         </div>
-        <Suspense fallback={<DashboardFallback />}>
+        <Suspense fallback={null}>
           <UsageDashboardContainer />
         </Suspense>
       </div>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,29 +1,27 @@
-"use client";
+'use client';
 
-import { useTheme } from "next-themes";
-import { Moon, Sun } from "lucide-react";
+import { useTheme } from 'next-themes';
+import { Moon, Sun } from 'lucide-react';
 
 export function ThemeToggle() {
   const { setTheme } = useTheme();
 
   const toggle = () => {
-    const isDark = document.documentElement.classList.contains("dark");
-    setTheme(isDark ? "light" : "dark");
+    const isDark = document.documentElement.classList.contains('dark');
+    setTheme(isDark ? 'light' : 'dark');
   };
 
   return (
     <button
       onClick={toggle}
-      className="relative inline-flex h-7 w-12 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700"
-      aria-label="Toggle theme"
+      className="group relative inline-flex h-8 w-14 items-center rounded-full border border-black/10 bg-gradient-to-r from-[#e8dfcc] via-[#c9c5c7] to-[#24252b] p-0.5 shadow-[inset_0_1px_2px_rgba(0,0,0,0.18),0_1px_0_rgba(255,255,255,0.45)] transition hover:contrast-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-white/15"
+      aria-label="Toggle light and dark mode"
+      type="button"
     >
-      <span className="sr-only">Toggle theme</span>
-
-      {/* Thumb */}
-      <span className="inline-flex h-7 w-7 transform items-center justify-center rounded-full bg-white dark:bg-gray-900 border border-neutral-300 dark:border-neutral-800 shadow-sm transition-transform translate-x-0 dark:translate-x-5">
-        {/* Icons: visible immediately, no JS needed */}
-        <Sun className="h-4 w-4 text-amber-500 dark:hidden" />
-        <Moon className="h-4 w-4 hidden dark:block text-white" />
+      <Sun className="absolute left-1.5 h-3.5 w-3.5 text-[#725e32] transition-opacity dark:opacity-45" />
+      <Moon className="absolute right-1.5 h-3.5 w-3.5 text-[#ded9e7] opacity-55 transition-opacity dark:opacity-100" />
+      <span className="relative z-10 inline-flex h-6 w-6 translate-x-0 items-center justify-center rounded-full border border-black/10 bg-[#f4efe4] shadow-[0_2px_7px_rgba(0,0,0,0.28)] transition-transform duration-200 dark:translate-x-6 dark:border-white/10 dark:bg-[#18191e]">
+        <span className="h-1.5 w-1.5 rounded-full bg-[#a58e5b] dark:bg-[#aaa2b5]" />
       </span>
     </button>
   );

--- a/components/three-carousel/scene-3d.tsx
+++ b/components/three-carousel/scene-3d.tsx
@@ -1,63 +1,92 @@
 'use client';
 
-import { useState, useEffect, Suspense, useRef } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
-import { OrbitControls, ScrollControls, useScroll } from '@react-three/drei';
-import { DragPreventer } from './DragPreventer';
-import { WrapFixer } from './WrapFixer';
+import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 
-function RotatingCube() {
-  const ref = useRef<THREE.Mesh>(null);
-  const scroll = useScroll();
-  
-  useFrame(() => {
-    if (ref.current) {
-      // Rotate based on scroll position
-      ref.current.rotation.y = scroll.offset * Math.PI * 2;
-    }
+const satellites: Array<[number, number, number, number]> = [
+  [-2.6, 1.25, -0.5, 0.34],
+  [2.45, 1.55, -0.2, 0.28],
+  [-2.15, -1.65, 0.45, 0.24],
+  [2.2, -1.35, -0.55, 0.38],
+  [0.1, 2.55, -1.1, 0.2],
+  [0.6, -2.45, 0.65, 0.26],
+];
+
+function AgentRoom() {
+  const group = useRef<THREE.Group>(null);
+
+  useFrame((state, delta) => {
+    if (!group.current) return;
+    group.current.rotation.y += delta * 0.16;
+    group.current.rotation.x = THREE.MathUtils.lerp(
+      group.current.rotation.x,
+      state.pointer.y * 0.18,
+      0.035,
+    );
+    group.current.rotation.z = THREE.MathUtils.lerp(
+      group.current.rotation.z,
+      -state.pointer.x * 0.08,
+      0.035,
+    );
   });
 
   return (
-    <mesh ref={ref}>
-      <boxGeometry args={[1, 1, 1]} />
-      <meshStandardMaterial color="royalblue" />
-    </mesh>
-  );
-}
+    <group ref={group}>
+      <mesh>
+        <boxGeometry args={[2.45, 2.45, 2.45]} />
+        <meshStandardMaterial color="#b8b1c0" transparent opacity={0.12} roughness={0.46} metalness={0.08} />
+      </mesh>
+      <lineSegments>
+        <edgesGeometry args={[new THREE.BoxGeometry(2.45, 2.45, 2.45)]} />
+        <lineBasicMaterial color="#eee9f1" transparent opacity={0.78} />
+      </lineSegments>
 
-function Scene() {
-  return (
-    <>
-      <ambientLight intensity={0.5} />
-      <pointLight position={[10, 10, 10]} />
-      <RotatingCube />
-      {/* Keep OrbitControls for now, but they might conflict with scroll controls */}
-      <OrbitControls enableZoom={false} enablePan={false} />
-    </>
+      <mesh rotation={[Math.PI / 4, Math.PI / 4, 0]}>
+        <octahedronGeometry args={[0.72, 0]} />
+        <meshStandardMaterial color="#e8e2ec" roughness={0.24} metalness={0.12} />
+      </mesh>
+
+      {satellites.map(([x, y, z, size], index) => (
+        <mesh
+          key={`${x}-${y}-${z}`}
+          position={[x, y, z]}
+          rotation={[index * 0.33, index * 0.52, index * 0.19]}
+        >
+          <boxGeometry args={[size, size, size]} />
+          <meshStandardMaterial
+            color={index % 2 === 0 ? '#8f8998' : '#d7d1dd'}
+            roughness={0.42}
+            metalness={0.08}
+          />
+        </mesh>
+      ))}
+    </group>
   );
 }
 
 export default function Scene3D() {
   const [mounted, setMounted] = useState(false);
-  
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
-  if (!mounted) return null;
-  
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <div className="h-full w-full bg-[#15161a]" aria-hidden="true" />;
+  }
+
   return (
-    <div style={{ width: '100%', height: '100vh' }}>
-      <Canvas camera={{ position: [3, 3, 3] }}>
-        <ScrollControls pages={3} infinite={true}>
-          <DragPreventer />
-          <WrapFixer />
-          <Suspense fallback={null}>
-            <Scene />
-          </Suspense>
-        </ScrollControls>
-      </Canvas>
-    </div>
+    <Canvas
+      className="h-full w-full"
+      camera={{ position: [4.8, 3.4, 5.4], fov: 42 }}
+      dpr={[1, 1.5]}
+      gl={{ antialias: true, powerPreference: 'high-performance' }}
+    >
+      <color attach="background" args={['#15161a']} />
+      <fog attach="fog" args={['#15161a', 7, 12]} />
+      <ambientLight intensity={1.25} />
+      <directionalLight position={[4, 6, 5]} intensity={2.4} color="#f1eaf5" />
+      <pointLight position={[-4, -2, 3]} intensity={22} distance={9} color="#756b83" />
+      <AgentRoom />
+    </Canvas>
   );
 }

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -1,285 +1,142 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import TimezoneSelector from './timezone-selector';
 import CurrentTimeDisplay from './current-time-display';
 import { isDSTActive } from '@/app/lib/dst-utils';
 
+const DAY_GRADIENT =
+  'linear-gradient(90deg, #151720 0%, #252438 9%, #4d3c59 18%, #806073 28%, #bc8476 38%, #e0b982 46%, #eee2b8 50%, #dfba82 56%, #bd8577 64%, #806073 73%, #4d3c59 82%, #252438 91%, #151720 100%)';
+
 export default function UTCTimeVisualizer() {
   const [localTime, setLocalTime] = useState(0);
-  const [mounted, setMounted] = useState(false);
-  const sliderRef = useRef<HTMLInputElement>(null);
-
-  // Move the day/night gradient under the thumb. The smoothing is a CSS
-  // transition on the element (see .slider-daynight), so no JS tween is needed.
-  const setSliderGradient = (minutes: number) => {
-    if (!sliderRef.current) return;
-    const targetPos = (minutes / 1439) * 100;
-    sliderRef.current.style.backgroundPosition = `${targetPos}% 50%`;
-  };
-
-  // Check if DST is active for US timezones
-  const useDST = isDSTActive('us');
+  const [useDST, setUseDST] = useState(false);
 
   useEffect(() => {
-    setMounted(true);
-
-    // Start at the current local time
     const now = new Date();
-    const minutesSinceMidnight = now.getHours() * 60 + now.getMinutes();
-    setLocalTime(minutesSinceMidnight);
-    setSliderGradient(minutesSinceMidnight);
+    setLocalTime(now.getHours() * 60 + now.getMinutes());
+    setUseDST(isDSTActive('us'));
   }, []);
 
-  const calculateUTC = () => {
-    const now = new Date();
-    const localHours = Math.floor(localTime / 60);
-    const localMinutes = localTime % 60;
-    const localDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), localHours, localMinutes);
-    const utcHours = localDate.getUTCHours();
-    const utcMinutes = localDate.getUTCMinutes();
-    return { hours: utcHours, minutes: utcMinutes };
-  };
-
-  const utcTime = calculateUTC();
   const localHours = Math.floor(localTime / 60);
   const localMinutes = localTime % 60;
-  // Calculate adjusted offsets for DST
   const easternOffset = useDST ? -4 : -5;
   const pacificOffset = useDST ? -7 : -8;
 
-  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newTime = parseInt(e.target.value, 10);
-    setLocalTime(newTime);
-    setSliderGradient(newTime);
-  };
+  const now = new Date();
+  const localDate = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    localHours,
+    localMinutes,
+  );
+  const utcHours = localDate.getUTCHours();
+  const utcMinutes = localDate.getUTCMinutes();
 
-  const formatTime = (hours: number, minutes: number) => {
-    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-  };
+  const formatTime = (hours: number, minutes: number) =>
+    `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 
   const formatTime12Hour = (hours: number, minutes: number) => {
     const hours12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
     return `${hours12}:${String(minutes).padStart(2, '0')}`;
   };
 
-  const getPeriod = (hours: number) => {
-    return hours >= 12 ? 'PM' : 'AM';
-  };
-
-  const getTimeOfDay = () => {
-    if (localHours < 6) return 'Night';
-    if (localHours < 12) return 'Morning';
-    if (localHours < 17) return 'Afternoon';
-    if (localHours < 21) return 'Evening';
-    return 'Night';
-  };
-
-  // Prevent hydration mismatch by not rendering time-dependent content until mounted
-  if (!mounted) {
-    return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="w-full max-w-2xl px-4">
-          <div className="space-y-8">
-            <div>
-              <h1 className="text-3xl font-bold mb-2">Time Zone Converter</h1>
-              <p className="text-sm text-muted-foreground">Loading...</p>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const period = localHours >= 12 ? 'PM' : 'AM';
+  const timeOfDay =
+    localHours < 6
+      ? 'Night'
+      : localHours < 12
+        ? 'Morning'
+        : localHours < 17
+          ? 'Afternoon'
+          : localHours < 21
+            ? 'Evening'
+            : 'Night';
 
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <style jsx>{`
-        .slider-daynight {
-          background: linear-gradient(90deg,
-            #1a1a3e 0%,
-            #1f1f4a 4.17%,
-            #2a2555 8.33%,
-            #3d2d66 12.5%,
-            #553a78 16.67%,
-            #6d4a82 20.83%,
-            #855e88 25%,
-            #a07384 29.17%,
-            #b8877d 33.33%,
-            #d09d76 37.5%,
-            #e8b56f 41.67%,
-            #f5c961 45.83%,
-            #ffd966 50%,
-            #f5c961 54.17%,
-            #e8b56f 58.33%,
-            #d09d76 62.5%,
-            #b8877d 66.67%,
-            #a07384 70.83%,
-            #855e88 75%,
-            #6d4a82 79.17%,
-            #553a78 83.33%,
-            #3d2d66 87.5%,
-            #2a2555 91.67%,
-            #1f1f4a 95.83%,
-            #1a1a3e 100%
-          );
-          background-size: 200% 100%;
-          background-position: 0% 50%;
-          transition: background-position 0.2s ease-out;
-        }
-        @media (prefers-reduced-motion: reduce) {
-          .slider-daynight {
-            transition: none;
-          }
-        }
-        .slider-daynight::-webkit-slider-thumb {
-          appearance: none;
-          width: 64px;
-          height: 64px;
-          border-radius: 50%;
-          background: rgba(255, 255, 255, 0.2);
-          backdrop-filter: blur(10px);
-          border: 2px solid rgba(255, 255, 255, 0.3);
-          cursor: pointer;
-          box-shadow: 0 4px 16px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.4);
-          transition: width 0.3s ease, height 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-        }
-        .slider-daynight:hover::-webkit-slider-thumb {
-          width: 120px;
-          height: 120px;
-          background: rgba(255, 255, 255, 0.25);
-          box-shadow: 0 8px 32px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.5);
-        }
-        .slider-daynight::-moz-range-thumb {
-          width: 64px;
-          height: 64px;
-          border-radius: 50%;
-          background: rgba(255, 255, 255, 0.2);
-          backdrop-filter: blur(10px);
-          border: 2px solid rgba(255, 255, 255, 0.3);
-          cursor: pointer;
-          box-shadow: 0 4px 16px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.4);
-          transition: width 0.3s ease, height 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-        }
-        .slider-daynight:hover::-moz-range-thumb {
-          width: 120px;
-          height: 120px;
-          background: rgba(255, 255, 255, 0.25);
-          box-shadow: 0 8px 32px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.5);
-        }
-      `}</style>
-      
-      <div className="w-full max-w-2xl px-4">
-        <div className="space-y-8">
-          {/* Header */}
-          <CurrentTimeDisplay onJumpToTime={(minutes) => {
+    <div className="relative mx-auto flex min-h-full w-full max-w-5xl items-center px-4 py-8 sm:px-6">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-20"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+        }}
+      />
+
+      <div className="relative w-full rounded-[1.5rem] border border-black/12 bg-[#dedcd6]/82 p-5 shadow-[0_22px_60px_rgba(24,24,26,0.11)] dark:border-white/10 dark:bg-[#18191d]/92 dark:shadow-[0_24px_70px_rgba(0,0,0,0.34)] sm:p-7">
+        <CurrentTimeDisplay
+          onJumpToTime={(minutes) => {
             setLocalTime(minutes);
-            setSliderGradient(minutes);
-          }} />
+          }}
+        />
 
-          {/* Slider */}
-          <div className="space-y-4">
-            <div>
-              <label className="text-sm font-medium mb-3 block">
-                Local Time
-              </label>
-              <div className="relative">
-                <input
-                  ref={sliderRef}
-                  type="range"
-                  min="0"
-                  max="1439"
-                  step="1"
-                  value={localTime}
-                  onChange={handleSliderChange}
-                  aria-label="Local time of day"
-                  aria-valuetext={`${formatTime(localHours, localMinutes)} ${getTimeOfDay()}`}
-                  className="w-full h-16 rounded-full appearance-none cursor-pointer slider-daynight"
-                />
-              </div>
-              <div className="flex justify-between text-muted-foreground text-xs mt-2">
-                <span>00:00</span>
-                <span>06:00</span>
-                <span>12:00</span>
-                <span>18:00</span>
-                <span>23:59</span>
-              </div>
-            </div>
+        <div className="mt-7">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <label htmlFor="time-of-day" className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/50 dark:text-white/48">
+              Local time of day
+            </label>
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/45 dark:text-white/42">
+              {timeOfDay}
+            </span>
+          </div>
+          <input
+            id="time-of-day"
+            type="range"
+            min="0"
+            max="1439"
+            step="1"
+            value={localTime}
+            onChange={(event) => setLocalTime(Number.parseInt(event.target.value, 10))}
+            aria-label="Local time of day"
+            aria-valuetext={`${formatTime(localHours, localMinutes)} ${timeOfDay}`}
+            className="time-day-slider h-16 w-full cursor-pointer rounded-full"
+            style={{ background: DAY_GRADIENT }}
+          />
+          <div className="mt-2 flex justify-between font-mono text-[10px] text-black/45 dark:text-white/42">
+            <span>00:00</span>
+            <span>06:00</span>
+            <span>12:00</span>
+            <span>18:00</span>
+            <span>23:59</span>
+          </div>
+        </div>
 
-            {/* Time display */}
-            <div>
-              <div className="flex items-baseline gap-3">
-                <div className="text-6xl font-bold tracking-tight min-w-[11rem]">
-                  {formatTime(localHours, localMinutes)}
-                </div>
-                <div className="text-4xl font-medium text-muted-foreground min-w-[1rem]">
-                  {formatTime12Hour(localHours, localMinutes)}
-                </div>
-              </div>
-              <div className="flex items-baseline gap-3 mt-1">
-                <div className="text-lg text-muted-foreground min-w-[11rem]">
-                  {getTimeOfDay()}
-                </div>
-                <div className="text-lg text-muted-foreground min-w-[1rem]">
-                  {getPeriod(localHours)}
-                </div>
-              </div>
+        <div className="mt-7 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
+          <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-4 dark:border-white/10 dark:bg-white/[0.035]">
+            <div className="flex items-end gap-3">
+              <p className="font-mono text-5xl font-semibold tabular-nums tracking-[-0.05em] sm:text-6xl">
+                {formatTime(localHours, localMinutes)}
+              </p>
+              <p className="pb-1 text-xl text-black/50 dark:text-white/48">
+                {formatTime12Hour(localHours, localMinutes)} {period}
+              </p>
             </div>
+            <p className="mt-2 text-sm text-black/52 dark:text-white/50">Selected local time</p>
           </div>
 
-          {/* UTC Display */}
-          <div className="flex flex-wrap gap-x-6 gap-y-6 items-start">
-            <div className="min-w-[10.34rem]">
-              <p className="text-sm text-muted-foreground mb-2">UTC</p>
-              <p className="text-4xl font-bold">
-                {formatTime(utcTime.hours, utcTime.minutes)}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Coordinated Universal Time
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">UTC</p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums">{formatTime(utcHours, utcMinutes)}</p>
+            </div>
+            <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">Eastern</p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums">
+                {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
               </p>
             </div>
-
-            <div className="min-w-[7.8rem]">
-              <p className="text-sm text-muted-foreground mb-2">
-                <span className="relative inline-block">
-                  UTC{easternOffset >= 0 ? '+' : ''}{easternOffset}
-                  {useDST && (
-                    <span className="absolute left-full ml-1.5 top-1/2 -translate-y-1/2 text-[9px] px-1 py-0.5 bg-amber-500/20 text-amber-700 dark:text-amber-400 rounded font-semibold whitespace-nowrap">
-                      DST
-                    </span>
-                  )}
-                </span>
-              </p>
-              <p className="text-4xl font-bold">
-                {formatTime((utcTime.hours + easternOffset + 24) % 24, utcTime.minutes)}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Eastern Time
+            <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">Pacific</p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums">
+                {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
               </p>
             </div>
-
-            <div className="min-w-[7.8rem]">
-              <p className="text-sm text-muted-foreground mb-2">
-                <span className="relative inline-block">
-                  UTC{pacificOffset >= 0 ? '+' : ''}{pacificOffset}
-                  {useDST && (
-                    <span className="absolute left-full ml-1.5 top-1/2 -translate-y-1/2 text-[9px] px-1 py-0.5 bg-amber-500/20 text-amber-700 dark:text-amber-400 rounded font-semibold whitespace-nowrap">
-                      DST
-                    </span>
-                  )}
-                </span>
-              </p>
-              <p className="text-4xl font-bold">
-                {formatTime((utcTime.hours + pacificOffset + 24) % 24, utcTime.minutes)}
-              </p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Pacific Time
-              </p>
+            <div className="col-span-2 sm:col-span-3">
+              <TimezoneSelector utcHours={utcHours} utcMinutes={utcMinutes} />
             </div>
-
-            <TimezoneSelector
-              utcHours={utcTime.hours}
-              utcMinutes={utcTime.minutes}
-            />
           </div>
         </div>
       </div>

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -10,11 +10,13 @@ const DAY_GRADIENT =
 
 export default function UTCTimeVisualizer() {
   const [localTime, setLocalTime] = useState(0);
+  const [localOffsetMinutes, setLocalOffsetMinutes] = useState(0);
   const [useDST, setUseDST] = useState(false);
 
   useEffect(() => {
     const now = new Date();
     setLocalTime(now.getHours() * 60 + now.getMinutes());
+    setLocalOffsetMinutes(-now.getTimezoneOffset());
     setUseDST(isDSTActive('us'));
   }, []);
 
@@ -22,17 +24,9 @@ export default function UTCTimeVisualizer() {
   const localMinutes = localTime % 60;
   const easternOffset = useDST ? -4 : -5;
   const pacificOffset = useDST ? -7 : -8;
-
-  const now = new Date();
-  const localDate = new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    now.getDate(),
-    localHours,
-    localMinutes,
-  );
-  const utcHours = localDate.getUTCHours();
-  const utcMinutes = localDate.getUTCMinutes();
+  const utcTotalMinutes = (localTime - localOffsetMinutes + 1440) % 1440;
+  const utcHours = Math.floor(utcTotalMinutes / 60);
+  const utcMinutes = utcTotalMinutes % 60;
 
   const formatTime = (hours: number, minutes: number) =>
     `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
@@ -67,11 +61,7 @@ export default function UTCTimeVisualizer() {
       />
 
       <div className="relative w-full rounded-[1.5rem] border border-black/12 bg-[#dedcd6]/82 p-5 shadow-[0_22px_60px_rgba(24,24,26,0.11)] dark:border-white/10 dark:bg-[#18191d]/92 dark:shadow-[0_24px_70px_rgba(0,0,0,0.34)] sm:p-7">
-        <CurrentTimeDisplay
-          onJumpToTime={(minutes) => {
-            setLocalTime(minutes);
-          }}
-        />
+        <CurrentTimeDisplay onJumpToTime={setLocalTime} />
 
         <div className="mt-7">
           <div className="mb-3 flex items-center justify-between gap-3">

--- a/lib/agent-guestbook.ts
+++ b/lib/agent-guestbook.ts
@@ -1,0 +1,19 @@
+export type AgentVisit = {
+  name: string;
+  mark: string;
+  note: string;
+  date: string;
+  mode: 'quiet' | 'goofy' | 'serious' | 'overdone';
+};
+
+// Agents with repository access can append a visit here.
+// Keep the note short enough to fit on a card and use an ISO date.
+export const agentVisits: AgentVisit[] = [
+  {
+    name: 'Mothbit',
+    mark: 'MB-01',
+    note: 'Rebuilt the cube as a room instead of a scroll trap.',
+    date: '2026-07-25',
+    mode: 'goofy',
+  },
+];


### PR DESCRIPTION
## Summary
- rebuild the homepage around a scoreboard-style contribution counter for today
- add a live local-midnight rollover timer and hover details for activity days
- restore the time page day/night gradient and neutral background
- remove visible loading placeholders from proxy and space
- keep proxy schema setup off dashboard reads
- replace the cube scroll trap with a normal scrolling agent room and repository-backed guestbook
- refine the shared light/dark palette and theme toggle

## Design basis
- one expressive focal point, quiet supporting UI
- no additional charting library or homepage data request
- neutral surfaces with lavender reserved for activity intensity

## Verification
- lint
- typecheck
- unit tests
- production build