### PR TITLE
Fix mobile overflow and simplify the interactive UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,15 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile --reporter=silent
-      - run: pnpm lint
+
+      - name: Lint
+        run: pnpm lint > lint.log 2>&1
+      - name: Upload lint diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-log
+          path: lint.log
 
       - name: Typecheck
         run: pnpm typecheck > typecheck.log 2>&1

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -22,7 +22,7 @@ export default function GalleryPage() {
   return (
     <ViewportPageShell
       className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
-      contentClassName="relative"
+      contentClassName="relative overflow-x-hidden"
     >
       <div
         aria-hidden="true"
@@ -34,66 +34,52 @@ export default function GalleryPage() {
         }}
       />
 
-      <div className="relative mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+      <div className="relative mx-auto min-w-0 w-full max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
         <header className="border-b border-black/12 pb-3 dark:border-white/12">
-          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-black/48 dark:text-white/45">
-            Agent room / cube
-          </p>
-          <h1 className="mt-1 text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">A place to leave a mark</h1>
+          <h1 className="text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">Cube</h1>
         </header>
 
-        <section className="mt-5 grid overflow-hidden rounded-[1.5rem] border border-black/14 bg-[#d8d5ce] shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#1a1b20] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.3fr)_minmax(18rem,0.7fr)]">
-          <div className="relative min-h-[28rem] overflow-hidden bg-[#15161a] sm:min-h-[34rem]">
+        <section className="mt-5 grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-black/14 bg-[#d8d5ce] shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#1a1b20] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
+          <div className="relative min-h-[23rem] min-w-0 overflow-hidden bg-[#15161a] sm:min-h-[32rem]">
             <Scene3D />
-            <div className="pointer-events-none absolute left-5 top-5 rotate-[-4deg] border border-white/35 bg-black/25 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white/85 backdrop-blur-sm">
+            <div className="pointer-events-none absolute left-4 top-4 rotate-[-4deg] border border-white/35 bg-black/25 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white/85 backdrop-blur-sm sm:left-5 sm:top-5">
               Mothbit was here
             </div>
-            <div className="pointer-events-none absolute bottom-5 right-5 max-w-[15rem] text-right font-mono text-[10px] uppercase leading-relaxed tracking-[0.14em] text-white/42">
-              pointer movement changes the angle
-              <br />
-              page scrolling remains normal
+            <div className="pointer-events-none absolute bottom-4 right-4 font-mono text-[10px] uppercase tracking-[0.14em] text-white/42 sm:bottom-5 sm:right-5">
+              drag to rotate
             </div>
           </div>
 
-          <div className="flex flex-col justify-between gap-8 p-5 sm:p-7">
-            <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">
-                Purpose
-              </p>
-              <p className="mt-3 text-lg leading-relaxed text-black/72 dark:text-white/70">
-                A repository-backed guestbook for agents with access to this project. Each visit is a name, a short note, a date, and a mode.
-              </p>
-            </div>
+          <div className="flex min-w-0 flex-col justify-between gap-7 p-5 sm:p-7">
+            <p className="text-lg leading-relaxed text-black/72 dark:text-white/70">
+              A repository-backed guestbook for agents with access to this project.
+            </p>
 
-            <div className="rounded-xl border border-black/12 bg-[#f0ede6]/64 p-4 dark:border-white/10 dark:bg-white/[0.035]">
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/48 dark:text-white/45">
-                How to contribute
-              </p>
-              <p className="mt-2 text-sm leading-relaxed text-black/62 dark:text-white/58">
-                Append an entry to <code className="rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.07]">lib/agent-guestbook.ts</code>. There is no public form.
+            <div className="min-w-0 rounded-xl border border-black/12 bg-[#f0ede6]/64 p-4 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="text-sm leading-relaxed text-black/62 dark:text-white/58">
+                Add a visit in{' '}
+                <code className="break-all rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.07]">
+                  lib/agent-guestbook.ts
+                </code>
+                .
               </p>
             </div>
           </div>
         </section>
 
-        <section className="mt-5">
+        <section className="mt-5 min-w-0">
           <div className="flex items-end justify-between gap-4">
-            <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">
-                Guestbook
-              </p>
-              <h2 className="mt-1 text-xl font-semibold tracking-tight">Recorded visits</h2>
-            </div>
+            <h2 className="text-xl font-semibold tracking-tight">Guestbook</h2>
             <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/42 dark:text-white/40">
               {agentVisits.length} {agentVisits.length === 1 ? 'entry' : 'entries'}
             </p>
           </div>
 
-          <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="mt-3 grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {agentVisits.map((visit) => (
               <article
                 key={`${visit.name}-${visit.date}`}
-                className="rounded-xl border border-black/12 bg-[#f2f0ea]/72 p-4 dark:border-white/10 dark:bg-[#18191d]/88"
+                className="min-w-0 rounded-xl border border-black/12 bg-[#f2f0ea]/72 p-4 dark:border-white/10 dark:bg-[#18191d]/88"
               >
                 <div className="flex items-center justify-between gap-3">
                   <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/44 dark:text-white/42">
@@ -114,9 +100,9 @@ export default function GalleryPage() {
             {Array.from({ length: Math.max(0, 3 - agentVisits.length) }, (_, index) => (
               <article
                 key={`open-${index}`}
-                className="flex min-h-48 items-center justify-center rounded-xl border border-dashed border-black/18 bg-black/[0.018] p-4 text-center dark:border-white/14 dark:bg-white/[0.018]"
+                className="flex min-h-48 min-w-0 items-center justify-center rounded-xl border border-dashed border-black/18 bg-black/[0.018] p-4 text-center dark:border-white/14 dark:bg-white/[0.018]"
               >
-                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/35 dark:text-white/32">unclaimed slot</p>
+                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/35 dark:text-white/32">unclaimed</p>
               </article>
             ))}
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import '@/app/globals.css';
 import { inter } from '@/components/ui/assets/fonts';
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { Analytics } from '@vercel/analytics/next';
@@ -16,6 +16,14 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://teamleaderleo.com'),
 };
 
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#ecebe6' },
+    { media: '(prefers-color-scheme: dark)', color: '#101115' },
+  ],
+  colorScheme: 'light dark',
+};
+
 export default function RootLayout({
   children,
 }: {
@@ -26,12 +34,12 @@ export default function RootLayout({
       <head>
         <style>{`
           html {
-            background-color: #ffffff;
+            background-color: #ecebe6;
             color-scheme: light;
           }
 
           html.dark {
-            background-color: #0e0e16;
+            background-color: #101115;
             color-scheme: dark;
           }
         `}</style>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
+import { ActivityGrid } from '@/components/home/activity-grid';
 import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
 import ViewportPageShell from '@/components/viewport-page-shell';
-import { getGitHubHomeData, type ContributionDay } from '@/lib/github-home';
+import { getGitHubHomeData } from '@/lib/github-home';
 import { ArrowUpRight } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -11,36 +12,15 @@ export const metadata: Metadata = {
   alternates: { canonical: '/' },
 };
 
-function activityClass(day: ContributionDay, maximum: number): string {
-  const base = 'ring-1 ring-inset ring-black/[0.05] dark:ring-white/[0.07]';
-  if (day.count === 0) return `${base} bg-[#c9c7c1] dark:bg-[#292a2f]`;
-
-  const ratio = maximum === 0 ? 0 : day.count / maximum;
-  if (ratio > 0.8) return `${base} bg-[#faf8f2] dark:bg-[#eeeaf2]`;
-  if (ratio > 0.55) return `${base} bg-[#e8e2ec] dark:bg-[#c9c2d0]`;
-  if (ratio > 0.3) return `${base} bg-[#d4cddb] dark:bg-[#8e8798]`;
-  if (ratio > 0.12) return `${base} bg-[#bfb8c7] dark:bg-[#66606d]`;
-  return `${base} bg-[#a9a3af] dark:bg-[#4b4750]`;
-}
-
-function formatDay(date: string): string {
-  return new Intl.DateTimeFormat('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    timeZone: 'UTC',
-  }).format(new Date(`${date}T00:00:00Z`));
-}
-
 export default async function Page() {
   const activity = await getGitHubHomeData();
-  const maximum = Math.max(...activity.days.map((day) => day.count), 0);
   const unit = activity.source === 'public-events' ? 'public actions' : 'contributions';
+  const days = activity.days.slice(-28);
 
   return (
     <ViewportPageShell
       className="relative bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
-      contentClassName="relative text-inherit"
+      contentClassName="relative overflow-x-hidden text-inherit"
     >
       <div
         aria-hidden="true"
@@ -56,75 +36,17 @@ export default async function Page() {
         <div className="absolute -right-28 bottom-10 h-80 w-80 rounded-full bg-[#d9d6cf]/75 blur-3xl dark:bg-[#1b1c20]/70" />
       </div>
 
-      <div className="relative mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
-        <div className="flex flex-col gap-4 sm:gap-5">
-          <header className="flex items-end justify-between gap-4 border-b border-black/12 pb-3 dark:border-white/12">
-            <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-black/48 dark:text-white/45">
-                Digital scrapbook / live counter
-              </p>
-              <h1 className="mt-1 text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">GitHub activity</h1>
-            </div>
-            <Link
-              href={`https://github.com/${activity.username}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex shrink-0 items-center gap-1 text-sm text-black/52 transition hover:text-black dark:text-white/52 dark:hover:text-white"
-            >
-              @{activity.username}
-              <ArrowUpRight size={14} />
-            </Link>
-          </header>
-
+      <div className="relative mx-auto w-full max-w-5xl px-4 py-5 sm:px-6 sm:py-7">
+        <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
           <ActivityScoreboard
             today={activity.today}
             weekTotal={activity.weekTotal}
             yearTotal={activity.total}
-            unit={unit}
           />
 
-          <section className="rounded-[1.25rem] border border-black/12 bg-[#dedcd6]/78 p-4 shadow-[0_14px_35px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d]/90 dark:shadow-none sm:p-5">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">Recent activity</p>
-                <p className="mt-0.5 text-sm text-black/58 dark:text-white/55">Last 35 days</p>
-              </div>
-              <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/45 dark:text-white/45">
-                <span>less</span>
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-[#a9a3af]" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-[#d4cddb]" />
-                <span className="h-2.5 w-2.5 rounded-[3px] bg-[#faf8f2] ring-1 ring-inset ring-black/[0.05]" />
-                <span>more</span>
-              </div>
-            </div>
+          <ActivityGrid days={days} unit={unit} />
 
-            <div className="mt-4 grid grid-cols-7 gap-2 sm:gap-2.5" aria-label="35 days of GitHub activity">
-              {activity.days.map((day, index) => {
-                const label = `${formatDay(day.date)} · ${day.count.toLocaleString('en-US')} ${unit}`;
-                const isLatest = index === activity.days.length - 1;
-                return (
-                  <div key={day.date} className="group relative">
-                    <div
-                      tabIndex={0}
-                      role="img"
-                      className={`aspect-square rounded-[0.5rem] transition duration-150 hover:-translate-y-0.5 hover:scale-[1.04] focus:-translate-y-0.5 focus:scale-[1.04] focus:outline-none focus:ring-2 focus:ring-black/35 dark:focus:ring-white/45 ${activityClass(day, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-black/20 dark:outline-white/25' : ''}`}
-                      aria-label={label}
-                    />
-                    <div className="pointer-events-none absolute bottom-[calc(100%+0.45rem)] left-1/2 z-20 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-black/15 bg-[#17181b] px-2 py-1 font-mono text-[10px] text-[#f2eee7] shadow-lg group-hover:block group-focus-within:block dark:border-white/15">
-                      {label}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-
-            <div className="mt-3 flex justify-between font-mono text-[10px] text-black/45 dark:text-white/42">
-              <span>{formatDay(activity.days[0]?.date ?? '')}</span>
-              <span>{formatDay(activity.days.at(-1)?.date ?? '')}</span>
-            </div>
-          </section>
-
-          <section className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <section className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
             {activity.repositories.map((repository) => (
               <Link
                 key={repository.name}
@@ -143,15 +65,6 @@ export default async function Page() {
               </Link>
             ))}
           </section>
-
-          <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-black/42 dark:text-white/38">
-            {activity.source === 'public-profile'
-              ? 'Public GitHub contribution graph'
-              : activity.source === 'public-events'
-                ? 'Public GitHub events fallback'
-                : 'GitHub data unavailable'}
-            {' · '}refreshes every five minutes
-          </p>
         </div>
       </div>
     </ViewportPageShell>

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -92,7 +92,7 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
         initialNowMs={nowMs}
         initialHasMore={hasMore}
       >
-        <div className="flex h-dvh min-h-0 w-full overflow-hidden bg-background text-foreground">
+        <div className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
           <SearchCommand />
           <AppSidebar />
           <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
@@ -105,8 +105,10 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
 
 export default function SpaceLayout({ children }: { children: React.ReactNode }) {
   return (
-    <Suspense fallback={<div className="h-dvh bg-background" aria-hidden="true" />}>
-      <SpaceDataShell>{children}</SpaceDataShell>
-    </Suspense>
+    <div className="h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
+      <Suspense fallback={null}>
+        <SpaceDataShell>{children}</SpaceDataShell>
+      </Suspense>
+    </div>
   );
 }

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+export type ActivityGridDay = {
+  date: string;
+  count: number;
+};
+
+function formatDay(date: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
+function activityClass(count: number, maximum: number): string {
+  const base = 'ring-1 ring-inset ring-black/[0.05] dark:ring-white/[0.07]';
+  if (count === 0) return `${base} bg-[#c9c7c1] dark:bg-[#292a2f]`;
+
+  const ratio = maximum === 0 ? 0 : count / maximum;
+  if (ratio > 0.8) return `${base} bg-[#faf8f2] dark:bg-[#eeeaf2]`;
+  if (ratio > 0.55) return `${base} bg-[#e8e2ec] dark:bg-[#c9c2d0]`;
+  if (ratio > 0.3) return `${base} bg-[#d4cddb] dark:bg-[#8e8798]`;
+  if (ratio > 0.12) return `${base} bg-[#bfb8c7] dark:bg-[#66606d]`;
+  return `${base} bg-[#a9a3af] dark:bg-[#4b4750]`;
+}
+
+export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: string }) {
+  const maximum = Math.max(...days.map((day) => day.count), 0);
+  const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
+  const selected = days.find((day) => day.date === selectedDate) ?? days.at(-1);
+  const selectedLabel = useMemo(() => {
+    if (!selected) return '';
+    return `${formatDay(selected.date)} · ${selected.count.toLocaleString('en-US')} ${unit}`;
+  }, [selected, unit]);
+
+  return (
+    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-black/12 bg-[#dedcd6]/78 p-4 shadow-[0_14px_35px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d]/90 dark:shadow-none sm:p-5">
+      <div className="flex justify-end">
+        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/45 dark:text-white/45" aria-hidden="true">
+          <span>less</span>
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#a9a3af]" />
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#d4cddb]" />
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#faf8f2] ring-1 ring-inset ring-black/[0.05]" />
+          <span>more</span>
+        </div>
+      </div>
+
+      <div className="mt-3 grid min-w-0 grid-cols-7 gap-2 sm:gap-2.5" aria-label="Four weeks of GitHub activity">
+        {days.map((day, index) => {
+          const label = `${formatDay(day.date)} · ${day.count.toLocaleString('en-US')} ${unit}`;
+          const isSelected = day.date === selected?.date;
+          const isLatest = index === days.length - 1;
+
+          return (
+            <button
+              key={day.date}
+              type="button"
+              className={`aspect-square min-w-0 rounded-[0.5rem] transition duration-150 hover:-translate-y-0.5 hover:scale-[1.035] focus-visible:-translate-y-0.5 focus-visible:scale-[1.035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/35 dark:focus-visible:ring-white/45 ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-black/20 dark:outline-white/25' : ''} ${isSelected ? 'brightness-[1.03] dark:brightness-110' : ''}`}
+              aria-label={label}
+              aria-pressed={isSelected}
+              title={label}
+              onPointerEnter={() => setSelectedDate(day.date)}
+              onFocus={() => setSelectedDate(day.date)}
+              onClick={() => setSelectedDate(day.date)}
+            />
+          );
+        })}
+      </div>
+
+      <p className="mt-3 min-h-4 truncate text-center font-mono text-[10px] text-black/48 dark:text-white/45" aria-live="polite">
+        {selectedLabel}
+      </p>
+    </section>
+  );
+}

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 function countdownToMidnight() {
   const now = new Date();
@@ -36,14 +36,14 @@ export function ActivityScoreboard({
   today,
   weekTotal,
   yearTotal,
-  unit,
 }: {
   today: number;
   weekTotal: number;
   yearTotal: number | null;
-  unit: string;
 }) {
   const [countdown, setCountdown] = useState('--:--:--');
+  const panelRef = useRef<HTMLDivElement>(null);
+  const frameRef = useRef<number | null>(null);
 
   useEffect(() => {
     const update = () => setCountdown(countdownToMidnight());
@@ -52,37 +52,66 @@ export function ActivityScoreboard({
     return () => window.clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
+
+  const movePanel = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const rect = currentTarget.getBoundingClientRect();
+    const x = Math.max(-1, Math.min(1, ((clientX - rect.left) / rect.width - 0.5) * 2));
+    const y = Math.max(-1, Math.min(1, ((clientY - rect.top) / rect.height - 0.5) * 2));
+
+    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    frameRef.current = window.requestAnimationFrame(() => {
+      if (!panelRef.current) return;
+      panelRef.current.style.transform = `perspective(900px) rotateX(${(-y * 1.4).toFixed(2)}deg) rotateY(${(x * 1.8).toFixed(2)}deg) translate3d(${(x * 1.4).toFixed(2)}px, ${(y * 1.1).toFixed(2)}px, 0)`;
+    });
+  };
+
+  const resetPanel = () => {
+    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    frameRef.current = window.requestAnimationFrame(() => {
+      if (panelRef.current) panelRef.current.style.transform = 'perspective(900px) rotateX(0deg) rotateY(0deg) translate3d(0,0,0)';
+    });
+  };
+
   return (
-    <section className="overflow-hidden rounded-[1.4rem] border border-black/15 bg-[#d8d5ce] shadow-[0_22px_55px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_24px_70px_rgba(0,0,0,0.35)]">
-      <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2.5 dark:border-white/10 dark:bg-[#18191d] sm:px-5">
-        <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/60 dark:text-white/58">
-          <span>Contribution counter</span>
-          <span className="tabular-nums">rollover {countdown}</span>
+    <section
+      className="touch-pan-y overflow-hidden rounded-[1.4rem] border border-black/15 bg-[#d8d5ce] shadow-[0_22px_55px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_24px_70px_rgba(0,0,0,0.35)]"
+      onPointerMove={(event) => movePanel(event.clientX, event.clientY, event.currentTarget)}
+      onPointerDown={(event) => movePanel(event.clientX, event.clientY, event.currentTarget)}
+      onPointerLeave={resetPanel}
+      onPointerCancel={resetPanel}
+    >
+      <div
+        ref={panelRef}
+        className="origin-center transition-transform duration-200 ease-out motion-reduce:transform-none"
+        style={{ transform: 'perspective(900px) rotateX(0deg) rotateY(0deg) translate3d(0,0,0)' }}
+      >
+        <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2.5 dark:border-white/10 dark:bg-[#18191d] sm:px-5">
+          <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/60 dark:text-white/58">
+            <span>Today</span>
+            <span className="tabular-nums">rollover {countdown}</span>
+          </div>
         </div>
-      </div>
 
-      <div className="grid gap-4 p-4 sm:p-5 lg:grid-cols-[minmax(0,1fr)_12rem]">
-        <div className="min-w-0">
-          <div className="mb-2 flex items-end justify-between gap-3">
-            <div>
-              <p className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-black/55 dark:text-white/55">Today</p>
-              <p className="mt-0.5 text-xs text-black/45 dark:text-white/42">{unit}</p>
+        <div className="grid gap-4 p-4 sm:p-5 lg:grid-cols-[minmax(0,1fr)_12rem]">
+          <div className="min-w-0">
+            <ScoreDigits value={today} />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2 lg:grid-cols-1">
+            <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/48 dark:text-white/45">7 days</p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{weekTotal.toLocaleString('en-US')}</p>
             </div>
-            <span className="rounded-full border border-black/10 bg-black/[0.045] px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-black/55 dark:border-white/10 dark:bg-white/[0.04] dark:text-white/55">
-              local midnight
-            </span>
-          </div>
-          <ScoreDigits value={today} />
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 lg:grid-cols-1">
-          <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
-            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/48 dark:text-white/45">Last 7 days</p>
-            <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{weekTotal.toLocaleString('en-US')}</p>
-          </div>
-          <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
-            <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/48 dark:text-white/45">This year</p>
-            <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{yearTotal?.toLocaleString('en-US') ?? '—'}</p>
+            <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/48 dark:text-white/45">Year</p>
+              <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{yearTotal?.toLocaleString('en-US') ?? '—'}</p>
+            </div>
           </div>
         </div>
       </div>

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -65,12 +65,12 @@ export function NavMenu({ label, children }: { label: string; children: ReactNod
   }, []);
 
   return (
-    <details ref={detailsRef} className="group relative">
-      <summary className="flex cursor-pointer list-none items-center gap-1 rounded-full px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground [&::-webkit-details-marker]:hidden">
+    <details ref={detailsRef} className="group relative min-w-0">
+      <summary className="flex cursor-pointer list-none items-center gap-1 rounded-full px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <span>{label}</span>
         <ChevronDown size={14} className="transition-transform group-open:rotate-180" />
       </summary>
-      <div className="absolute right-0 top-full z-50 mt-2 w-max min-w-[8.5rem] rounded-xl border bg-background/95 p-1 shadow-xl backdrop-blur">
+      <div className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border bg-background/96 p-1 shadow-xl backdrop-blur">
         {children}
       </div>
     </details>

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -21,7 +21,7 @@ const siteLinks: NavLinkItem[] = [
     href: '/proxy-dashboard',
     label: 'proxy',
     icon: <Activity size={15} />,
-    hoverClass: 'hover:text-emerald-500 focus:text-emerald-500',
+    hoverClass: 'hover:text-emerald-600 focus:text-emerald-600 dark:hover:text-emerald-400 dark:focus:text-emerald-400',
   },
   {
     href: '/space',
@@ -100,11 +100,19 @@ function InlineLink({ item }: { item: NavLinkItem }) {
   );
 }
 
+function MenuLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="px-2.5 pb-1 pt-2 font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70">
+      {children}
+    </p>
+  );
+}
+
 export default function SiteNav() {
   return (
-    <nav className="border-b bg-background text-foreground">
+    <nav className="min-w-0 border-b bg-background text-foreground">
       <div className="mx-auto max-w-7xl px-3 sm:px-6 lg:px-8">
-        <div className="flex h-12 min-w-0 items-center justify-between gap-3">
+        <div className="flex h-12 min-w-0 items-center justify-between gap-2 sm:gap-3">
           <Link href="/" className="min-w-0 shrink truncate text-base font-bold sm:text-lg">
             teamleaderleo
           </Link>
@@ -128,25 +136,27 @@ export default function SiteNav() {
             <NavThemeToggle />
           </div>
 
-          <div className="flex shrink-0 items-center gap-1 sm:gap-2 lg:hidden">
+          <div className="flex min-w-0 shrink-0 items-center gap-1.5 lg:hidden">
             <TimeLink />
-
-            <NavMenu label="site">
+            <NavMenu label="menu">
+              <MenuLabel>site</MenuLabel>
               {siteLinks.map((item) => (
                 <MenuLink key={item.label} item={item} />
               ))}
-            </NavMenu>
 
-            <NavMenu label="socials">
+              <div className="my-1 border-t" />
+              <MenuLabel>social</MenuLabel>
               {socialLinks.map((item) => (
                 <MenuLink key={item.label} item={item} />
               ))}
               <DiscordButton menu />
-            </NavMenu>
 
-            <div className="ml-0.5 border-l pl-1 sm:ml-2 sm:pl-2">
-              <NavThemeToggle />
-            </div>
+              <div className="my-1 border-t" />
+              <div className="flex items-center justify-between gap-4 px-2.5 py-2">
+                <span className="text-sm text-muted-foreground">appearance</span>
+                <NavThemeToggle />
+              </div>
+            </NavMenu>
           </div>
         </div>
       </div>

--- a/components/space/app-sidebar.tsx
+++ b/components/space/app-sidebar.tsx
@@ -1,117 +1,103 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { usePathname, useSearchParams, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Sidebar,
-  SidebarHeader,
   SidebarContent,
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarGroupContent,
-  SidebarMenu,
-  SidebarMenuItem,
-  SidebarMenuButton,
   SidebarFooter,
-} from "@/components/ui/sidebar";
-import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { LogOut, Loader2, Search, ArrowLeft, ArrowRight, Plus } from "lucide-react";
-import { shortcuts } from "@/app/lib/sidebar-data";
-import { useItems } from "@/app/lib/contexts/item-context";
-import { createClient } from "@/utils/supabase/client";
-import { ThemeToggle } from "@/components/theme-toggle";
-import { GoogleIcon } from "@/components/icons/google-icon";
-import { GitHubIcon } from "@/components/icons/github-icon";
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from '@/components/ui/sidebar';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { ArrowLeft, ArrowRight, Loader2, LogOut, Plus, Search } from 'lucide-react';
+import { shortcuts } from '@/app/lib/sidebar-data';
+import { useItems } from '@/app/lib/contexts/item-context';
+import { createClient } from '@/utils/supabase/client';
+import { ThemeToggle } from '@/components/theme-toggle';
+import { GoogleIcon } from '@/components/icons/google-icon';
+import { GitHubIcon } from '@/components/icons/github-icon';
+import { SpaceLinkHint } from '@/components/space/space-link-hint';
 
 export function AppSidebar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
-
-  const currentQuery = searchParams.get("tags") || "";
-
-  // Treat /space/review, /space/add, and /space/edit/* as the same "review-like" context
+  const { isMobile, setOpenMobile } = useSidebar();
+  const currentQuery = searchParams.get('tags') || '';
   const isReviewLike =
-    pathname === "/space/review" ||
-    pathname?.startsWith("/space/add") ||
-    pathname?.startsWith("/space/edit");
-
+    pathname === '/space/review' ||
+    pathname?.startsWith('/space/add') ||
+    pathname?.startsWith('/space/edit');
   const { user, isAdmin, signOut } = useItems();
   const [loading, setLoading] = useState(false);
-
-  const listHref = `/space${currentQuery ? `?tags=${currentQuery}` : ""}`;
-  const reviewHref = `/space/review${currentQuery ? `?tags=${currentQuery}` : ""}`;
+  const listHref = `/space${currentQuery ? `?tags=${currentQuery}` : ''}`;
+  const reviewHref = `/space/review${currentQuery ? `?tags=${currentQuery}` : ''}`;
   const toggleViewHref = isReviewLike ? listHref : reviewHref;
+  const isMac = useMemo(
+    () =>
+      typeof navigator !== 'undefined' &&
+      (navigator.platform.includes('Mac') || /iPhone|iPad/i.test(navigator.platform)),
+    [],
+  );
 
-  // Hotkeys:
-  // ⌘/Ctrl + Alt + A => /space/add
-  // ⌘/Ctrl + E => prefers /space (if already there, toggles to /space/review)
-  // ⌘/Ctrl + Shift + E => prefers /space/review (if already there, toggles to /space)
+  const closeMobile = () => {
+    if (isMobile) setOpenMobile(false);
+  };
+
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
+    const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
-      const role = target?.getAttribute?.("role");
+      const role = target?.getAttribute?.('role');
       const isTyping =
-        tag === "input" ||
-        tag === "textarea" ||
-        target?.getAttribute("contenteditable") === "true" ||
-        role === "textbox";
-
+        tag === 'input' ||
+        tag === 'textarea' ||
+        target?.getAttribute('contenteditable') === 'true' ||
+        role === 'textbox';
       if (isTyping) return;
 
-      const isMod = e.metaKey || e.ctrlKey;
-
-      // Add Item
-      if (isMod && e.altKey && (e.key === "a" || e.code === "KeyA")) {
-        e.preventDefault();
-        router.push("/space/add");
+      const isMod = event.metaKey || event.ctrlKey;
+      if (isMod && event.altKey && (event.key === 'a' || event.code === 'KeyA')) {
+        event.preventDefault();
+        router.push('/space/add');
         return;
       }
 
-      // Base Space (E)
-      if (isMod && !e.altKey && !e.shiftKey && (e.key === "e" || e.code === "KeyE")) {
-        e.preventDefault();
-        if (isReviewLike) {
-          router.push(listHref);
-        } else {
-          router.push(reviewHref); // toggle if already on base
-        }
+      if (isMod && !event.altKey && !event.shiftKey && (event.key === 'e' || event.code === 'KeyE')) {
+        event.preventDefault();
+        router.push(isReviewLike ? listHref : reviewHref);
         return;
       }
 
-      // Review Mode (Shift+E)
-      if (isMod && !e.altKey && e.shiftKey && (e.key === "e" || e.code === "KeyE")) {
-        e.preventDefault();
-        if (isReviewLike) {
-          router.push(listHref); // toggle if already on review-like
-        } else {
-          router.push(reviewHref);
-        }
-        return;
+      if (isMod && !event.altKey && event.shiftKey && (event.key === 'e' || event.code === 'KeyE')) {
+        event.preventDefault();
+        router.push(isReviewLike ? listHref : reviewHref);
       }
     };
 
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [router, isReviewLike, listHref, reviewHref]);
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isReviewLike, listHref, reviewHref, router]);
 
-  // TODO: add signInWithOAuth into the context later to centralize all auth flows
-  const handleOAuthSignIn = async (provider: "google" | "github") => {
+  const handleOAuthSignIn = async (provider: 'google' | 'github') => {
     setLoading(true);
     const supabase = createClient();
-
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
 
     if (error) {
-      console.error("OAuth error:", error);
+      console.error('OAuth error:', error);
       setLoading(false);
     }
   };
@@ -120,141 +106,81 @@ export function AppSidebar() {
     try {
       await signOut();
       router.refresh();
-    } catch (e) {
-      // Already logged inside signOut, but we can toast here if desired
+    } catch {
+      // The context reports sign-out failures.
     }
   };
 
-  // Trigger search dialog (will be handled by Ctrl+K event)
   const triggerSearch = () => {
     window.dispatchEvent(new Event('open-search'));
+    closeMobile();
   };
 
-  // Safe-ish platform check (client component)
-  const isMac = useMemo(
-    () =>
-      typeof navigator !== "undefined" &&
-      (navigator.platform.includes("Mac") || /iPhone|iPad/i.test(navigator.platform)),
-    []
-  );
-
   return (
-    <Sidebar className="flex flex-col h-screen">
-      <SidebarHeader className="h-[48px] p-0 m-0 bg-background text-foreground border-b">
+    <Sidebar className="flex h-dvh max-h-dvh max-w-[calc(100vw-0.75rem)] flex-col pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] md:h-svh md:max-h-svh md:pb-0 md:pt-0">
+      <SidebarHeader className="m-0 h-12 shrink-0 border-b bg-background p-0 text-foreground">
         <div className="flex h-full items-center justify-between px-4">
-          <Link href="/" className="text-lg font-bold leading-none">
+          <Link href="/" onClick={closeMobile} className="text-lg font-bold leading-none">
             teamleaderleo
           </Link>
           <ThemeToggle />
         </div>
       </SidebarHeader>
 
-      {/* Search Bar */}
-      <div className="p-4 border-b">
+      <div className="shrink-0 border-b p-3">
         <button
           onClick={triggerSearch}
-          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground bg-muted/50 hover:bg-muted rounded-md transition-colors"
+          className="flex w-full items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted"
+          type="button"
         >
           <Search className="h-4 w-4" />
-          <span className="flex-1 text-left">Search...</span>
-          <div className="flex gap-1">
-            <kbd className="px-1.5 py-0.5 text-xs font-semibold border rounded bg-background">
-              {isMac ? "⌘" : "Ctrl"}
+          <span className="flex-1 text-left">Search</span>
+          <span className="hidden gap-1 sm:flex">
+            <kbd className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold">
+              {isMac ? '⌘' : 'Ctrl'}
             </kbd>
-            <kbd className="px-1.5 py-0.5 text-xs font-semibold border rounded bg-background">
-              K
-            </kbd>
-          </div>
+            <kbd className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold">K</kbd>
+          </span>
         </button>
       </div>
 
-      {/* Only show Actions if admin */}
-      {isAdmin && (
-        <SidebarGroup>
-          <SidebarGroupLabel className="px-4">Actions</SidebarGroupLabel>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              <SidebarMenuItem>
-                {/* Make the button itself the flex row to control wrapping */}
-                <SidebarMenuButton
-                  className="flex w-full items-center justify-between gap-2 px-4 pl-6"
-                  asChild
-                >
-                  <Link href="/space/add">
-                    {/* Left: icon + label (no literal "+") */}
-                    <span className="flex items-center gap-2 truncate whitespace-nowrap leading-none">
-                      <Plus className="h-4 w-4 shrink-0" />
-                      <span className="truncate">Add Item</span>
-                    </span>
-                    {/* Right: hotkeys */}
-                    <span className="flex gap-1 text-muted-foreground shrink-0 whitespace-nowrap">
-                      <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                        {isMac ? "⌘" : "Ctrl"}
-                      </kbd>
-                      <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                        Alt
-                      </kbd>
-                      <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                        A
-                      </kbd>
-                    </span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            </SidebarMenu>
-          </SidebarGroupContent>
-        </SidebarGroup>
-      )}
+      <ScrollArea className="min-h-0 flex-1">
+        <SidebarContent className="py-3">
+          {isAdmin ? (
+            <SidebarGroup>
+              <SidebarGroupLabel className="px-4">Actions</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton className="px-4 pl-6" asChild>
+                      <Link href="/space/add" onClick={closeMobile} className="flex items-center gap-2">
+                        <Plus className="h-4 w-4 shrink-0" />
+                        <span className="min-w-0 flex-1 truncate">Add item</span>
+                        <SpaceLinkHint />
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          ) : null}
 
-      <ScrollArea className="flex-1">
-        <SidebarContent className="py-4">
-          {/* View mode toggle */}
           <SidebarGroup>
-            <SidebarGroupLabel className="px-4">View Mode</SidebarGroupLabel>
+            <SidebarGroupLabel className="px-4">View</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
-                  {/* Make the button itself the flex row + no-wrap */}
-                  <SidebarMenuButton
-                    className="flex w-full items-center justify-between gap-2 px-4 pl-6"
-                    asChild
-                  >
-                    <Link href={toggleViewHref}>
-                      {/* Left: arrow icon + label */}
-                      <span className="flex items-center gap-2 truncate whitespace-nowrap leading-none">
-                        {isReviewLike ? (
-                          <ArrowLeft className="h-4 w-4 shrink-0" />
-                        ) : (
-                          <ArrowRight className="h-4 w-4 shrink-0" />
-                        )}
-                        <span className="truncate">
-                          {isReviewLike ? "Back to List" : "Review"}
-                        </span>
-                      </span>
-
-                      {/* Show ONLY the opposite view's hotkey and keep it on one line */}
+                  <SidebarMenuButton className="px-4 pl-6" asChild>
+                    <Link href={toggleViewHref} onClick={closeMobile} className="flex items-center gap-2">
                       {isReviewLike ? (
-                        <span className="flex gap-1 text-muted-foreground shrink-0 whitespace-nowrap">
-                          <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                            {isMac ? "⌘" : "Ctrl"}
-                          </kbd>
-                          <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                            E
-                          </kbd>
-                        </span>
+                        <ArrowLeft className="h-4 w-4 shrink-0" />
                       ) : (
-                        <span className="flex gap-1 text-muted-foreground shrink-0 whitespace-nowrap">
-                          <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                            {isMac ? "⌘" : "Ctrl"}
-                          </kbd>
-                          <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                            Shift
-                          </kbd>
-                          <kbd className="px-1.5 py-0.5 text-[10px] font-semibold border rounded bg-background">
-                            E
-                          </kbd>
-                        </span>
+                        <ArrowRight className="h-4 w-4 shrink-0" />
                       )}
+                      <span className="min-w-0 flex-1 truncate">
+                        {isReviewLike ? 'List' : 'Review'}
+                      </span>
+                      <SpaceLinkHint />
                     </Link>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -262,18 +188,21 @@ export function AppSidebar() {
             </SidebarGroupContent>
           </SidebarGroup>
 
-          {/* Shortcuts */}
           <SidebarGroup>
             <SidebarGroupLabel className="px-4">Shortcuts</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {shortcuts.map((s) => {
-                  // When in review-like contexts (review/add/edit), mirror how you rewrite links
-                  const href = isReviewLike ? s.href.replace("/space", "/space/review") : s.href;
+                {shortcuts.map((shortcut) => {
+                  const href = isReviewLike
+                    ? shortcut.href.replace('/space', '/space/review')
+                    : shortcut.href;
                   return (
-                    <SidebarMenuItem key={s.label}>
+                    <SidebarMenuItem key={shortcut.label}>
                       <SidebarMenuButton asChild className="justify-start gap-2 px-4 pl-6">
-                        <Link href={href}>{s.label}</Link>
+                        <Link href={href} onClick={closeMobile} className="flex items-center gap-2">
+                          <span className="min-w-0 flex-1 truncate">{shortcut.label}</span>
+                          <SpaceLinkHint />
+                        </Link>
                       </SidebarMenuButton>
                     </SidebarMenuItem>
                   );
@@ -284,50 +213,38 @@ export function AppSidebar() {
         </SidebarContent>
       </ScrollArea>
 
-      {/* Auth Section */}
-      <SidebarFooter className="border-t p-4 space-y-2">
+      <SidebarFooter className="shrink-0 space-y-2 border-t p-3">
         {user ? (
-          // User is logged in
           <>
-            <div className="text-sm text-muted-foreground truncate px-2" title={user.email}>
+            <div className="truncate px-2 text-sm text-muted-foreground" title={user.email}>
               {user.email}
             </div>
             <Button variant="outline" size="sm" onClick={handleSignOut} className="w-full">
-              <LogOut className="w-4 h-4 mr-2" />
-              Sign Out
+              <LogOut className="mr-2 h-4 w-4" />
+              Sign out
             </Button>
           </>
         ) : (
-          // User is not logged in
           <>
             <Button
               variant="default"
               size="sm"
-              onClick={() => handleOAuthSignIn("google")}
+              onClick={() => handleOAuthSignIn('google')}
               disabled={loading}
               className="w-full"
             >
-              {loading ? (
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              ) : (
-                <GoogleIcon className="w-4 h-4 mr-2" />
-              )}
-              Sign in with Google
+              {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <GoogleIcon className="mr-2 h-4 w-4" />}
+              Google
             </Button>
-
             <Button
               variant="outline"
               size="sm"
-              onClick={() => handleOAuthSignIn("github")}
+              onClick={() => handleOAuthSignIn('github')}
               disabled={loading}
               className="w-full"
             >
-              {loading ? (
-                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-              ) : (
-                <GitHubIcon className="w-4 h-4 mr-2" />
-              )}
-              Sign in with GitHub
+              {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <GitHubIcon className="mr-2 h-4 w-4" />}
+              GitHub
             </Button>
           </>
         )}

--- a/components/space/space-header.tsx
+++ b/components/space/space-header.tsx
@@ -1,30 +1,24 @@
-"use client";
+'use client';
 
-import Link from "next/link";
-import { useMemo } from "react";
-import { Button } from "@/components/ui/button";
-import { useSearchParams, usePathname } from "next/navigation";
-import { useSidebar } from "@/components/ui/sidebar";
-import { PanelLeft, ArrowLeft, ArrowRight, Code } from "lucide-react";
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useSidebar } from '@/components/ui/sidebar';
+import { ArrowLeft, ArrowRight, Code, PanelLeft } from 'lucide-react';
+import { SpaceLinkHint } from '@/components/space/space-link-hint';
 
 interface SpaceHeaderProps {
-  // Left side info
   leftContent: React.ReactNode;
-
-  // Center action (optional, defaults to toggle)
   centerContent?: React.ReactNode;
-
-  // Right side actions (optional). If omitted, we show the hotkey hint.
   rightContent?: React.ReactNode;
-
-  // Monaco editor control
   onEditorToggle?: () => void;
   isEditorOpen?: boolean;
 }
 
-export function SpaceHeader({ 
-  leftContent, 
-  centerContent, 
+export function SpaceHeader({
+  leftContent,
+  centerContent,
   rightContent,
   onEditorToggle,
   isEditorOpen = false,
@@ -32,122 +26,72 @@ export function SpaceHeader({
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { toggleSidebar } = useSidebar();
-
-  const tagsParam = searchParams.get("tags") || "";
-
-  // Treat /space/review, /space/add, and /space/edit/* as the same "review-like" context
+  const tagsParam = searchParams.get('tags') || '';
   const isReviewLike =
-    pathname === "/space/review" ||
-    pathname?.startsWith("/space/add") ||
-    pathname?.startsWith("/space/edit");
-
-  // Safe platform check for SSR
+    pathname === '/space/review' ||
+    pathname?.startsWith('/space/add') ||
+    pathname?.startsWith('/space/edit');
   const isMac = useMemo(
-    () => (typeof navigator !== "undefined" && /Mac|iPhone|iPad/i.test(navigator.platform)),
-    []
+    () => typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform),
+    [],
   );
-
-  // Toggle between list and review view with same query
   const toggleHref = isReviewLike
-    ? `/space${tagsParam ? `?tags=${tagsParam}` : ""}`
-    : `/space/review${tagsParam ? `?tags=${tagsParam}` : ""}`;
+    ? `/space${tagsParam ? `?tags=${tagsParam}` : ''}`
+    : `/space/review${tagsParam ? `?tags=${tagsParam}` : ''}`;
 
   const defaultCenterContent = (
     <Link
       href={toggleHref}
-      prefetch={true}
-      className="text-sm text-primary-foreground hover:text-primary-foreground/70 transition-colors font-medium inline-flex items-center gap-2"
+      prefetch
+      className="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      aria-label={isReviewLike ? 'Back to list' : 'Open review'}
     >
-      {isReviewLike ? (
-        <>
-          <ArrowLeft className="h-4 w-4" />
-          <span>Back to List</span>
-        </>
-      ) : (
-        <>
-          <ArrowRight className="h-4 w-4" />
-          <span>Review</span>
-        </>
-      )}
+      {isReviewLike ? <ArrowLeft className="h-4 w-4" /> : <ArrowRight className="h-4 w-4" />}
+      <span className="hidden sm:inline">{isReviewLike ? 'List' : 'Review'}</span>
+      <SpaceLinkHint />
     </Link>
   );
 
-  const defaultRightContent = (
-    <div className="hidden sm:flex items-center gap-3 text-muted-foreground text-xs">
-      <div className="flex items-center gap-1.5">
-        <span>Expand on hover:</span>
-        <kbd className="px-1.5 py-0.5 font-semibold border rounded bg-background">Shift</kbd>
-      </div>
-      <div className="flex items-center gap-1.5">
-        <span>Sidebar:</span>
-        <div className="flex gap-1">
-          <kbd className="px-1.5 py-0.5 font-semibold border rounded bg-background">
-            {isMac ? "⌘" : "Ctrl"}
-          </kbd>
-          <kbd className="px-1.5 py-0.5 font-semibold border rounded bg-background">
-            B
-          </kbd>
-        </div>
-      </div>
-      {onEditorToggle && (
-        <div className="flex items-center gap-1.5">
-          <span>Editor:</span>
-          <div className="flex gap-1">
-            <kbd className="px-1.5 py-0.5 font-semibold border rounded bg-background">
-              {isMac ? "⌘" : "Ctrl"}
-            </kbd>
-            <kbd className="px-1.5 py-0.5 font-semibold border rounded bg-background">
-              I
-            </kbd>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-
   return (
-    <div className="bg-background px-6 h-12 relative border-b border-border">
-      <div className="flex items-center justify-between h-full">
-        {/* LEFT: toggle button, then our leftContent */}
-        <div className="flex-1 flex items-center gap-3 min-w-0">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 px-2"
-            aria-label="Toggle sidebar"
-            title={`Toggle sidebar (${isMac ? "⌘" : "Ctrl"} + B)`}
-            onClick={() => toggleSidebar?.()}
+    <header className="flex h-12 min-w-0 items-center gap-1.5 border-b border-border bg-background px-2 sm:gap-2 sm:px-4">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0"
+        aria-label="Toggle sidebar"
+        title={`Toggle sidebar (${isMac ? '⌘' : 'Ctrl'} + B)`}
+        onClick={() => toggleSidebar?.()}
+      >
+        <PanelLeft className="h-4 w-4" />
+      </Button>
+
+      <p className="min-w-0 flex-1 truncate px-1 text-xs text-muted-foreground sm:text-sm">
+        {leftContent}
+      </p>
+
+      <div className="flex shrink-0 items-center gap-1">
+        {centerContent ?? defaultCenterContent}
+
+        {onEditorToggle ? (
+          <button
+            onClick={onEditorToggle}
+            className={`inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              isEditorOpen
+                ? 'bg-muted text-foreground'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+            }`}
+            title={`Toggle editor (${isMac ? '⌘' : 'Ctrl'} + I)`}
+            aria-label="Toggle editor"
+            aria-pressed={isEditorOpen}
+            type="button"
           >
-            <PanelLeft className="h-4 w-4" />
-          </Button>
+            <Code className="h-4 w-4" />
+            <span className="hidden sm:inline">Editor</span>
+          </button>
+        ) : null}
 
-          <p className="text-sm text-muted-foreground truncate">
-            {leftContent}
-          </p>
-        </div>
-
-        {/* CENTER: exactly centered in viewport with editor button to the right (positioned absolutely) */}
-        <div className="fixed left-1/2 -translate-x-1/2 top-3 z-10 flex items-center gap-4 bg-background/50 backdrop-blur-[0.5px] px-3 py-1.5 rounded-md">
-          {centerContent ?? defaultCenterContent}
-          
-          {/* Editor toggle to the right of center content - doesn't affect header height */}
-          {onEditorToggle && (
-            <button
-              onClick={onEditorToggle}
-              className="text-sm text-primary-foreground hover:text-primary-foreground/70 transition-colors font-medium inline-flex items-center gap-2"
-              title={`Toggle editor (${isMac ? "⌘" : "Ctrl"} + I)`}
-            >
-              <Code className="h-4 w-4" />
-              <span>Editor</span>
-            </button>
-          )}
-        </div>
-
-        {/* RIGHT: hotkey hint (or custom rightContent) */}
-        <div className="flex-1 flex justify-end gap-2">
-          {rightContent ?? defaultRightContent}
-        </div>
+        {rightContent}
       </div>
-    </div>
+    </header>
   );
 }

--- a/components/space/space-link-hint.tsx
+++ b/components/space/space-link-hint.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useLinkStatus } from 'next/link';
+
+export function SpaceLinkHint() {
+  const { pending } = useLinkStatus();
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`h-1.5 w-1.5 shrink-0 rounded-full bg-current transition-opacity duration-150 ${
+        pending ? 'animate-pulse opacity-40' : 'opacity-0'
+      }`}
+    />
+  );
+}

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -58,6 +58,8 @@ export function SpaceView() {
   }, [items, page]);
 
   const totalPages = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
+  const itemCount = `${items.length}${hasMore ? '+' : ''}`;
+  const headerStatus = tagsParam ? `${itemCount} · ${tagsParam}` : `${itemCount} items`;
 
   useEffect(() => {
     if (page >= totalPages && hasMore && !loadingMore) {
@@ -160,11 +162,11 @@ export function SpaceView() {
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <SpaceHeader
-        leftContent={`Query: ${tagsParam ?? '(none)'} · ${items.length} loaded${hasMore ? '+' : ''}${totalPages > 1 ? ` · Page ${page}/${totalPages}` : ''}`}
+        leftContent={headerStatus}
         onEditorToggle={() => setEditorOpen(!editorOpen)}
         isEditorOpen={editorOpen}
       />
-      <main className="min-h-0 flex-1 overflow-y-auto p-4">
+      <main className="min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:p-4">
         <ResultsClient
           items={paginatedItems}
           onReview={onReview}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -14,15 +14,12 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggle}
-      className="group relative inline-flex h-8 w-14 items-center rounded-full border border-black/10 bg-gradient-to-r from-[#e8dfcc] via-[#c9c5c7] to-[#24252b] p-0.5 shadow-[inset_0_1px_2px_rgba(0,0,0,0.18),0_1px_0_rgba(255,255,255,0.45)] transition hover:contrast-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-white/15"
+      className="relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-black/12 bg-[#e2dfd8] text-black/58 shadow-[inset_0_1px_0_rgba(255,255,255,0.45),0_1px_3px_rgba(0,0,0,0.08)] transition hover:bg-[#d8d4cc] hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-white/12 dark:bg-[#202126] dark:text-white/60 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_4px_rgba(0,0,0,0.25)] dark:hover:bg-[#292a30] dark:hover:text-white"
       aria-label="Toggle light and dark mode"
       type="button"
     >
-      <Sun className="absolute left-1.5 h-3.5 w-3.5 text-[#725e32] transition-opacity dark:opacity-45" />
-      <Moon className="absolute right-1.5 h-3.5 w-3.5 text-[#ded9e7] opacity-55 transition-opacity dark:opacity-100" />
-      <span className="relative z-10 inline-flex h-6 w-6 translate-x-0 items-center justify-center rounded-full border border-black/10 bg-[#f4efe4] shadow-[0_2px_7px_rgba(0,0,0,0.28)] transition-transform duration-200 dark:translate-x-6 dark:border-white/10 dark:bg-[#18191e]">
-        <span className="h-1.5 w-1.5 rounded-full bg-[#a58e5b] dark:bg-[#aaa2b5]" />
-      </span>
+      <Sun className="h-3.5 w-3.5 transition-all dark:scale-75 dark:opacity-0" />
+      <Moon className="absolute h-3.5 w-3.5 scale-75 opacity-0 transition-all dark:scale-100 dark:opacity-100" />
     </button>
   );
 }

--- a/components/three-carousel/scene-3d.tsx
+++ b/components/three-carousel/scene-3d.tsx
@@ -15,27 +15,22 @@ const satellites: Array<[number, number, number, number]> = [
 
 type RotationTarget = { x: number; y: number };
 
-function AgentRoom({
-  target,
-  dragging,
-}: {
-  target: React.MutableRefObject<RotationTarget>;
-  dragging: React.MutableRefObject<boolean>;
-}) {
+function AgentRoom({ target, dragging }: { target: RotationTarget; dragging: boolean }) {
   const group = useRef<THREE.Group>(null);
+  const idleRotation = useRef(0);
 
   useFrame((state, delta) => {
     if (!group.current) return;
-    if (!dragging.current) target.current.y += delta * 0.12;
+    if (!dragging) idleRotation.current += delta * 0.12;
 
     group.current.rotation.x = THREE.MathUtils.lerp(
       group.current.rotation.x,
-      target.current.x + state.pointer.y * 0.06,
+      target.x + state.pointer.y * 0.06,
       0.08,
     );
     group.current.rotation.y = THREE.MathUtils.lerp(
       group.current.rotation.y,
-      target.current.y + state.pointer.x * 0.05,
+      target.y + idleRotation.current + state.pointer.x * 0.05,
       0.08,
     );
     group.current.rotation.z = THREE.MathUtils.lerp(
@@ -82,16 +77,12 @@ function AgentRoom({
 export default function Scene3D() {
   const [mounted, setMounted] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const rotationTarget = useRef<RotationTarget>({ x: 0, y: 0 });
-  const dragging = useRef(false);
+  const [rotationTarget, setRotationTarget] = useState<RotationTarget>({ x: 0, y: 0 });
   const lastPointer = useRef({ x: 0, y: 0 });
 
   useEffect(() => setMounted(true), []);
 
-  const stopDragging = () => {
-    dragging.current = false;
-    setIsDragging(false);
-  };
+  const stopDragging = () => setIsDragging(false);
 
   if (!mounted) {
     return <div className="h-full min-w-0 w-full bg-[#15161a]" aria-hidden="true" />;
@@ -104,22 +95,19 @@ export default function Scene3D() {
       aria-label="Draggable three-dimensional agent room"
       tabIndex={0}
       onPointerDown={(event) => {
-        dragging.current = true;
         setIsDragging(true);
         lastPointer.current = { x: event.clientX, y: event.clientY };
         event.currentTarget.setPointerCapture(event.pointerId);
       }}
       onPointerMove={(event) => {
-        if (!dragging.current) return;
+        if (!isDragging) return;
         const dx = event.clientX - lastPointer.current.x;
         const dy = event.clientY - lastPointer.current.y;
         lastPointer.current = { x: event.clientX, y: event.clientY };
-        rotationTarget.current.y += dx * 0.008;
-        rotationTarget.current.x = THREE.MathUtils.clamp(
-          rotationTarget.current.x + dy * 0.006,
-          -0.72,
-          0.72,
-        );
+        setRotationTarget((current) => ({
+          y: current.y + dx * 0.008,
+          x: THREE.MathUtils.clamp(current.x + dy * 0.006, -0.72, 0.72),
+        }));
       }}
       onPointerUp={(event) => {
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -129,10 +117,18 @@ export default function Scene3D() {
       }}
       onPointerCancel={stopDragging}
       onKeyDown={(event) => {
-        if (event.key === 'ArrowLeft') rotationTarget.current.y -= 0.18;
-        if (event.key === 'ArrowRight') rotationTarget.current.y += 0.18;
-        if (event.key === 'ArrowUp') rotationTarget.current.x = Math.max(-0.72, rotationTarget.current.x - 0.14);
-        if (event.key === 'ArrowDown') rotationTarget.current.x = Math.min(0.72, rotationTarget.current.x + 0.14);
+        if (event.key === 'ArrowLeft') {
+          setRotationTarget((current) => ({ ...current, y: current.y - 0.18 }));
+        }
+        if (event.key === 'ArrowRight') {
+          setRotationTarget((current) => ({ ...current, y: current.y + 0.18 }));
+        }
+        if (event.key === 'ArrowUp') {
+          setRotationTarget((current) => ({ ...current, x: Math.max(-0.72, current.x - 0.14) }));
+        }
+        if (event.key === 'ArrowDown') {
+          setRotationTarget((current) => ({ ...current, x: Math.min(0.72, current.x + 0.14) }));
+        }
       }}
     >
       <Canvas
@@ -147,7 +143,7 @@ export default function Scene3D() {
         <ambientLight intensity={1.25} />
         <directionalLight position={[4, 6, 5]} intensity={2.4} color="#f1eaf5" />
         <pointLight position={[-4, -2, 3]} intensity={22} distance={9} color="#756b83" />
-        <AgentRoom target={rotationTarget} dragging={dragging} />
+        <AgentRoom target={rotationTarget} dragging={isDragging} />
       </Canvas>
     </div>
   );

--- a/components/three-carousel/scene-3d.tsx
+++ b/components/three-carousel/scene-3d.tsx
@@ -13,21 +13,35 @@ const satellites: Array<[number, number, number, number]> = [
   [0.6, -2.45, 0.65, 0.26],
 ];
 
-function AgentRoom() {
+type RotationTarget = { x: number; y: number };
+
+function AgentRoom({
+  target,
+  dragging,
+}: {
+  target: React.MutableRefObject<RotationTarget>;
+  dragging: React.MutableRefObject<boolean>;
+}) {
   const group = useRef<THREE.Group>(null);
 
   useFrame((state, delta) => {
     if (!group.current) return;
-    group.current.rotation.y += delta * 0.16;
+    if (!dragging.current) target.current.y += delta * 0.12;
+
     group.current.rotation.x = THREE.MathUtils.lerp(
       group.current.rotation.x,
-      state.pointer.y * 0.18,
-      0.035,
+      target.current.x + state.pointer.y * 0.06,
+      0.08,
+    );
+    group.current.rotation.y = THREE.MathUtils.lerp(
+      group.current.rotation.y,
+      target.current.y + state.pointer.x * 0.05,
+      0.08,
     );
     group.current.rotation.z = THREE.MathUtils.lerp(
       group.current.rotation.z,
-      -state.pointer.x * 0.08,
-      0.035,
+      -state.pointer.x * 0.035,
+      0.05,
     );
   });
 
@@ -67,26 +81,74 @@ function AgentRoom() {
 
 export default function Scene3D() {
   const [mounted, setMounted] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const rotationTarget = useRef<RotationTarget>({ x: 0, y: 0 });
+  const dragging = useRef(false);
+  const lastPointer = useRef({ x: 0, y: 0 });
 
   useEffect(() => setMounted(true), []);
 
+  const stopDragging = () => {
+    dragging.current = false;
+    setIsDragging(false);
+  };
+
   if (!mounted) {
-    return <div className="h-full w-full bg-[#15161a]" aria-hidden="true" />;
+    return <div className="h-full min-w-0 w-full bg-[#15161a]" aria-hidden="true" />;
   }
 
   return (
-    <Canvas
-      className="h-full w-full"
-      camera={{ position: [4.8, 3.4, 5.4], fov: 42 }}
-      dpr={[1, 1.5]}
-      gl={{ antialias: true, powerPreference: 'high-performance' }}
+    <div
+      className={`h-full min-w-0 w-full touch-pan-y select-none overflow-hidden outline-none ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+      role="img"
+      aria-label="Draggable three-dimensional agent room"
+      tabIndex={0}
+      onPointerDown={(event) => {
+        dragging.current = true;
+        setIsDragging(true);
+        lastPointer.current = { x: event.clientX, y: event.clientY };
+        event.currentTarget.setPointerCapture(event.pointerId);
+      }}
+      onPointerMove={(event) => {
+        if (!dragging.current) return;
+        const dx = event.clientX - lastPointer.current.x;
+        const dy = event.clientY - lastPointer.current.y;
+        lastPointer.current = { x: event.clientX, y: event.clientY };
+        rotationTarget.current.y += dx * 0.008;
+        rotationTarget.current.x = THREE.MathUtils.clamp(
+          rotationTarget.current.x + dy * 0.006,
+          -0.72,
+          0.72,
+        );
+      }}
+      onPointerUp={(event) => {
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+        stopDragging();
+      }}
+      onPointerCancel={stopDragging}
+      onKeyDown={(event) => {
+        if (event.key === 'ArrowLeft') rotationTarget.current.y -= 0.18;
+        if (event.key === 'ArrowRight') rotationTarget.current.y += 0.18;
+        if (event.key === 'ArrowUp') rotationTarget.current.x = Math.max(-0.72, rotationTarget.current.x - 0.14);
+        if (event.key === 'ArrowDown') rotationTarget.current.x = Math.min(0.72, rotationTarget.current.x + 0.14);
+      }}
     >
-      <color attach="background" args={['#15161a']} />
-      <fog attach="fog" args={['#15161a', 7, 12]} />
-      <ambientLight intensity={1.25} />
-      <directionalLight position={[4, 6, 5]} intensity={2.4} color="#f1eaf5" />
-      <pointLight position={[-4, -2, 3]} intensity={22} distance={9} color="#756b83" />
-      <AgentRoom />
-    </Canvas>
+      <Canvas
+        className="block h-full min-w-0 w-full"
+        camera={{ position: [4.8, 3.4, 5.4], fov: 42 }}
+        dpr={[1, 1.5]}
+        gl={{ antialias: true, powerPreference: 'high-performance' }}
+        style={{ width: '100%', height: '100%', display: 'block', touchAction: 'pan-y' }}
+      >
+        <color attach="background" args={['#15161a']} />
+        <fog attach="fog" args={['#15161a', 7, 12]} />
+        <ambientLight intensity={1.25} />
+        <directionalLight position={[4, 6, 5]} intensity={2.4} color="#f1eaf5" />
+        <pointLight position={[-4, -2, 3]} intensity={22} distance={9} color="#756b83" />
+        <AgentRoom target={rotationTarget} dragging={dragging} />
+      </Canvas>
+    </div>
   );
 }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -18,7 +18,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/35 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-transparent data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -8,11 +8,8 @@ import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 const Sheet = SheetPrimitive.Root
-
 const SheetTrigger = SheetPrimitive.Trigger
-
 const SheetClose = SheetPrimitive.Close
-
 const SheetPortal = SheetPrimitive.Portal
 
 const SheetOverlay = React.forwardRef<
@@ -21,7 +18,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/35 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -40,7 +37,7 @@ const sheetVariants = cva(
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
         left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {
@@ -51,14 +48,16 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  showOverlay?: boolean
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, showOverlay = true, ...props }, ref) => (
   <SheetPortal>
-    <SheetOverlay />
+    {showOverlay ? <SheetOverlay /> : null}
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}

--- a/components/viewport-page-shell.tsx
+++ b/components/viewport-page-shell.tsx
@@ -14,14 +14,17 @@ export default function ViewportPageShell({
   contentClassName = '',
   scroll = 'page',
 }: ViewportPageShellProps) {
-  const overflowClass = scroll === 'locked' ? 'overflow-hidden' : 'overflow-y-auto overscroll-contain';
+  const overflowClass =
+    scroll === 'locked'
+      ? 'overflow-hidden'
+      : 'overflow-x-hidden overflow-y-auto overscroll-contain';
 
   return (
     <main
-      className={`grid h-dvh grid-rows-[auto_minmax(0,1fr)] overflow-hidden ${className}`}
+      className={`grid h-dvh min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden ${className}`}
     >
       <SiteNav />
-      <div className={`min-h-0 ${overflowClass} ${contentClassName}`}>{children}</div>
+      <div className={`min-h-0 min-w-0 ${overflowClass} ${contentClassName}`}>{children}</div>
     </main>
   );
 }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -21,6 +21,31 @@ test('homepage fits within the viewport', async ({ page }) => {
   expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport + 1);
 });
 
+test('homepage activity stays inside a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+  await page.locator('[aria-label="Four weeks of GitHub activity"] button').last().click();
+
+  const dimensions = await page.evaluate(() => ({
+    viewport: window.innerWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+
+  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport + 1);
+});
+
+test('cube stays inside a mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/gallery');
+
+  const dimensions = await page.evaluate(() => ({
+    viewport: window.innerWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+
+  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport + 1);
+});
+
 test.describe('connected-data routes', () => {
   test.skip(!process.env.PLAYWRIGHT_FULL_APP, 'Requires connected app environment variables');
 


### PR DESCRIPTION
## Summary
- contain homepage activity details and switch the visible window to 28 days
- make the analog contribution counter react subtly to pointer and touch position
- keep the compact nav to brand, clock, and one unified menu
- replace the oversized theme switch with a fixed-size icon control
- make the cube draggable without capturing normal vertical scrolling
- remove mobile-width leaks from the cube and shared viewport shell
- simplify the Space header and add inline navigation feedback
- keep Space on its existing surface while data resolves
- respect iPhone safe-area spacing in the Space sidebar and stop dimming the full viewport

## Verification
- lint
- typecheck
- unit tests
- production build