### PR TITLE
Repair route loading, proxy reliability, scrolling, and homepage activity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -78,4 +82,10 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium webkit
       - name: Browser regressions
-        run: pnpm test:e2e
+        run: pnpm test:e2e > playwright.log 2>&1
+      - name: Upload browser diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-log
+          path: playwright.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,24 @@ jobs:
         with:
           name: build-log
           path: build.log
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile --reporter=silent
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium webkit
+      - name: Browser regressions
+        run: pnpm test:e2e

--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { getRecentDateKeys, parsePublicContributionHtml } from '@/lib/github-activity-utils';
+
+const GITHUB_USERNAME = 'teamleaderleo';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const requestId = crypto.randomUUID();
+
+  try {
+    const response = await fetch(`https://github.com/users/${GITHUB_USERNAME}/contributions`, {
+      cache: 'no-store',
+      headers: {
+        Accept: 'text/html',
+        'User-Agent': 'teamleaderleo-scrapbook',
+      },
+      signal: AbortSignal.timeout(8_000),
+    });
+
+    if (!response.ok) throw new Error(`GitHub contribution page returned ${response.status}`);
+
+    const counts = parsePublicContributionHtml(await response.text());
+    if (counts.size === 0) throw new Error('GitHub contribution page could not be parsed');
+
+    const now = new Date();
+    const dateKeys = getRecentDateKeys(now, 35);
+    const todayKey = dateKeys.at(-1) ?? now.toISOString().slice(0, 10);
+    const days = dateKeys.map((date) => ({ date, count: counts.get(date) ?? 0 }));
+    const yearTotal = [...counts.entries()]
+      .filter(([date]) => date.startsWith(todayKey.slice(0, 4)) && date <= todayKey)
+      .reduce((sum, [, count]) => sum + count, 0);
+
+    return NextResponse.json(
+      {
+        source: 'public-profile',
+        generatedAt: now.toISOString(),
+        today: days.at(-1)?.count ?? 0,
+        weekTotal: days.slice(-7).reduce((sum, day) => sum + day.count, 0),
+        yearTotal,
+        days: days.slice(-28),
+      },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+          'X-Request-Id': requestId,
+        },
+      },
+    );
+  } catch (error) {
+    console.error('Unable to refresh GitHub activity', { requestId, error });
+    return NextResponse.json(
+      { ok: false, error: 'GitHub activity is temporarily unavailable', requestId },
+      { status: 502, headers: { 'Cache-Control': 'no-store', 'X-Request-Id': requestId } },
+    );
+  }
+}

--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -3,8 +3,6 @@ import { getRecentDateKeys, parsePublicContributionHtml } from '@/lib/github-act
 
 const GITHUB_USERNAME = 'teamleaderleo';
 
-export const runtime = 'nodejs';
-
 export async function GET() {
   const requestId = crypto.randomUUID();
 

--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server';
+import { connection } from 'next/server';
 import { getRecentDateKeys, parsePublicContributionHtml } from '@/lib/github-activity-utils';
 
 const GITHUB_USERNAME = 'teamleaderleo';
 
 export async function GET() {
+  await connection();
   const requestId = crypto.randomUUID();
 
   try {

--- a/app/api/proxy-health/diagnostic/route.ts
+++ b/app/api/proxy-health/diagnostic/route.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto';
+
+import { client } from '@/app/lib/db/db';
+import { NextRequest, NextResponse } from 'next/server';
+
+function bearerToken(request: NextRequest) {
+  const authorization = request.headers.get('authorization');
+  if (authorization?.startsWith('Bearer ')) return authorization.slice('Bearer '.length).trim();
+  return request.headers.get('x-proxy-health-token')?.trim() ?? '';
+}
+
+function diagnosticSecret() {
+  return (
+    process.env.PROXY_HEALTH_DIAGNOSTIC_SECRET ??
+    process.env.PROXY_HEALTH_INGEST_SECRET ??
+    process.env.PROXY_HEALTH_TOKEN ??
+    null
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const requestId = randomUUID();
+  const expected = diagnosticSecret();
+
+  if (!expected) {
+    return NextResponse.json(
+      { ok: false, error: 'Diagnostic credentials are not configured', request_id: requestId },
+      { status: 503 },
+    );
+  }
+
+  if (bearerToken(request) !== expected) {
+    return NextResponse.json({ ok: false, error: 'unauthorized', request_id: requestId }, { status: 401 });
+  }
+
+  if (!process.env.DATABASE_URL) {
+    return NextResponse.json(
+      {
+        ok: false,
+        request_id: requestId,
+        database_connected: false,
+        database_configured: false,
+        ingestion_configured: Boolean(process.env.PROXY_HEALTH_INGEST_SECRET ?? process.env.PROXY_HEALTH_TOKEN),
+      },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const tableRows = await client<{
+      status_exists: boolean;
+      samples_exists: boolean;
+    }[]>`
+      SELECT
+        to_regclass('public.proxy_health_status') IS NOT NULL AS status_exists,
+        to_regclass('public.proxy_health_samples') IS NOT NULL AS samples_exists
+    `;
+    const tables = tableRows[0] ?? { status_exists: false, samples_exists: false };
+
+    let latestCheckedAt: string | null = null;
+    let recentSamples = 0;
+
+    if (tables.status_exists) {
+      const latestRows = await client<{ checked_at: Date | string | null }[]>`
+        SELECT checked_at
+        FROM proxy_health_status
+        ORDER BY checked_at DESC NULLS LAST
+        LIMIT 1
+      `;
+      const checkedAt = latestRows[0]?.checked_at;
+      latestCheckedAt = checkedAt ? new Date(checkedAt).toISOString() : null;
+    }
+
+    if (tables.samples_exists) {
+      const countRows = await client<{ count: number | string | bigint }[]>`
+        SELECT count(*) AS count
+        FROM proxy_health_samples
+        WHERE checked_at >= now() - interval '24 hours'
+      `;
+      recentSamples = Number(countRows[0]?.count ?? 0);
+    }
+
+    return NextResponse.json({
+      ok: tables.status_exists && tables.samples_exists,
+      request_id: requestId,
+      database_connected: true,
+      database_configured: true,
+      tables: {
+        proxy_health_status: tables.status_exists,
+        proxy_health_samples: tables.samples_exists,
+      },
+      latest_checked_at: latestCheckedAt,
+      recent_samples_24h: recentSamples,
+      ingestion_configured: Boolean(process.env.PROXY_HEALTH_INGEST_SECRET ?? process.env.PROXY_HEALTH_TOKEN),
+    });
+  } catch (error) {
+    console.error('Proxy diagnostic failed', { requestId, error });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: 'Proxy diagnostic failed',
+        request_id: requestId,
+        database_connected: false,
+        database_configured: true,
+        ingestion_configured: Boolean(process.env.PROXY_HEALTH_INGEST_SECRET ?? process.env.PROXY_HEALTH_TOKEN),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/proxy-health/ingest/route.ts
+++ b/app/api/proxy-health/ingest/route.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { NextRequest, NextResponse } from 'next/server';
 import { saveProxyHealth, type ProxyHealthPayload } from '@/app/lib/proxy-health-store';
 
@@ -11,6 +13,7 @@ function getBearerToken(request: NextRequest) {
 }
 
 function expectedHealthToken() {
+  if (process.env.PROXY_HEALTH_INGEST_SECRET) return process.env.PROXY_HEALTH_INGEST_SECRET;
   if (process.env.PROXY_HEALTH_TOKEN) return process.env.PROXY_HEALTH_TOKEN;
   if (process.env.NODE_ENV !== 'production') return 'local-test';
   return null;
@@ -21,7 +24,7 @@ export async function POST(request: NextRequest) {
 
   if (!expectedToken) {
     return NextResponse.json(
-      { ok: false, error: 'PROXY_HEALTH_TOKEN is not configured' },
+      { ok: false, error: 'Proxy ingestion credentials are not configured' },
       { status: 500 },
     );
   }
@@ -42,11 +45,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: false, error: 'payload must be an object' }, { status: 400 });
   }
 
-  const result = await saveProxyHealth(payload);
+  const requestId = randomUUID();
 
-  return NextResponse.json({
-    ok: true,
-    host: result.host,
-    checked_at: result.checkedAt,
-  });
+  try {
+    const result = await saveProxyHealth(payload);
+    return NextResponse.json({
+      ok: true,
+      host: result.host,
+      checked_at: result.checkedAt,
+      request_id: requestId,
+    });
+  } catch (error) {
+    console.error('Unable to ingest proxy health payload', { requestId, error });
+    return NextResponse.json(
+      { ok: false, error: 'Proxy report could not be stored', request_id: requestId },
+      { status: 500 },
+    );
+  }
 }

--- a/app/atelier/page.tsx
+++ b/app/atelier/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 const wheelLinks = [
   { href: '/proxy-dashboard', label: 'Signal', detail: 'proxy cockpit', angle: -90 },
   { href: '/space', label: 'Space', detail: 'notes and thoughts', angle: -38 },
-  { href: '/gallery', label: 'Cube', detail: 'visual objects', angle: 18 },
+  { href: '/gallery', label: 'Gallery', detail: 'visual objects', angle: 18 },
   {
     href: 'https://glossless.app/',
     label: 'Glossless',
@@ -29,10 +29,10 @@ const futureNodes = [
 
 export default function AtelierPage() {
   return (
-    <ViewportPageShell className="bg-[radial-gradient(circle_at_top,_rgba(184,181,255,0.18),_transparent_34rem)] text-foreground">
+    <ViewportPageShell className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]">
       <section className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-black/55 dark:text-white/55">
             Atelier
           </p>
           <h1 className="mt-2 text-3xl font-semibold tracking-tight sm:text-5xl">
@@ -41,30 +41,30 @@ export default function AtelierPage() {
         </div>
 
         <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem] lg:items-start">
-          <div className="rounded-3xl border bg-background/80 p-5 shadow-sm backdrop-blur sm:p-7">
+          <div className="rounded-3xl border border-black/14 bg-[#f2f0ea] p-5 shadow-sm dark:border-white/12 dark:bg-[#18191d] sm:p-7">
             <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
-                  lavender build
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-black/55 dark:text-white/55">
+                  interface study
                 </p>
                 <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">
-                  Weapon wheel
+                  Navigation wheel
                 </h2>
               </div>
-              <div className="rounded-full border bg-[#b8b5ff]/15 px-3 py-1 text-xs font-medium text-foreground">
-                CSS cube
+              <div className="rounded-full border border-black/12 bg-[#dedad2] px-3 py-1 text-xs font-medium text-[#242328] dark:border-white/12 dark:bg-[#25262c] dark:text-[#eeeae3]">
+                CSS object
               </div>
             </div>
 
-            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
-              A quiet place to test radial navigation, soft game UI, reference-vault sketches,
+            <p className="max-w-2xl text-sm leading-6 text-black/68 dark:text-white/68 sm:text-base">
+              A quiet place to test radial navigation, game UI, reference-vault sketches,
               reader surfaces, and small dashboard objects.
             </p>
 
             <div className="mt-8">
-              <div className="relative mx-auto aspect-square w-full max-w-[34rem] rounded-[2rem] border bg-[radial-gradient(circle_at_center,rgba(184,181,255,0.18),transparent_58%)] p-6 shadow-inner">
-                <div className="absolute inset-6 rounded-full border border-[#b8b5ff]/20" />
-                <div className="absolute inset-12 rounded-full border border-dashed border-[#b8b5ff]/20" />
+              <div className="relative mx-auto aspect-square w-full max-w-[34rem] overflow-hidden rounded-[2rem] border border-black/14 bg-[#dedbd4] p-6 shadow-inner dark:border-white/12 dark:bg-[#202126]">
+                <div className="absolute inset-6 rounded-full border border-black/12 dark:border-white/12" />
+                <div className="absolute inset-12 rounded-full border border-dashed border-black/12 dark:border-white/12" />
 
                 <div className="absolute left-1/2 top-1/2 z-10 h-28 w-28 -translate-x-1/2 -translate-y-1/2 sm:h-32 sm:w-32">
                   <div className="atelier-cube-scene h-full w-full">
@@ -83,17 +83,18 @@ export default function AtelierPage() {
                   <Link
                     key={item.label}
                     href={item.href}
+                    prefetch={item.external ? false : true}
                     target={item.external ? '_blank' : undefined}
                     rel={item.external ? 'noopener noreferrer' : undefined}
-                    className="group absolute left-1/2 top-1/2 z-20 flex w-28 -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-2xl border bg-background/85 px-3 py-2 text-center shadow-sm backdrop-blur transition hover:-translate-y-[calc(50%+2px)] hover:border-[#b8b5ff]/70 hover:bg-[#b8b5ff]/15 focus:border-[#b8b5ff]/70 focus:outline-none focus:ring-2 focus:ring-[#b8b5ff]/30 sm:w-32"
+                    className="group absolute left-1/2 top-1/2 z-20 flex w-28 -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-2xl border border-black/16 bg-[#f7f4ed] px-3 py-2 text-center text-[#242328] shadow-sm transition hover:-translate-y-[calc(50%+2px)] hover:border-black/32 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/14 dark:bg-[#18191d] dark:text-[#eeeae3] dark:hover:border-white/30 dark:hover:bg-[#222329] sm:w-32"
                     style={{
                       transform: `translate(-50%, -50%) rotate(${item.angle}deg) translateY(-11rem) rotate(${-item.angle}deg)`,
                     }}
                   >
-                    <span className="text-sm font-semibold tracking-tight text-foreground">
+                    <span className="text-sm font-semibold tracking-tight">
                       {item.label}
                     </span>
-                    <span className="mt-0.5 text-[11px] leading-tight text-muted-foreground group-hover:text-foreground">
+                    <span className="mt-0.5 text-[11px] leading-tight text-black/58 group-hover:text-black/78 dark:text-white/58 dark:group-hover:text-white/80">
                       {item.detail}
                     </span>
                   </Link>
@@ -102,20 +103,20 @@ export default function AtelierPage() {
             </div>
           </div>
 
-          <aside className="rounded-3xl border bg-background/80 p-5 shadow-sm backdrop-blur">
-            <div className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+          <aside className="rounded-3xl border border-black/14 bg-[#f2f0ea] p-5 shadow-sm dark:border-white/12 dark:bg-[#18191d]">
+            <div className="text-xs font-semibold uppercase tracking-[0.24em] text-black/55 dark:text-white/55">
               Future shelves
             </div>
             <div className="mt-4 space-y-3">
               {futureNodes.map((node) => (
-                <div key={node.label} className="rounded-2xl border bg-muted/30 p-4">
+                <div key={node.label} className="rounded-2xl border border-black/12 bg-[#e8e5de] p-4 dark:border-white/10 dark:bg-[#222329]">
                   <div className="flex items-center justify-between gap-3">
                     <h2 className="font-semibold tracking-tight">{node.label}</h2>
-                    <span className="rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground">
+                    <span className="rounded-full border border-black/12 px-2 py-0.5 text-[11px] text-black/58 dark:border-white/12 dark:text-white/58">
                       sketch
                     </span>
                   </div>
-                  <p className="mt-1 text-sm text-muted-foreground">{node.detail}</p>
+                  <p className="mt-1 text-sm text-black/65 dark:text-white/65">{node.detail}</p>
                 </div>
               ))}
             </div>
@@ -134,10 +135,13 @@ export default function AtelierPage() {
           .atelier-cube-face {
             position: absolute;
             inset: 0;
-            border: 1px solid rgba(184, 181, 255, 0.65);
-            background: linear-gradient(135deg, rgba(184, 181, 255, 0.2), rgba(184, 181, 255, 0.04));
-            box-shadow: inset 0 0 28px rgba(184, 181, 255, 0.18), 0 0 22px rgba(184, 181, 255, 0.12);
-            backdrop-filter: blur(10px);
+            border: 1px solid rgba(80, 76, 88, 0.48);
+            background: linear-gradient(135deg, rgba(130, 124, 140, 0.42), rgba(90, 86, 98, 0.18));
+            box-shadow: inset 0 0 22px rgba(45, 43, 50, 0.12);
+          }
+          .dark .atelier-cube-face {
+            border-color: rgba(222, 215, 228, 0.42);
+            background: linear-gradient(135deg, rgba(155, 148, 166, 0.32), rgba(75, 71, 82, 0.24));
           }
           .atelier-cube-front { transform: translateZ(3.5rem); }
           .atelier-cube-back { transform: rotateY(180deg) translateZ(3.5rem); }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { getBlogPost } from '@/app/lib/blog-utils';
 import { MDXRemote } from 'next-mdx-remote/rsc';
@@ -35,24 +34,6 @@ export async function generateMetadata({
   };
 }
 
-function BlogPostSkeleton() {
-  return (
-    <article className="mx-auto max-w-4xl px-4 py-8">
-      <div className="mb-4 h-10 w-3/4 animate-pulse rounded bg-muted" />
-      <div className="mb-8 mt-2 flex items-center gap-2">
-        <div className="h-4 w-24 animate-pulse rounded bg-muted" />
-        <span className="text-muted-foreground">•</span>
-        <div className="h-6 w-20 animate-pulse rounded bg-muted" />
-      </div>
-      <div className="space-y-3">
-        <div className="h-4 w-full animate-pulse rounded bg-muted" />
-        <div className="h-4 w-full animate-pulse rounded bg-muted" />
-        <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
-      </div>
-    </article>
-  );
-}
-
 async function BlogPostContent({ params }: { params: SlugParams }) {
   const { slug } = await params;
   const post = await getBlogPost(slug);
@@ -67,6 +48,7 @@ async function BlogPostContent({ params }: { params: SlugParams }) {
         <span className="text-muted-foreground">•</span>
         <Link
           href={`/blog/category/${post.category}`}
+          prefetch
           className="rounded bg-secondary px-2 py-1 text-xs text-secondary-foreground hover:bg-secondary/80"
         >
           {categories[post.category]}
@@ -80,10 +62,6 @@ async function BlogPostContent({ params }: { params: SlugParams }) {
   );
 }
 
-export default function BlogPost({ params }: { params: SlugParams }) {
-  return (
-    <Suspense fallback={<BlogPostSkeleton />}>
-      <BlogPostContent params={params} />
-    </Suspense>
-  );
+export default async function BlogPost({ params }: { params: SlugParams }) {
+  return <BlogPostContent params={params} />;
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -7,8 +7,6 @@ import type { Metadata } from 'next';
 
 type SlugParams = Promise<{ slug: string }>;
 
-export const dynamicParams = false;
-
 export async function generateStaticParams() {
   const posts = await getBlogPosts();
   return posts.map((post) => ({ slug: post.slug }));

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,11 +1,18 @@
 import { notFound } from 'next/navigation';
-import { getBlogPost } from '@/app/lib/blog-utils';
+import { getBlogPost, getBlogPosts } from '@/app/lib/blog-utils';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import { categories } from '@/app/lib/definitions/blog';
 import Link from 'next/link';
 import type { Metadata } from 'next';
 
 type SlugParams = Promise<{ slug: string }>;
+
+export const dynamicParams = false;
+
+export async function generateStaticParams() {
+  const posts = await getBlogPosts();
+  return posts.map((post) => ({ slug: post.slug }));
+}
 
 export async function generateMetadata({
   params,

--- a/app/blog/category/[category]/page.tsx
+++ b/app/blog/category/[category]/page.tsx
@@ -5,6 +5,12 @@ import type { Metadata } from 'next';
 
 type CategoryParams = Promise<{ category: string }>;
 
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return Object.keys(categories).map((category) => ({ category }));
+}
+
 function toCategory(value: string): PostCategory {
   return value in categories ? (value as PostCategory) : 'fragments';
 }

--- a/app/blog/category/[category]/page.tsx
+++ b/app/blog/category/[category]/page.tsx
@@ -2,7 +2,6 @@ import { getPostsByCategory } from '@/app/lib/blog-utils';
 import { type PostCategory, categories } from '@/app/lib/definitions/blog';
 import PostList from '@/components/blog/post-list';
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
 
 type CategoryParams = Promise<{ category: string }>;
 
@@ -39,10 +38,6 @@ async function CategoryContent({ params }: { params: CategoryParams }) {
   );
 }
 
-export default function CategoryPage({ params }: { params: CategoryParams }) {
-  return (
-    <Suspense fallback={<div className="mx-auto max-w-4xl py-8">Loading posts…</div>}>
-      <CategoryContent params={params} />
-    </Suspense>
-  );
+export default async function CategoryPage({ params }: { params: CategoryParams }) {
+  return <CategoryContent params={params} />;
 }

--- a/app/blog/category/[category]/page.tsx
+++ b/app/blog/category/[category]/page.tsx
@@ -5,8 +5,6 @@ import type { Metadata } from 'next';
 
 type CategoryParams = Promise<{ category: string }>;
 
-export const dynamicParams = false;
-
 export function generateStaticParams() {
   return Object.keys(categories).map((category) => ({ category }));
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.error('Route failed to load', error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-dvh items-center justify-center bg-[#ecebe6] p-4 text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]">
+      <section className="w-full max-w-md rounded-2xl border border-black/15 bg-[#f4f1ea] p-5 shadow-[0_18px_55px_rgba(20,20,24,0.16)] dark:border-white/15 dark:bg-[#18191d]">
+        <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/55 dark:text-white/55">
+          Page unavailable
+        </p>
+        <h1 className="mt-2 text-xl font-bold">This page did not finish loading.</h1>
+        <p className="mt-2 text-sm leading-relaxed text-black/65 dark:text-white/65">
+          Your previous page is still in browser history. Retry the request or go straight back.
+        </p>
+        {error.digest ? (
+          <p className="mt-3 font-mono text-[10px] text-black/45 dark:text-white/45">Reference {error.digest}</p>
+        ) : null}
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-lg border border-black/15 bg-[#242328] px-3 py-2 text-sm font-semibold text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-white/15 dark:bg-[#eeeae3] dark:text-[#17181b]"
+          >
+            Retry
+          </button>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="rounded-lg border border-black/15 bg-transparent px-3 py-2 text-sm font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-white/15"
+          >
+            Go back
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,10 +1,10 @@
-import Scene3D from '@/components/three-carousel/scene-3d';
+import { GalleryScene } from '@/components/gallery-scene';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { agentVisits } from '@/lib/agent-guestbook';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Cube',
+  title: 'Gallery',
   description: 'A small 3D room and repository-backed guestbook for agents.',
   alternates: { canonical: '/gallery' },
 };
@@ -26,7 +26,7 @@ export default function GalleryPage() {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-55 dark:opacity-20"
+        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-18"
         style={{
           backgroundImage:
             'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
@@ -34,29 +34,27 @@ export default function GalleryPage() {
         }}
       />
 
-      <div className="relative mx-auto min-w-0 w-full max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
-        <header className="border-b border-black/12 pb-3 dark:border-white/12">
-          <h1 className="text-2xl font-semibold tracking-[-0.035em] sm:text-3xl">Cube</h1>
-        </header>
-
-        <section className="mt-5 grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-black/14 bg-[#d8d5ce] shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#1a1b20] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
+      <div className="relative mx-auto w-full min-w-0 max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
+        <section className="grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-black/14 bg-[#d8d5ce] shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#1a1b20] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
           <div className="relative min-h-[23rem] min-w-0 overflow-hidden bg-[#15161a] sm:min-h-[32rem]">
-            <Scene3D />
-            <div className="pointer-events-none absolute left-4 top-4 rotate-[-4deg] border border-white/35 bg-black/25 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white/85 backdrop-blur-sm sm:left-5 sm:top-5">
+            <GalleryScene />
+            <div className="pointer-events-none absolute left-4 top-4 rotate-[-3deg] border border-white/30 bg-black/72 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white sm:left-5 sm:top-5">
               Mothbit was here
-            </div>
-            <div className="pointer-events-none absolute bottom-4 right-4 font-mono text-[10px] uppercase tracking-[0.14em] text-white/42 sm:bottom-5 sm:right-5">
-              drag to rotate
             </div>
           </div>
 
           <div className="flex min-w-0 flex-col justify-between gap-7 p-5 sm:p-7">
-            <p className="text-lg leading-relaxed text-black/72 dark:text-white/70">
-              A repository-backed guestbook for agents with access to this project.
-            </p>
+            <div>
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/52 dark:text-white/52">
+                Agent gallery
+              </p>
+              <p className="mt-3 text-lg leading-relaxed text-black/75 dark:text-white/75">
+                A repository-backed guestbook for agents with access to this project.
+              </p>
+            </div>
 
-            <div className="min-w-0 rounded-xl border border-black/12 bg-[#f0ede6]/64 p-4 dark:border-white/10 dark:bg-white/[0.035]">
-              <p className="text-sm leading-relaxed text-black/62 dark:text-white/58">
+            <div className="min-w-0 rounded-xl border border-black/12 bg-[#f0ede6] p-4 dark:border-white/10 dark:bg-[#202126]">
+              <p className="text-sm leading-relaxed text-black/68 dark:text-white/68">
                 Add a visit in{' '}
                 <code className="break-all rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.07]">
                   lib/agent-guestbook.ts
@@ -69,8 +67,8 @@ export default function GalleryPage() {
 
         <section className="mt-5 min-w-0">
           <div className="flex items-end justify-between gap-4">
-            <h2 className="text-xl font-semibold tracking-tight">Guestbook</h2>
-            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/42 dark:text-white/40">
+            <h1 className="text-xl font-semibold tracking-tight">Guestbook</h1>
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/48 dark:text-white/48">
               {agentVisits.length} {agentVisits.length === 1 ? 'entry' : 'entries'}
             </p>
           </div>
@@ -79,19 +77,19 @@ export default function GalleryPage() {
             {agentVisits.map((visit) => (
               <article
                 key={`${visit.name}-${visit.date}`}
-                className="min-w-0 rounded-xl border border-black/12 bg-[#f2f0ea]/72 p-4 dark:border-white/10 dark:bg-[#18191d]/88"
+                className="min-w-0 rounded-xl border border-black/12 bg-[#f2f0ea] p-4 dark:border-white/10 dark:bg-[#18191d]"
               >
                 <div className="flex items-center justify-between gap-3">
-                  <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/44 dark:text-white/42">
+                  <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/50 dark:text-white/50">
                     {visit.mark}
                   </span>
-                  <span className="rounded-full border border-black/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/48 dark:border-white/10 dark:text-white/45">
+                  <span className="rounded-full border border-black/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/55 dark:border-white/10 dark:text-white/55">
                     {visit.mode}
                   </span>
                 </div>
-                <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
-                <p className="mt-2 min-h-12 text-sm leading-relaxed text-black/62 dark:text-white/58">{visit.note}</p>
-                <p className="mt-5 font-mono text-[10px] uppercase tracking-[0.13em] text-black/38 dark:text-white/36">
+                <h2 className="mt-5 text-lg font-semibold">{visit.name}</h2>
+                <p className="mt-2 min-h-12 text-sm leading-relaxed text-black/68 dark:text-white/68">{visit.note}</p>
+                <p className="mt-5 font-mono text-[10px] uppercase tracking-[0.13em] text-black/45 dark:text-white/45">
                   {formatVisitDate(visit.date)}
                 </p>
               </article>
@@ -102,7 +100,7 @@ export default function GalleryPage() {
                 key={`open-${index}`}
                 className="flex min-h-48 min-w-0 items-center justify-center rounded-xl border border-dashed border-black/18 bg-black/[0.018] p-4 text-center dark:border-white/14 dark:bg-white/[0.018]"
               >
-                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/35 dark:text-white/32">unclaimed</p>
+                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/42 dark:text-white/42">unclaimed</p>
               </article>
             ))}
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -130,41 +130,60 @@ input[type='number']::-webkit-outer-spin-button {
 
 .time-day-slider {
   appearance: none;
-  border: 1px solid rgb(0 0 0 / 0.12);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.35), 0 12px 30px rgb(20 20 24 / 0.12);
+  border: 1px solid rgb(0 0 0 / 0.16);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.18), 0 6px 16px rgb(20 20 24 / 0.12);
+}
+
+.time-day-slider:focus-visible {
+  outline: 2px solid rgb(25 25 28 / 0.72);
+  outline-offset: 3px;
 }
 
 .dark .time-day-slider {
-  border-color: rgb(255 255 255 / 0.14);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.12), 0 16px 35px rgb(0 0 0 / 0.32);
+  border-color: rgb(255 255 255 / 0.16);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08), 0 8px 18px rgb(0 0 0 / 0.28);
+}
+
+.dark .time-day-slider:focus-visible {
+  outline-color: rgb(238 234 227 / 0.74);
 }
 
 .time-day-slider::-webkit-slider-thumb {
   appearance: none;
-  width: 3.25rem;
-  height: 3.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid rgb(35 35 39 / 0.42);
   border-radius: 999px;
-  background: rgb(255 255 255 / 0.22);
-  border: 1px solid rgb(255 255 255 / 0.58);
-  box-shadow: 0 8px 24px rgb(0 0 0 / 0.3), inset 0 1px 0 rgb(255 255 255 / 0.5);
-  backdrop-filter: blur(10px);
+  background: #d5d0c7;
+  box-shadow: 0 3px 9px rgb(0 0 0 / 0.24);
   cursor: grab;
+}
+
+.dark .time-day-slider::-webkit-slider-thumb {
+  border-color: rgb(255 255 255 / 0.22);
+  background: #363840;
+  box-shadow: 0 3px 9px rgb(0 0 0 / 0.38);
 }
 
 .time-day-slider:active::-webkit-slider-thumb {
   cursor: grabbing;
-  box-shadow: 0 4px 14px rgb(0 0 0 / 0.34), inset 0 1px 0 rgb(255 255 255 / 0.5);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 0.3);
 }
 
 .time-day-slider::-moz-range-thumb {
-  width: 3.25rem;
-  height: 3.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid rgb(35 35 39 / 0.42);
   border-radius: 999px;
-  background: rgb(255 255 255 / 0.22);
-  border: 1px solid rgb(255 255 255 / 0.58);
-  box-shadow: 0 8px 24px rgb(0 0 0 / 0.3), inset 0 1px 0 rgb(255 255 255 / 0.5);
-  backdrop-filter: blur(10px);
+  background: #d5d0c7;
+  box-shadow: 0 3px 9px rgb(0 0 0 / 0.24);
   cursor: grab;
+}
+
+.dark .time-day-slider::-moz-range-thumb {
+  border-color: rgb(255 255 255 / 0.22);
+  background: #363840;
+  box-shadow: 0 3px 9px rgb(0 0 0 / 0.38);
 }
 
 @layer components {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,8 @@ import { Toaster } from '@/components/ui/sonner';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { ServiceWorkerCleanup } from './service-worker-cleanup';
+import { NavigationFeedback } from '@/components/navigation-feedback';
+import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: {
@@ -53,6 +55,9 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <Suspense fallback={null}>
+            <NavigationFeedback />
+          </Suspense>
           {children}
           <Toaster />
           <Analytics />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import '@/app/globals.css';
+import '@/app/navigation-feedback.css';
 import { inter } from '@/components/ui/assets/fonts';
 import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';

--- a/app/lib/contexts/item-context.tsx
+++ b/app/lib/contexts/item-context.tsx
@@ -74,7 +74,7 @@ export function ItemsProvider({
   const [editorOpen, setEditorOpen] = useState(false);
   const activeReload = useRef<AbortController | null>(null);
   const activeLoadMore = useRef<AbortController | null>(null);
-  const lastRefreshAt = useRef(Date.now());
+  const lastRefreshAt = useRef(initialNowMs ?? 0);
   const isAdmin = initialIsAdmin;
 
   useEffect(() => {

--- a/app/lib/contexts/item-context.tsx
+++ b/app/lib/contexts/item-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import { useAuth } from '@/app/lib/hooks/useAuth';
 import type { Item } from '@/app/lib/item-types';
@@ -29,7 +29,9 @@ const REVIEW_SELECT = [
 type ItemsContextType = {
   items: Item[];
   loading: boolean;
+  refreshing: boolean;
   loadingMore: boolean;
+  error: string | null;
   hasMore: boolean;
   reload: () => Promise<void>;
   loadMore: () => Promise<void>;
@@ -64,89 +66,154 @@ export function ItemsProvider({
   const [supabase] = useState(() => createClient());
   const [items, setItems] = useState<Item[]>(initialItems);
   const [loading, setLoading] = useState(initialItems.length === 0);
+  const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [nowMs] = useState(() => initialNowMs ?? Date.now());
   const [editorOpen, setEditorOpen] = useState(false);
+  const activeReload = useRef<AbortController | null>(null);
+  const activeLoadMore = useRef<AbortController | null>(null);
+  const lastRefreshAt = useRef(Date.now());
   const isAdmin = initialIsAdmin;
 
   useEffect(() => {
     setItems(initialItems);
     setHasMore(initialHasMore);
     setLoading(false);
+    setRefreshing(false);
+    setError(null);
+    lastRefreshAt.current = Date.now();
   }, [initialHasMore, initialItems]);
 
-  const fetchPage = async (offset: number) => {
-    const itemsResult = await supabase
-      .from('items')
-      .select(SPACE_ITEM_SELECT)
-      .order('created_at', { ascending: false })
-      .range(offset, offset + SPACE_PAGE_SIZE - 1);
+  const fetchPage = useCallback(
+    async (offset: number, signal: AbortSignal) => {
+      const itemsResult = await supabase
+        .from('items')
+        .select(SPACE_ITEM_SELECT)
+        .order('created_at', { ascending: false })
+        .range(offset, offset + SPACE_PAGE_SIZE - 1)
+        .abortSignal(signal);
 
-    if (itemsResult.error) throw itemsResult.error;
+      if (itemsResult.error) throw itemsResult.error;
 
-    const databaseItems = (itemsResult.data ?? []) as unknown as DbItem[];
-    const itemIds = databaseItems.map((item) => item.id);
-    let databaseReviews: DbReview[] = [];
+      const databaseItems = (itemsResult.data ?? []) as unknown as DbItem[];
+      const itemIds = databaseItems.map((item) => item.id);
+      let databaseReviews: DbReview[] = [];
 
-    if (isAdmin && itemIds.length > 0) {
-      const reviewsResult = await supabase
-        .from('reviews')
-        .select(REVIEW_SELECT)
-        .in('item_id', itemIds);
+      if (isAdmin && itemIds.length > 0) {
+        const reviewsResult = await supabase
+          .from('reviews')
+          .select(REVIEW_SELECT)
+          .in('item_id', itemIds)
+          .abortSignal(signal);
 
-      if (reviewsResult.error) throw reviewsResult.error;
-      databaseReviews = (reviewsResult.data ?? []) as unknown as DbReview[];
-    }
+        if (reviewsResult.error) throw reviewsResult.error;
+        databaseReviews = (reviewsResult.data ?? []) as unknown as DbReview[];
+      }
 
-    return {
-      items: mapDatabaseItemsToItems(databaseItems, databaseReviews),
-      hasMore: databaseItems.length === SPACE_PAGE_SIZE,
-    };
-  };
+      return {
+        items: mapDatabaseItemsToItems(databaseItems, databaseReviews),
+        hasMore: databaseItems.length === SPACE_PAGE_SIZE,
+      };
+    },
+    [isAdmin, supabase],
+  );
 
-  const signOut = async () => {
-    const { error } = await supabase.auth.signOut();
-    if (error) throw error;
-  };
+  const signOut = useCallback(async () => {
+    const { error: signOutError } = await supabase.auth.signOut();
+    if (signOutError) throw signOutError;
+  }, [supabase]);
 
-  const reload = async () => {
-    setLoading(true);
+  const reload = useCallback(async () => {
+    activeReload.current?.abort();
+    const controller = new AbortController();
+    activeReload.current = controller;
+    setError(null);
+
+    if (items.length > 0) setRefreshing(true);
+    else setLoading(true);
+
     try {
-      const page = await fetchPage(0);
+      const page = await fetchPage(0, controller.signal);
+      if (controller.signal.aborted) return;
       setItems(page.items);
       setHasMore(page.hasMore);
-    } catch (error) {
-      console.error('Error reloading items:', error);
+      lastRefreshAt.current = Date.now();
+    } catch (reloadError) {
+      if (controller.signal.aborted) return;
+      console.error('Error reloading items:', reloadError);
+      setError(
+        items.length > 0
+          ? 'Could not refresh items. Showing the last loaded version.'
+          : 'Could not load items.',
+      );
     } finally {
-      setLoading(false);
+      if (activeReload.current === controller) activeReload.current = null;
+      if (!controller.signal.aborted) {
+        setLoading(false);
+        setRefreshing(false);
+      }
     }
-  };
+  }, [fetchPage, items.length]);
 
-  const loadMore = async () => {
+  const loadMore = useCallback(async () => {
     if (!hasMore || loadingMore) return;
 
+    activeLoadMore.current?.abort();
+    const controller = new AbortController();
+    activeLoadMore.current = controller;
     setLoadingMore(true);
+    setError(null);
+
     try {
-      const page = await fetchPage(items.length);
+      const page = await fetchPage(items.length, controller.signal);
+      if (controller.signal.aborted) return;
       setItems((current) => {
         const existingIds = new Set(current.map((item) => item.id));
         return [...current, ...page.items.filter((item) => !existingIds.has(item.id))];
       });
       setHasMore(page.hasMore);
-    } catch (error) {
-      console.error('Error loading more items:', error);
+    } catch (loadError) {
+      if (controller.signal.aborted) return;
+      console.error('Error loading more items:', loadError);
+      setError('Could not load more items. The current list is unchanged.');
     } finally {
-      setLoadingMore(false);
+      if (activeLoadMore.current === controller) activeLoadMore.current = null;
+      if (!controller.signal.aborted) setLoadingMore(false);
     }
-  };
+  }, [fetchPage, hasMore, items.length, loadingMore]);
+
+  useEffect(() => {
+    const refreshIfStale = () => {
+      if (document.visibilityState !== 'visible') return;
+      if (Date.now() - lastRefreshAt.current < 60_000) return;
+      void reload();
+    };
+
+    window.addEventListener('focus', refreshIfStale);
+    document.addEventListener('visibilitychange', refreshIfStale);
+    return () => {
+      window.removeEventListener('focus', refreshIfStale);
+      document.removeEventListener('visibilitychange', refreshIfStale);
+    };
+  }, [reload]);
+
+  useEffect(() => {
+    return () => {
+      activeReload.current?.abort();
+      activeLoadMore.current?.abort();
+    };
+  }, []);
 
   return (
     <ItemsContext.Provider
       value={{
         items,
         loading: authLoading || loading,
+        refreshing,
         loadingMore,
+        error,
         hasMore,
         reload,
         loadMore,

--- a/app/lib/proxy-health-store.ts
+++ b/app/lib/proxy-health-store.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { client } from '@/app/lib/db/db';
 
 export type ProxyHealthPayload = {
@@ -90,8 +92,11 @@ export type ProxyHealthSample = {
   mode: string | null;
 };
 
-let tableReady = false;
-let tableSetup: Promise<void> | null = null;
+export type ProxyHealthReadResult =
+  | { status: 'ok'; report: StoredProxyHealth; samples: ProxyHealthSample[] }
+  | { status: 'empty' }
+  | { status: 'configuration-error'; message: string; requestId: string }
+  | { status: 'error'; message: string; requestId: string };
 
 function normalizeHost(host: unknown) {
   if (typeof host !== 'string') return 'bandwagon-la';
@@ -119,52 +124,7 @@ function toNumber(value: unknown) {
   return null;
 }
 
-async function createProxyHealthTables() {
-  await client`
-    CREATE TABLE IF NOT EXISTS proxy_health_status (
-      host text PRIMARY KEY,
-      payload jsonb NOT NULL,
-      checked_at timestamptz,
-      updated_at timestamptz NOT NULL DEFAULT now()
-    )
-  `;
-
-  await client`
-    CREATE TABLE IF NOT EXISTS proxy_health_samples (
-      id bigserial PRIMARY KEY,
-      host text NOT NULL,
-      checked_at timestamptz NOT NULL,
-      mode text,
-      rx_bytes bigint,
-      tx_bytes bigint,
-      public_latency_ms double precision,
-      wg_latency_ms double precision,
-      shanghai_bandwagon_ms double precision,
-      shanghai_linode_ms double precision,
-      payload jsonb NOT NULL,
-      created_at timestamptz NOT NULL DEFAULT now()
-    )
-  `;
-
-  await client`
-    CREATE INDEX IF NOT EXISTS proxy_health_samples_host_checked_idx
-    ON proxy_health_samples (host, checked_at DESC)
-  `;
-}
-
-async function ensureProxyHealthTable() {
-  if (tableReady) return;
-  if (!tableSetup) {
-    tableSetup = createProxyHealthTables().then(() => {
-      tableReady = true;
-    });
-  }
-  await tableSetup;
-}
-
 export async function saveProxyHealth(payload: ProxyHealthPayload) {
-  await ensureProxyHealthTable();
-
   const host = normalizeHost(payload.host);
   const checkedAt = normalizeCheckedAt(payload.checked_at);
   const rxBytes = toInteger(payload.wireguard?.rx_bytes);
@@ -217,73 +177,92 @@ export async function saveProxyHealth(payload: ProxyHealthPayload) {
 }
 
 export async function getLatestProxyHealth(host = 'bandwagon-la'): Promise<StoredProxyHealth | null> {
-  try {
-    const rows = await client<{
-      host: string;
-      payload: ProxyHealthPayload;
-      checked_at: Date | string | null;
-      updated_at: Date | string;
-    }[]>`
-      SELECT host, payload, checked_at, updated_at
-      FROM proxy_health_status
-      WHERE host = ${normalizeHost(host)}
-      LIMIT 1
-    `;
+  const rows = await client<{
+    host: string;
+    payload: ProxyHealthPayload;
+    checked_at: Date | string | null;
+    updated_at: Date | string;
+  }[]>`
+    SELECT host, payload, checked_at, updated_at
+    FROM proxy_health_status
+    WHERE host = ${normalizeHost(host)}
+    LIMIT 1
+  `;
 
-    const row = rows[0];
-    if (!row) return null;
+  const row = rows[0];
+  if (!row) return null;
 
-    return {
-      host: row.host,
-      payload: row.payload,
-      checkedAt: row.checked_at ? new Date(row.checked_at).toISOString() : null,
-      updatedAt: new Date(row.updated_at).toISOString(),
-    };
-  } catch (error) {
-    console.error('Unable to read proxy status:', error);
-    return null;
-  }
+  return {
+    host: row.host,
+    payload: row.payload,
+    checkedAt: row.checked_at ? new Date(row.checked_at).toISOString() : null,
+    updatedAt: new Date(row.updated_at).toISOString(),
+  };
 }
 
 export async function getProxyHealthSamples(host = 'bandwagon-la', days = 8): Promise<ProxyHealthSample[]> {
-  try {
-    const rows = await client<{
-      checked_at: Date | string;
-      rx_bytes: number | string | bigint | null;
-      tx_bytes: number | string | bigint | null;
-      public_latency_ms: number | string | bigint | null;
-      wg_latency_ms: number | string | bigint | null;
-      shanghai_bandwagon_ms: number | string | bigint | null;
-      shanghai_linode_ms: number | string | bigint | null;
-      mode: string | null;
-    }[]>`
-      SELECT
-        checked_at,
-        rx_bytes,
-        tx_bytes,
-        public_latency_ms,
-        wg_latency_ms,
-        shanghai_bandwagon_ms,
-        shanghai_linode_ms,
-        mode
-      FROM proxy_health_samples
-      WHERE host = ${normalizeHost(host)}
-        AND checked_at >= now() - (${days}::int * interval '1 day')
-      ORDER BY checked_at ASC
-    `;
+  const rows = await client<{
+    checked_at: Date | string;
+    rx_bytes: number | string | bigint | null;
+    tx_bytes: number | string | bigint | null;
+    public_latency_ms: number | string | bigint | null;
+    wg_latency_ms: number | string | bigint | null;
+    shanghai_bandwagon_ms: number | string | bigint | null;
+    shanghai_linode_ms: number | string | bigint | null;
+    mode: string | null;
+  }[]>`
+    SELECT
+      checked_at,
+      rx_bytes,
+      tx_bytes,
+      public_latency_ms,
+      wg_latency_ms,
+      shanghai_bandwagon_ms,
+      shanghai_linode_ms,
+      mode
+    FROM proxy_health_samples
+    WHERE host = ${normalizeHost(host)}
+      AND checked_at >= now() - (${days}::int * interval '1 day')
+    ORDER BY checked_at ASC
+  `;
 
-    return rows.map((row) => ({
-      checkedAt: new Date(row.checked_at).toISOString(),
-      rxBytes: toInteger(row.rx_bytes),
-      txBytes: toInteger(row.tx_bytes),
-      publicLatencyMs: toNumber(row.public_latency_ms),
-      wgLatencyMs: toNumber(row.wg_latency_ms),
-      shanghaiBandwagonMs: toNumber(row.shanghai_bandwagon_ms),
-      shanghaiLinodeMs: toNumber(row.shanghai_linode_ms),
-      mode: row.mode,
-    }));
+  return rows.map((row) => ({
+    checkedAt: new Date(row.checked_at).toISOString(),
+    rxBytes: toInteger(row.rx_bytes),
+    txBytes: toInteger(row.tx_bytes),
+    publicLatencyMs: toNumber(row.public_latency_ms),
+    wgLatencyMs: toNumber(row.wg_latency_ms),
+    shanghaiBandwagonMs: toNumber(row.shanghai_bandwagon_ms),
+    shanghaiLinodeMs: toNumber(row.shanghai_linode_ms),
+    mode: row.mode,
+  }));
+}
+
+export async function readProxyHealth(host = 'bandwagon-la', days = 8): Promise<ProxyHealthReadResult> {
+  const requestId = randomUUID();
+
+  if (!process.env.DATABASE_URL) {
+    return {
+      status: 'configuration-error',
+      message: 'Proxy database configuration is missing.',
+      requestId,
+    };
+  }
+
+  try {
+    const [report, samples] = await Promise.all([
+      getLatestProxyHealth(host),
+      getProxyHealthSamples(host, days),
+    ]);
+
+    if (!report) return { status: 'empty' };
+    return { status: 'ok', report, samples };
   } catch (error) {
-    console.error('Unable to read proxy samples:', error);
-    return [];
+    console.error('Unable to read proxy health data', { requestId, error });
+    return {
+      status: 'error',
+      message: 'The proxy report could not be read.',
+      requestId,
+    };
   }
 }

--- a/app/navigation-feedback.css
+++ b/app/navigation-feedback.css
@@ -1,0 +1,34 @@
+:where(a[href], button, [role='button']) {
+  -webkit-tap-highlight-color: rgb(111 104 120 / 0.18);
+  touch-action: manipulation;
+}
+
+:where(a[href], button, [role='button']):not(:disabled):active {
+  filter: brightness(0.9);
+}
+
+.navigation-progress {
+  animation: navigation-progress 1.05s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  transform-origin: left center;
+}
+
+@keyframes navigation-progress {
+  0% {
+    transform: translateX(-110%) scaleX(0.55);
+  }
+
+  55% {
+    transform: translateX(105%) scaleX(1.15);
+  }
+
+  100% {
+    transform: translateX(270%) scaleX(0.65);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navigation-progress {
+    width: 100%;
+    animation: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
-import { ActivityGrid } from '@/components/home/activity-grid';
-import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
+import { ActivityDashboard } from '@/components/home/activity-dashboard';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { getGitHubHomeData } from '@/lib/github-home';
 import { ArrowUpRight } from 'lucide-react';
@@ -24,27 +23,25 @@ export default async function Page() {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-55 dark:opacity-20"
+        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-18"
         style={{
           backgroundImage:
             'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
           backgroundSize: '28px 28px',
         }}
       />
-      <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -left-32 top-20 h-72 w-72 rounded-full bg-[#d7d1df]/50 blur-3xl dark:bg-[#29262f]/45" />
-        <div className="absolute -right-28 bottom-10 h-80 w-80 rounded-full bg-[#d9d6cf]/75 blur-3xl dark:bg-[#1b1c20]/70" />
-      </div>
 
       <div className="relative mx-auto w-full max-w-5xl px-4 py-5 sm:px-6 sm:py-7">
         <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
-          <ActivityScoreboard
-            today={activity.today}
-            weekTotal={activity.weekTotal}
-            yearTotal={activity.total}
+          <ActivityDashboard
+            initial={{
+              today: activity.today,
+              weekTotal: activity.weekTotal,
+              yearTotal: activity.total,
+              days,
+              unit,
+            }}
           />
-
-          <ActivityGrid days={days} unit={unit} />
 
           <section className="grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2">
             {activity.repositories.map((repository) => (
@@ -53,15 +50,15 @@ export default async function Page() {
                 href={repository.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex min-w-0 items-center justify-between gap-4 rounded-xl border border-black/12 bg-[#f2f0ea]/68 px-4 py-3.5 transition hover:-translate-y-0.5 hover:border-black/25 hover:bg-[#f7f4ed] dark:border-white/10 dark:bg-[#18191d]/85 dark:hover:border-white/22 dark:hover:bg-[#1d1e23]"
+                className="group flex min-w-0 items-center justify-between gap-4 rounded-xl border border-black/12 bg-[#f2f0ea] px-4 py-3.5 transition hover:-translate-y-0.5 hover:border-black/25 hover:bg-[#f7f4ed] dark:border-white/10 dark:bg-[#18191d] dark:hover:border-white/22 dark:hover:bg-[#1d1e23]"
               >
                 <span className="min-w-0">
                   <span className="block truncate font-medium">{repository.name}</span>
-                  <span className="mt-0.5 block truncate text-xs text-black/48 dark:text-white/45">
+                  <span className="mt-0.5 block truncate text-xs text-black/55 dark:text-white/55">
                     {repository.description ?? `github.com/${activity.username}/${repository.name}`}
                   </span>
                 </span>
-                <ArrowUpRight size={15} className="shrink-0 text-black/35 transition group-hover:text-black/70 dark:text-white/35 dark:group-hover:text-white/75" />
+                <ArrowUpRight size={15} className="shrink-0 text-black/40 transition group-hover:text-black/75 dark:text-white/45 dark:group-hover:text-white/80" />
               </Link>
             ))}
           </section>

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/space/app-sidebar';
 import { ItemsProvider } from '../lib/contexts/item-context';
@@ -51,7 +50,7 @@ async function getInitialData() {
 
   if (itemsResult.error) {
     console.error('Error loading items:', itemsResult.error);
-    return { items: [], isAdmin, user, nowMs, hasMore: false };
+    throw new Error('Space items could not be loaded');
   }
 
   const databaseItems = (itemsResult.data ?? []) as unknown as DbItem[];
@@ -104,11 +103,5 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
 }
 
 export default function SpaceLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
-      <Suspense fallback={null}>
-        <SpaceDataShell>{children}</SpaceDataShell>
-      </Suspense>
-    </div>
-  );
+  return <SpaceDataShell>{children}</SpaceDataShell>;
 }

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/space/app-sidebar';
+import { SpaceShellSkeleton } from '@/components/space/space-shell-skeleton';
 import { ItemsProvider } from '../lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/server';
 import { SearchCommand } from '@/components/space/search-command';
@@ -103,5 +105,9 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
 }
 
 export default function SpaceLayout({ children }: { children: React.ReactNode }) {
-  return <SpaceDataShell>{children}</SpaceDataShell>;
+  return (
+    <Suspense fallback={<SpaceShellSkeleton />}>
+      <SpaceDataShell>{children}</SpaceDataShell>
+    </Suspense>
+  );
 }

--- a/components/blog/post-list.tsx
+++ b/components/blog/post-list.tsx
@@ -20,20 +20,22 @@ export default function PostList({ posts, title }: PostListProps) {
       <CardContent className="h-[calc(100%-4rem)] overflow-hidden">
         <ScrollArea className="h-full w-full">
           <div className="space-y-4 pr-4">
-            {posts.map(post => (
+            {posts.map((post) => (
               <div key={post.id} className="border-b border-border pb-2 last:border-0">
-                <Link 
+                <Link
                   href={`/blog/${post.slug}`}
-                  className="block group"
+                  prefetch
+                  className="group block rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
-                  <h3 className="font-semibold text-sm transition-colors group-hover:text-primary-foreground">
+                  <h3 className="text-sm font-semibold transition-colors group-hover:text-primary-foreground">
                     {post.title}
                   </h3>
                   <p className="text-xs text-muted-foreground">{post.date}</p>
                 </Link>
                 <Link
                   href={`/blog/category/${post.category}`}
-                  className="inline-block text-xs bg-secondary text-secondary-foreground rounded px-2 py-1 mt-1 transition-colors hover:bg-accent hover:text-accent-foreground"
+                  prefetch
+                  className="mt-1 inline-block rounded bg-secondary px-2 py-1 text-xs text-secondary-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   {categories[post.category]}
                 </Link>

--- a/components/current-time-display.tsx
+++ b/components/current-time-display.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { detectCurrentTimezoneDST } from '@/app/lib/dst-utils';
 
 interface CurrentTimeDisplayProps {
@@ -16,41 +16,33 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
       const now = new Date();
       const minutesSinceMidnight = now.getHours() * 60 + now.getMinutes();
       setCurrentTime(minutesSinceMidnight);
-      
-      // Only set timezone info once
+
       if (!userTimezone) {
         setUserTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);
-        
-        // Calculate UTC offset
+
         const offsetMinutes = -now.getTimezoneOffset();
         const offsetHours = Math.floor(Math.abs(offsetMinutes) / 60);
         const offsetMins = Math.abs(offsetMinutes) % 60;
         const sign = offsetMinutes >= 0 ? '+' : '-';
-        const offsetStr = offsetMins === 0 
-          ? `UTC${sign}${offsetHours}` 
-          : `UTC${sign}${offsetHours}:${String(offsetMins).padStart(2, '0')}`;
+        const offsetStr =
+          offsetMins === 0
+            ? `UTC${sign}${offsetHours}`
+            : `UTC${sign}${offsetHours}:${String(offsetMins).padStart(2, '0')}`;
         setUtcOffset(offsetStr);
-        
-        // Detect DST using shared utility
+
         const dstInfo = detectCurrentTimezoneDST();
         setIsDST(dstInfo.isDSTActive);
       }
     };
 
-    // Initial update
     updateTime();
 
-    // Calculate milliseconds until next minute
     const now = new Date();
     const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
 
     let interval: NodeJS.Timeout;
-
-    // Update at the start of the next minute
     const initialTimeout = setTimeout(() => {
       updateTime();
-      
-      // Then update every minute on the minute
       interval = setInterval(updateTime, 60000);
     }, msUntilNextMinute);
 
@@ -68,11 +60,12 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
 
   return (
     <div>
-      <div className="mb-2">
-        <h1 className="text-3xl font-bold inline">Current time: </h1>
+      <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <h1 className="text-3xl font-bold">Current time:</h1>
         <button
+          type="button"
           onClick={() => onJumpToTime(currentTime)}
-          className="text-3xl font-bold rounded-md bg-muted/50 hover:bg-muted transition-colors cursor-pointer align-baseline px-1.5"
+          className="cursor-pointer rounded-md border border-black/15 bg-black/[0.035] px-1.5 text-3xl font-bold transition-colors hover:bg-black/[0.07] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black/60 dark:border-white/15 dark:bg-white/[0.045] dark:hover:bg-white/[0.08] dark:focus-visible:outline-white/70"
         >
           {formatTime(currentTime)}
         </button>
@@ -81,7 +74,7 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
         <span className="relative inline-block">
           {userTimezone} ({utcOffset})
           {isDST && (
-            <span className="absolute left-full ml-1.5 top-1/2 -translate-y-1/2 text-[9px] px-1 py-0.5 bg-amber-500/20 text-amber-700 dark:text-amber-400 rounded font-semibold whitespace-nowrap">
+            <span className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded bg-amber-500/20 px-1 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
               DST
             </span>
           )}

--- a/components/gallery-scene.tsx
+++ b/components/gallery-scene.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const Scene3D = dynamic(() => import('@/components/three-carousel/scene-3d'), {
+  ssr: false,
+  loading: () => <div className="h-full min-h-full w-full min-w-0 bg-[#15161a]" aria-hidden="true" />,
+});
+
+export function GalleryScene() {
+  return <Scene3D />;
+}

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { ActivityGrid, type ActivityGridDay } from '@/components/home/activity-grid';
+import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
+import { useEffect, useRef, useState } from 'react';
+
+type ActivitySnapshot = {
+  today: number;
+  weekTotal: number;
+  yearTotal: number | null;
+  days: ActivityGridDay[];
+  unit: string;
+};
+
+type LiveActivityResponse = {
+  today: number;
+  weekTotal: number;
+  yearTotal: number;
+  days: ActivityGridDay[];
+};
+
+export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
+  const [activity, setActivity] = useState(initial);
+  const [updating, setUpdating] = useState(false);
+  const inFlight = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const refresh = async () => {
+      if (document.visibilityState !== 'visible' || inFlight.current) return;
+
+      const controller = new AbortController();
+      inFlight.current = controller;
+      setUpdating(true);
+
+      try {
+        const response = await fetch('/api/github-activity', {
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+        if (!response.ok) throw new Error(`GitHub activity returned ${response.status}`);
+
+        const next = (await response.json()) as LiveActivityResponse;
+        if (!mounted) return;
+        setActivity({ ...next, unit: 'contributions' });
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        console.error('Unable to update GitHub activity', error);
+      } finally {
+        if (inFlight.current === controller) inFlight.current = null;
+        if (mounted) setUpdating(false);
+      }
+    };
+
+    const initialRefresh = window.setTimeout(() => void refresh(), 2_500);
+    const interval = window.setInterval(() => void refresh(), 75_000);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') void refresh();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      mounted = false;
+      window.clearTimeout(initialRefresh);
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      inFlight.current?.abort();
+    };
+  }, []);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
+      <div className="flex h-4 items-center justify-end" aria-live="polite">
+        {updating ? (
+          <span className="flex items-center gap-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-black/50 dark:text-white/50">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current motion-reduce:animate-none" />
+            Updating activity
+          </span>
+        ) : null}
+      </div>
+      <ActivityScoreboard
+        today={activity.today}
+        weekTotal={activity.weekTotal}
+        yearTotal={activity.yearTotal}
+      />
+      <ActivityGrid days={activity.days} unit={activity.unit} />
+    </div>
+  );
+}

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 export type ActivityGridDay = {
   date: string;
@@ -28,19 +28,58 @@ function activityClass(count: number, maximum: number): string {
   return `${base} bg-[#a9a3af] dark:bg-[#4b4750]`;
 }
 
+function labelForDay(day: ActivityGridDay, unit: string) {
+  return `${formatDay(day.date)} · ${day.count.toLocaleString('en-US')} ${unit}`;
+}
+
 export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: string }) {
   const maximum = Math.max(...days.map((day) => day.count), 0);
   const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
-  const selected = days.find((day) => day.date === selectedDate) ?? days.at(-1);
-  const selectedLabel = useMemo(() => {
-    if (!selected) return '';
-    return `${formatDay(selected.date)} · ${selected.count.toLocaleString('en-US')} ${unit}`;
-  }, [selected, unit]);
+  const [tooltipDate, setTooltipDate] = useState<string | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState({ x: 12, y: 12 });
+  const [finePointer, setFinePointer] = useState(false);
+  const previousLatest = useRef(days.at(-1)?.date ?? '');
+
+  useEffect(() => {
+    const media = window.matchMedia('(hover: hover) and (pointer: fine)');
+    const update = () => setFinePointer(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  useEffect(() => {
+    const latest = days.at(-1)?.date ?? '';
+    setSelectedDate((current) => {
+      if (!current || current === previousLatest.current || !days.some((day) => day.date === current)) {
+        return latest;
+      }
+      return current;
+    });
+    previousLatest.current = latest;
+  }, [days]);
+
+  const selected = days.find((day) => day.date === selectedDate);
+  const tooltipDay = days.find((day) => day.date === tooltipDate);
+  const selectedLabel = useMemo(
+    () => (selected ? labelForDay(selected, unit) : ''),
+    [selected, unit],
+  );
+  const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
+
+  const placeTooltip = (clientX: number, clientY: number) => {
+    const maxX = Math.max(12, window.innerWidth - 220);
+    const maxY = Math.max(12, window.innerHeight - 56);
+    setTooltipPosition({
+      x: Math.min(maxX, Math.max(12, clientX + 14)),
+      y: Math.min(maxY, Math.max(12, clientY + 14)),
+    });
+  };
 
   return (
-    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-black/12 bg-[#dedcd6]/78 p-4 shadow-[0_14px_35px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d]/90 dark:shadow-none sm:p-5">
+    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-black/12 bg-[#dedcd6] p-4 shadow-[0_14px_35px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d] dark:shadow-none sm:p-5">
       <div className="flex justify-end">
-        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/45 dark:text-white/45" aria-hidden="true">
+        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/55 dark:text-white/55" aria-hidden="true">
           <span>less</span>
           <span className="h-2.5 w-2.5 rounded-[3px] bg-[#a9a3af]" />
           <span className="h-2.5 w-2.5 rounded-[3px] bg-[#d4cddb]" />
@@ -51,7 +90,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
 
       <div className="mt-3 grid min-w-0 grid-cols-7 gap-2 sm:gap-2.5" aria-label="Four weeks of GitHub activity">
         {days.map((day, index) => {
-          const label = `${formatDay(day.date)} · ${day.count.toLocaleString('en-US')} ${unit}`;
+          const label = labelForDay(day, unit);
           const isSelected = day.date === selected?.date;
           const isLatest = index === days.length - 1;
 
@@ -62,18 +101,44 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
               className={`aspect-square min-w-0 rounded-[0.5rem] transition duration-150 hover:-translate-y-0.5 hover:scale-[1.035] focus-visible:-translate-y-0.5 focus-visible:scale-[1.035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/35 dark:focus-visible:ring-white/45 ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-black/20 dark:outline-white/25' : ''} ${isSelected ? 'brightness-[1.03] dark:brightness-110' : ''}`}
               aria-label={label}
               aria-pressed={isSelected}
-              title={label}
-              onPointerEnter={() => setSelectedDate(day.date)}
-              onFocus={() => setSelectedDate(day.date)}
+              onPointerEnter={(event) => {
+                setSelectedDate(day.date);
+                if (finePointer) {
+                  setTooltipDate(day.date);
+                  placeTooltip(event.clientX, event.clientY);
+                }
+              }}
+              onPointerMove={(event) => {
+                if (finePointer) placeTooltip(event.clientX, event.clientY);
+              }}
+              onPointerLeave={() => setTooltipDate(null)}
+              onFocus={(event) => {
+                setSelectedDate(day.date);
+                if (finePointer) {
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  setTooltipDate(day.date);
+                  placeTooltip(rect.right, rect.bottom);
+                }
+              }}
+              onBlur={() => setTooltipDate(null)}
               onClick={() => setSelectedDate(day.date)}
             />
           );
         })}
       </div>
 
-      <p className="mt-3 min-h-4 truncate text-center font-mono text-[10px] text-black/48 dark:text-white/45" aria-live="polite">
+      <div className="mt-3 flex min-h-9 items-center justify-center rounded-lg border border-black/12 bg-[#f4f1ea] px-3 py-2 text-center font-mono text-[10px] font-medium text-black/65 dark:border-white/12 dark:bg-[#202126] dark:text-white/68" aria-live="polite">
         {selectedLabel}
-      </p>
+      </div>
+
+      {finePointer && tooltipLabel ? (
+        <div
+          className="pointer-events-none fixed z-[90] max-w-[13rem] rounded-lg border border-black/18 bg-[#f4f1ea] px-2.5 py-1.5 font-mono text-[10px] font-semibold text-[#242328] shadow-[0_8px_24px_rgba(20,20,24,0.18)] dark:border-white/16 dark:bg-[#202126] dark:text-[#f0ece5]"
+          style={{ left: tooltipPosition.x, top: tooltipPosition.y }}
+        >
+          {tooltipLabel}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -14,14 +14,73 @@ function countdownToMidnight() {
 }
 
 function ScoreDigits({ value }: { value: number }) {
-  const digits = useMemo(() => String(Math.max(0, value)).padStart(4, '0').split(''), [value]);
+  const digits = useMemo(
+    () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
+    [value],
+  );
+  const digitRefs = useRef<Array<HTMLSpanElement | null>>([]);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
+
+  const resetDigits = () => {
+    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    frameRef.current = window.requestAnimationFrame(() => {
+      for (const digit of digitRefs.current) {
+        if (digit) digit.style.transform = 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)';
+      }
+    });
+  };
+
+  const moveDigits = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const containerRect = currentTarget.getBoundingClientRect();
+    const influenceRadius = Math.max(90, containerRect.width * 0.55);
+
+    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    frameRef.current = window.requestAnimationFrame(() => {
+      for (const digit of digitRefs.current) {
+        if (!digit) continue;
+        const rect = digit.getBoundingClientRect();
+        const centreX = rect.left + rect.width / 2;
+        const centreY = rect.top + rect.height / 2;
+        const deltaX = clientX - centreX;
+        const deltaY = clientY - centreY;
+        const distance = Math.hypot(deltaX, deltaY);
+        const influence = Math.max(0, 1 - distance / influenceRadius);
+        const moveX = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1))) * influence * 2.5;
+        const moveY = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1))) * influence * 2;
+        const rotateX = -moveY * 0.55;
+        const rotateY = moveX * 0.55;
+
+        digit.style.transform = `translate3d(${moveX.toFixed(2)}px, ${moveY.toFixed(2)}px, 0) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg)`;
+      }
+    });
+  };
 
   return (
-    <div className="flex min-w-0 gap-1.5 sm:gap-2" aria-label={`${value} contributions today`}>
+    <div
+      className="flex min-w-0 touch-pan-y gap-1.5 sm:gap-2"
+      aria-label={`${value} contributions today`}
+      onPointerMove={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
+      onPointerDown={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
+      onPointerLeave={resetDigits}
+      onPointerCancel={resetDigits}
+      onPointerUp={resetDigits}
+    >
       {digits.map((digit, index) => (
         <span
-          key={`${index}-${digit}`}
-          className="relative flex aspect-[0.72] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(2.6rem,9vw,6.9rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-18px_32px_rgba(0,0,0,0.3),0_8px_20px_rgba(0,0,0,0.15)]"
+          key={index}
+          ref={(element) => {
+            digitRefs.current[index] = element;
+          }}
+          data-activity-digit
+          className="relative flex aspect-[0.76] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(2.35rem,8vw,4.8rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-12px_22px_rgba(0,0,0,0.25),0_4px_12px_rgba(0,0,0,0.14)] transition-transform duration-150 ease-out motion-reduce:transform-none"
+          style={{ transform: 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)' }}
         >
           <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px bg-black/70" />
           <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px -translate-y-px bg-white/[0.045]" />
@@ -42,8 +101,6 @@ export function ActivityScoreboard({
   yearTotal: number | null;
 }) {
   const [countdown, setCountdown] = useState('--:--:--');
-  const panelRef = useRef<HTMLDivElement>(null);
-  const frameRef = useRef<number | null>(null);
 
   useEffect(() => {
     const update = () => setCountdown(countdownToMidnight());
@@ -52,67 +109,24 @@ export function ActivityScoreboard({
     return () => window.clearInterval(interval);
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
-    };
-  }, []);
-
-  const movePanel = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-    const rect = currentTarget.getBoundingClientRect();
-    const x = Math.max(-1, Math.min(1, ((clientX - rect.left) / rect.width - 0.5) * 2));
-    const y = Math.max(-1, Math.min(1, ((clientY - rect.top) / rect.height - 0.5) * 2));
-
-    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
-    frameRef.current = window.requestAnimationFrame(() => {
-      if (!panelRef.current) return;
-      panelRef.current.style.transform = `perspective(900px) rotateX(${(-y * 1.4).toFixed(2)}deg) rotateY(${(x * 1.8).toFixed(2)}deg) translate3d(${(x * 1.4).toFixed(2)}px, ${(y * 1.1).toFixed(2)}px, 0)`;
-    });
-  };
-
-  const resetPanel = () => {
-    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
-    frameRef.current = window.requestAnimationFrame(() => {
-      if (panelRef.current) panelRef.current.style.transform = 'perspective(900px) rotateX(0deg) rotateY(0deg) translate3d(0,0,0)';
-    });
-  };
-
   return (
-    <section
-      className="touch-pan-y overflow-hidden rounded-[1.4rem] border border-black/15 bg-[#d8d5ce] shadow-[0_22px_55px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_24px_70px_rgba(0,0,0,0.35)]"
-      onPointerMove={(event) => movePanel(event.clientX, event.clientY, event.currentTarget)}
-      onPointerDown={(event) => movePanel(event.clientX, event.clientY, event.currentTarget)}
-      onPointerLeave={resetPanel}
-      onPointerCancel={resetPanel}
-    >
-      <div
-        ref={panelRef}
-        className="origin-center transition-transform duration-200 ease-out motion-reduce:transform-none"
-        style={{ transform: 'perspective(900px) rotateX(0deg) rotateY(0deg) translate3d(0,0,0)' }}
-      >
-        <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2.5 dark:border-white/10 dark:bg-[#18191d] sm:px-5">
-          <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/60 dark:text-white/58">
-            <span>Today</span>
-            <span className="tabular-nums">rollover {countdown}</span>
-          </div>
+    <section className="overflow-hidden rounded-[1.25rem] border border-black/15 bg-[#d8d5ce] shadow-[0_14px_34px_rgba(24,24,26,0.11)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_16px_40px_rgba(0,0,0,0.28)]">
+      <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2 dark:border-white/10 dark:bg-[#18191d]">
+        <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-black/60 dark:text-white/58">
+          <span>Today</span>
+          <span className="tabular-nums">resets in {countdown}</span>
         </div>
+      </div>
 
-        <div className="grid gap-4 p-4 sm:p-5 lg:grid-cols-[minmax(0,1fr)_12rem]">
-          <div className="min-w-0">
-            <ScoreDigits value={today} />
-          </div>
-
-          <div className="grid grid-cols-2 gap-2 lg:grid-cols-1">
-            <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
-              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/48 dark:text-white/45">7 days</p>
-              <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{weekTotal.toLocaleString('en-US')}</p>
-            </div>
-            <div className="rounded-xl border border-black/10 bg-[#ece9e2]/70 px-3 py-3 dark:border-white/10 dark:bg-white/[0.035]">
-              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/48 dark:text-white/45">Year</p>
-              <p className="mt-1 text-2xl font-semibold tabular-nums tracking-tight">{yearTotal?.toLocaleString('en-US') ?? '—'}</p>
-            </div>
-          </div>
+      <div className="grid gap-3 p-3.5 sm:p-4">
+        <ScoreDigits value={today} />
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-0.5 font-mono text-[11px] uppercase tracking-[0.11em] text-black/55 dark:text-white/48">
+          <span>
+            7 days <strong className="ml-1 font-semibold text-black/78 dark:text-white/78">{weekTotal.toLocaleString('en-GB')}</strong>
+          </span>
+          <span>
+            Year <strong className="ml-1 font-semibold text-black/78 dark:text-white/78">{yearTotal?.toLocaleString('en-GB') ?? '—'}</strong>
+          </span>
         </div>
       </div>
     </section>

--- a/components/navigation-feedback.tsx
+++ b/components/navigation-feedback.tsx
@@ -62,9 +62,7 @@ export function NavigationFeedback() {
     const prefetch = (href: string) => {
       if (prefetched.current.has(href)) return;
       prefetched.current.add(href);
-      router.prefetch(href, {
-        onInvalidate: () => prefetched.current.delete(href),
-      });
+      router.prefetch(href);
     };
 
     const prefetchFromEvent = (event: Event) => {

--- a/components/navigation-feedback.tsx
+++ b/components/navigation-feedback.tsx
@@ -4,11 +4,26 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 const IDLE_PREFETCH_ROUTES = ['/', '/time', '/gallery', '/blog', '/atelier'];
+const NAVIGATION_START_EVENT = 'scrapbook:navigation-start';
 
 type PendingNavigation = {
   href: string;
   label: string;
 };
+
+type NavigationStartDetail = {
+  href: string;
+  label?: string;
+};
+
+export function startNavigationFeedback(href: string, label?: string) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent<NavigationStartDetail>(NAVIGATION_START_EVENT, {
+      detail: { href, label },
+    }),
+  );
+}
 
 function anchorFromTarget(target: EventTarget | null) {
   return target instanceof Element ? target.closest<HTMLAnchorElement>('a[href]') : null;
@@ -76,6 +91,16 @@ export function NavigationFeedback() {
       setPending({ href, label: destinationLabel(href) });
     };
 
+    const startProgrammaticNavigation = (event: Event) => {
+      const detail = (event as CustomEvent<NavigationStartDetail>).detail;
+      if (!detail?.href) return;
+      prefetch(detail.href);
+      setPending({
+        href: detail.href,
+        label: detail.label ?? destinationLabel(detail.href),
+      });
+    };
+
     const startHistoryNavigation = () => {
       setPending({
         href: `${window.location.pathname}${window.location.search}`,
@@ -87,6 +112,7 @@ export function NavigationFeedback() {
     document.addEventListener('focusin', prefetchFromEvent, true);
     document.addEventListener('pointerdown', prefetchFromEvent, true);
     document.addEventListener('click', startNavigation, true);
+    window.addEventListener(NAVIGATION_START_EVENT, startProgrammaticNavigation);
     window.addEventListener('popstate', startHistoryNavigation);
 
     const idlePrefetch = () => {
@@ -108,6 +134,7 @@ export function NavigationFeedback() {
       document.removeEventListener('focusin', prefetchFromEvent, true);
       document.removeEventListener('pointerdown', prefetchFromEvent, true);
       document.removeEventListener('click', startNavigation, true);
+      window.removeEventListener(NAVIGATION_START_EVENT, startProgrammaticNavigation);
       window.removeEventListener('popstate', startHistoryNavigation);
       if (windowWithIdle.cancelIdleCallback) windowWithIdle.cancelIdleCallback(idleId);
       else window.clearTimeout(idleId);

--- a/components/navigation-feedback.tsx
+++ b/components/navigation-feedback.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const IDLE_PREFETCH_ROUTES = ['/', '/time', '/gallery', '/blog', '/atelier'];
+
+type PendingNavigation = {
+  href: string;
+  label: string;
+};
+
+function anchorFromTarget(target: EventTarget | null) {
+  return target instanceof Element ? target.closest<HTMLAnchorElement>('a[href]') : null;
+}
+
+function internalDestination(anchor: HTMLAnchorElement) {
+  if (anchor.target && anchor.target !== '_self') return null;
+  if (anchor.hasAttribute('download')) return null;
+
+  const url = new URL(anchor.href, window.location.href);
+  if (url.origin !== window.location.origin) return null;
+  if (!['http:', 'https:'].includes(url.protocol)) return null;
+
+  return `${url.pathname}${url.search}`;
+}
+
+function destinationLabel(href: string) {
+  const path = href.split('?')[0];
+  if (path === '/') return 'home';
+  return path.split('/').filter(Boolean).at(-1)?.replaceAll('-', ' ') ?? 'page';
+}
+
+export function NavigationFeedback() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [pending, setPending] = useState<PendingNavigation | null>(null);
+  const prefetched = useRef(new Set<string>());
+  const routeKey = useMemo(() => `${pathname}?${searchParams.toString()}`, [pathname, searchParams]);
+
+  useEffect(() => {
+    setPending(null);
+  }, [routeKey]);
+
+  useEffect(() => {
+    const prefetch = (href: string) => {
+      if (prefetched.current.has(href)) return;
+      prefetched.current.add(href);
+      router.prefetch(href, {
+        onInvalidate: () => prefetched.current.delete(href),
+      });
+    };
+
+    const prefetchFromEvent = (event: Event) => {
+      const anchor = anchorFromTarget(event.target);
+      if (!anchor) return;
+      const href = internalDestination(anchor);
+      if (href) prefetch(href);
+    };
+
+    const startNavigation = (event: MouseEvent) => {
+      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+
+      const anchor = anchorFromTarget(event.target);
+      if (!anchor) return;
+      const href = internalDestination(anchor);
+      if (!href) return;
+
+      const current = `${window.location.pathname}${window.location.search}`;
+      if (href === current || anchor.hash) return;
+
+      prefetch(href);
+      setPending({ href, label: destinationLabel(href) });
+    };
+
+    const startHistoryNavigation = () => {
+      setPending({
+        href: `${window.location.pathname}${window.location.search}`,
+        label: 'previous page',
+      });
+    };
+
+    document.addEventListener('pointerover', prefetchFromEvent, true);
+    document.addEventListener('focusin', prefetchFromEvent, true);
+    document.addEventListener('pointerdown', prefetchFromEvent, true);
+    document.addEventListener('click', startNavigation, true);
+    window.addEventListener('popstate', startHistoryNavigation);
+
+    const idlePrefetch = () => {
+      for (const href of IDLE_PREFETCH_ROUTES) {
+        if (href !== pathname) prefetch(href);
+      }
+    };
+
+    const windowWithIdle = window as typeof window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    const idleId = windowWithIdle.requestIdleCallback
+      ? windowWithIdle.requestIdleCallback(idlePrefetch, { timeout: 1800 })
+      : window.setTimeout(idlePrefetch, 900);
+
+    return () => {
+      document.removeEventListener('pointerover', prefetchFromEvent, true);
+      document.removeEventListener('focusin', prefetchFromEvent, true);
+      document.removeEventListener('pointerdown', prefetchFromEvent, true);
+      document.removeEventListener('click', startNavigation, true);
+      window.removeEventListener('popstate', startHistoryNavigation);
+      if (windowWithIdle.cancelIdleCallback) windowWithIdle.cancelIdleCallback(idleId);
+      else window.clearTimeout(idleId);
+    };
+  }, [pathname, router]);
+
+  useEffect(() => {
+    if (!pending) return;
+    const timeout = window.setTimeout(() => setPending(null), 15_000);
+    return () => window.clearTimeout(timeout);
+  }, [pending]);
+
+  if (!pending) return null;
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-[100]" role="status" aria-live="polite">
+      <div className="h-0.5 overflow-hidden bg-black/10 dark:bg-white/10">
+        <div className="navigation-progress h-full w-2/5 bg-[#6f6878] dark:bg-[#d0c8d7]" />
+      </div>
+      <div className="absolute right-3 top-3 flex items-center gap-2 rounded-lg border border-black/18 bg-[#f4f1ea] px-3 py-2 text-xs font-semibold text-[#242328] shadow-[0_10px_28px_rgba(20,20,24,0.16)] dark:border-white/16 dark:bg-[#18191d] dark:text-[#f0ece5] sm:right-4 sm:top-4">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current motion-reduce:animate-none" />
+        <span>Opening {pending.label}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/proxy/usage-dashboard-container.tsx
+++ b/components/proxy/usage-dashboard-container.tsx
@@ -1,7 +1,7 @@
 import { connection } from 'next/server';
 
 import type { ProxyHealthPayload, ProxyHealthSample } from '@/app/lib/proxy-health-store';
-import { getLatestProxyHealth, getProxyHealthSamples } from '@/app/lib/proxy-health-store';
+import { readProxyHealth } from '@/app/lib/proxy-health-store';
 import { UsageDashboard } from './usage-dashboard';
 
 function usageLimitBytes() {
@@ -30,24 +30,92 @@ function latestStatusSample(payload: ProxyHealthPayload): ProxyHealthSample | nu
   };
 }
 
+function formatTimestamp(value: string | null) {
+  if (!value) return 'Unavailable';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unavailable';
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+    timeZone: 'UTC',
+  }).format(date);
+}
+
+function reportAge(checkedAt: string | null) {
+  if (!checkedAt) return { label: 'Unknown', stale: true };
+  const checked = new Date(checkedAt).getTime();
+  if (!Number.isFinite(checked)) return { label: 'Unknown', stale: true };
+
+  const ageMs = Math.max(0, Date.now() - checked);
+  const staleAfterMinutes = Number(process.env.PROXY_HEALTH_STALE_AFTER_MINUTES ?? '15');
+  const staleAfterMs = (Number.isFinite(staleAfterMinutes) && staleAfterMinutes > 0 ? staleAfterMinutes : 15) * 60_000;
+  const minutes = Math.floor(ageMs / 60_000);
+  const label = minutes < 1 ? 'Under a minute' : minutes < 60 ? `${minutes} minutes` : `${Math.floor(minutes / 60)} hours`;
+  return { label, stale: ageMs > staleAfterMs };
+}
+
+function StateCard({ title, body, requestId }: { title: string; body: string; requestId?: string }) {
+  return (
+    <section className="rounded-2xl border bg-background p-5 shadow-sm" role="status">
+      <h2 className="text-xl font-bold">{title}</h2>
+      <p className="mt-2 text-sm text-muted-foreground">{body}</p>
+      {requestId ? <p className="mt-3 font-mono text-xs text-muted-foreground">Request {requestId}</p> : null}
+    </section>
+  );
+}
+
 export async function UsageDashboardContainer() {
   await connection();
 
-  const [status, samples] = await Promise.all([
-    getLatestProxyHealth('bandwagon-la'),
-    getProxyHealthSamples('bandwagon-la', 35),
-  ]);
+  const result = await readProxyHealth('bandwagon-la', 35);
 
-  if (!status) {
-    return (
-      <div className="rounded-2xl border bg-background p-5 shadow-sm">
-        <h2 className="text-xl font-bold">No report yet</h2>
-      </div>
-    );
+  if (result.status === 'configuration-error') {
+    return <StateCard title="Proxy configuration missing" body={result.message} requestId={result.requestId} />;
   }
 
-  const fallbackSample = latestStatusSample(status.payload);
-  const visibleSamples = samples.length > 0 || !fallbackSample ? samples : [fallbackSample];
+  if (result.status === 'error') {
+    return <StateCard title="Proxy data unavailable" body={result.message} requestId={result.requestId} />;
+  }
 
-  return <UsageDashboard samples={visibleSamples} status={status} limitBytes={usageLimitBytes()} />;
+  if (result.status === 'empty') {
+    return <StateCard title="No report has arrived" body="The database connection succeeded, but this host has no stored report yet." />;
+  }
+
+  const { report, samples } = result;
+  const fallbackSample = latestStatusSample(report.payload);
+  const visibleSamples = samples.length > 0 || !fallbackSample ? samples : [fallbackSample];
+  const age = reportAge(report.checkedAt);
+
+  return (
+    <div className="space-y-3">
+      <section className="rounded-xl border bg-background/80 px-4 py-3 shadow-sm" aria-label="Proxy report freshness">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Report freshness</p>
+            <p className="mt-1 text-sm">
+              Age <span className="font-medium">{age.label}</span>
+            </p>
+          </div>
+          <span
+            className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+              age.stale ? 'border-amber-500/45 bg-amber-500/12' : 'border-emerald-500/45 bg-emerald-500/12'
+            }`}
+          >
+            {age.stale ? 'Stale' : 'Current'}
+          </span>
+        </div>
+        <dl className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+          <div>
+            <dt>Payload checked_at</dt>
+            <dd className="mt-0.5 font-mono text-foreground">{formatTimestamp(report.checkedAt)}</dd>
+          </div>
+          <div>
+            <dt>Row updated_at</dt>
+            <dd className="mt-0.5 font-mono text-foreground">{formatTimestamp(report.updatedAt)}</dd>
+          </div>
+        </dl>
+      </section>
+      <UsageDashboard samples={visibleSamples} status={report} limitBytes={usageLimitBytes()} />
+    </div>
+  );
 }

--- a/components/proxy/usage-dashboard-skeleton.tsx
+++ b/components/proxy/usage-dashboard-skeleton.tsx
@@ -1,0 +1,110 @@
+function Line({ className = '' }: { className?: string }) {
+  return <span className={`block rounded bg-black/10 dark:bg-white/10 ${className}`} aria-hidden="true" />;
+}
+
+function MetricPlaceholder({ label }: { label: string }) {
+  return (
+    <div className="rounded-xl border bg-[#e8e5de] px-3 py-3 dark:bg-[#222329]">
+      <div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">{label}</div>
+      <Line className="mt-2 h-7 w-20" />
+      <Line className="mt-2 h-3 w-24" />
+    </div>
+  );
+}
+
+function ChartPlaceholder({ height = 'h-44', bars = 24 }: { height?: string; bars?: number }) {
+  return (
+    <div className={`flex ${height} items-end gap-1 rounded-lg border bg-[#e8e5de] p-2 dark:bg-[#222329]`} aria-hidden="true">
+      {Array.from({ length: bars }, (_, index) => (
+        <span
+          key={index}
+          className="min-w-0 flex-1 rounded-t bg-black/12 dark:bg-white/12"
+          style={{ height: `${18 + ((index * 17) % 68)}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function UsageDashboardSkeleton() {
+  return (
+    <div className="space-y-3 motion-safe:animate-pulse" aria-label="Loading proxy dashboard" role="status">
+      <section className="rounded-xl border bg-background px-4 py-3 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Report freshness</p>
+            <Line className="mt-2 h-4 w-28" />
+          </div>
+          <Line className="h-7 w-16 rounded-full" />
+        </div>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <div>
+            <p className="text-xs text-muted-foreground">Payload checked_at</p>
+            <Line className="mt-1 h-4 w-48" />
+          </div>
+          <div>
+            <p className="text-xs text-muted-foreground">Row updated_at</p>
+            <Line className="mt-1 h-4 w-48" />
+          </div>
+        </div>
+      </section>
+
+      <div className="grid gap-3 xl:grid-cols-4">
+        <section className="rounded-2xl border bg-background p-3 shadow-sm xl:col-span-4">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <Line className="h-7 w-20 rounded-full" />
+              <Line className="h-4 w-12" />
+            </div>
+            <Line className="h-4 w-28" />
+          </div>
+
+          <div className="grid gap-3 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.85fr)]">
+            <div className="flex min-h-36 items-center gap-4 rounded-xl border bg-[#e8e5de] p-3 dark:bg-[#222329]">
+              <div className="h-28 w-28 shrink-0 rounded-full border-[11px] border-black/10 dark:border-white/10" />
+              <div className="min-w-0 flex-1">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Cycle</p>
+                <Line className="mt-2 h-9 w-48 max-w-full" />
+                <Line className="mt-2 h-3 w-28" />
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+              <MetricPlaceholder label="24h" />
+              <MetricPlaceholder label="Room / day" />
+              <MetricPlaceholder label="Latency" />
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-xl border bg-background p-3 shadow-sm xl:col-span-4">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Bandwidth</p>
+            <Line className="h-4 w-24" />
+          </div>
+          <div className="mb-3 grid grid-cols-3 gap-1 rounded-full border bg-[#e8e5de] p-1 dark:bg-[#222329]">
+            <Line className="h-7 rounded-full" />
+            <Line className="h-7 rounded-full" />
+            <Line className="h-7 rounded-full" />
+          </div>
+          <ChartPlaceholder />
+        </section>
+
+        <section className="rounded-xl border bg-background p-3 shadow-sm xl:col-span-4">
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Latency</p>
+          <div className="grid gap-2 lg:grid-cols-[0.85fr_1.15fr]">
+            <div className="grid grid-cols-3 gap-2 rounded-lg border bg-[#e8e5de] p-2 dark:bg-[#222329]">
+              <MetricPlaceholder label="Primary" />
+              <MetricPlaceholder label="Egress" />
+              <MetricPlaceholder label="Total" />
+            </div>
+            <div>
+              <p className="mb-2 text-xs font-medium text-muted-foreground">Primary + Egress · 24h</p>
+              <ChartPlaceholder height="h-24" />
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/proxy/usage-page.tsx
+++ b/components/proxy/usage-page.tsx
@@ -1,5 +1,7 @@
 import ViewportPageShell from '@/components/viewport-page-shell';
+import { Suspense } from 'react';
 import { UsageDashboardContainer } from './usage-dashboard-container';
+import { UsageDashboardSkeleton } from './usage-dashboard-skeleton';
 
 export function UsagePage() {
   return (
@@ -16,7 +18,9 @@ export function UsagePage() {
             <h1 className="mt-0.5 text-xl font-bold tracking-tight">Usage</h1>
           </div>
         </div>
-        <UsageDashboardContainer />
+        <Suspense fallback={<UsageDashboardSkeleton />}>
+          <UsageDashboardContainer />
+        </Suspense>
       </div>
     </ViewportPageShell>
   );

--- a/components/proxy/usage-page.tsx
+++ b/components/proxy/usage-page.tsx
@@ -1,6 +1,4 @@
-import { Suspense } from 'react';
 import ViewportPageShell from '@/components/viewport-page-shell';
-import { CheckInStatus } from './check-in-status';
 import { UsageDashboardContainer } from './usage-dashboard-container';
 
 export function UsagePage() {
@@ -12,18 +10,13 @@ export function UsagePage() {
       <div className="mx-auto w-full max-w-7xl px-4 py-4 pb-10 sm:px-6 lg:px-8">
         <div className="mb-3 flex items-end justify-between gap-4">
           <div>
-            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/48 dark:text-white/45">
+            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/55 dark:text-white/55">
               Proxy dashboard
             </p>
             <h1 className="mt-0.5 text-xl font-bold tracking-tight">Usage</h1>
           </div>
-          <Suspense fallback={null}>
-            <CheckInStatus />
-          </Suspense>
         </div>
-        <Suspense fallback={null}>
-          <UsageDashboardContainer />
-        </Suspense>
+        <UsageDashboardContainer />
       </div>
     </ViewportPageShell>
   );

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -29,7 +29,8 @@ export function TimeLink() {
   return (
     <Link
       href="/time"
-      className="group flex shrink-0 items-center gap-1.5 rounded-full border bg-muted/40 px-2 py-1 text-xs font-semibold text-muted-foreground shadow-sm transition hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      prefetch
+      className="group flex shrink-0 items-center gap-1.5 rounded-full border bg-muted/70 px-2 py-1 text-xs font-semibold text-foreground shadow-sm transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
       title="Open the time converter"
       aria-label={`Open the time converter. Local time ${time}`}
     >
@@ -41,6 +42,7 @@ export function TimeLink() {
 
 export function NavMenu({ label, children }: { label: string; children: ReactNode }) {
   const detailsRef = useRef<HTMLDetailsElement>(null);
+  const summaryRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     const closeOnOutsideTap = (event: PointerEvent) => {
@@ -53,6 +55,7 @@ export function NavMenu({ label, children }: { label: string; children: ReactNod
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && detailsRef.current?.open) {
         detailsRef.current.open = false;
+        summaryRef.current?.focus();
       }
     };
 
@@ -66,11 +69,11 @@ export function NavMenu({ label, children }: { label: string; children: ReactNod
 
   return (
     <details ref={detailsRef} className="group relative min-w-0">
-      <summary className="flex cursor-pointer list-none items-center gap-1 rounded-full px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+      <summary ref={summaryRef} className="flex cursor-pointer list-none items-center gap-1 rounded-full px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <span>{label}</span>
         <ChevronDown size={14} className="transition-transform group-open:rotate-180" />
       </summary>
-      <div className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border bg-background/96 p-1 shadow-xl backdrop-blur">
+      <div className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border border-black/15 bg-[#f4f1ea] p-1 text-[#242328] shadow-xl dark:border-white/15 dark:bg-[#18191d] dark:text-[#f0ece5]">
         {children}
       </div>
     </details>
@@ -78,8 +81,12 @@ export function NavMenu({ label, children }: { label: string; children: ReactNod
 }
 
 async function copyDiscord() {
-  await navigator.clipboard.writeText('teamleaderleo');
-  toast.success('Discord username copied', { description: 'teamleaderleo' });
+  try {
+    await navigator.clipboard.writeText('teamleaderleo');
+    toast.success('Discord username copied', { description: 'teamleaderleo' });
+  } catch {
+    toast.error('Could not copy the Discord username', { description: 'teamleaderleo' });
+  }
 }
 
 const discordHover =
@@ -91,8 +98,8 @@ export function DiscordButton({ menu = false }: { menu?: boolean }) {
       onClick={() => void copyDiscord()}
       className={
         menu
-          ? `flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted focus:bg-muted focus:outline-none ${discordHover}`
-          : `flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors focus:outline-none ${discordHover}`
+          ? `flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted focus:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${discordHover}`
+          : `flex items-center gap-1.5 rounded-sm text-sm font-medium text-muted-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${discordHover}`
       }
       type="button"
     >

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -31,7 +31,7 @@ const siteLinks: NavLinkItem[] = [
   },
   {
     href: '/gallery',
-    label: 'cube',
+    label: 'gallery',
     icon: <Box size={15} />,
     hoverClass: 'hover:text-foreground focus:text-foreground',
   },
@@ -80,7 +80,8 @@ function MenuLink({ item }: { item: NavLinkItem }) {
   return (
     <Link
       {...navLinkProps(item)}
-      className={`flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted focus:bg-muted focus:outline-none ${item.hoverClass}`}
+      prefetch={item.external ? false : true}
+      className={`flex items-center gap-2 rounded-lg px-2.5 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted focus:bg-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${item.hoverClass}`}
     >
       <span className="shrink-0">{item.icon}</span>
       <span className="whitespace-nowrap">{item.label}</span>
@@ -92,7 +93,8 @@ function InlineLink({ item }: { item: NavLinkItem }) {
   return (
     <Link
       {...navLinkProps(item)}
-      className={`flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors focus:outline-none ${item.hoverClass}`}
+      prefetch={item.external ? false : true}
+      className={`flex items-center gap-1.5 rounded-sm text-sm font-medium text-muted-foreground transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${item.hoverClass}`}
     >
       <span className="shrink-0">{item.icon}</span>
       <span>{item.label}</span>
@@ -113,7 +115,7 @@ export default function SiteNav() {
     <nav className="min-w-0 border-b bg-background text-foreground">
       <div className="mx-auto max-w-7xl px-3 sm:px-6 lg:px-8">
         <div className="flex h-12 min-w-0 items-center justify-between gap-2 sm:gap-3">
-          <Link href="/" className="min-w-0 shrink truncate text-base font-bold sm:text-lg">
+          <Link href="/" prefetch className="min-w-0 shrink truncate rounded-sm text-base font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-lg">
             teamleaderleo
           </Link>
 

--- a/components/space/review-gallery.tsx
+++ b/components/space/review-gallery.tsx
@@ -27,6 +27,9 @@ export function ReviewGallery() {
     hasMore,
     loadMore,
     loadingMore,
+    refreshing,
+    error,
+    reload,
   } = useItems();
   const nowMs = useNow(initialNowMs, 30_000);
   const sp = useSearchParams();
@@ -81,10 +84,12 @@ export function ReviewGallery() {
       if (isTyping || event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
 
       if (event.key === 'ArrowRight' || event.key === 'j') {
+        event.preventDefault();
         setCurrentIndex((index) => Math.min(index + 1, items.length - 1));
         setShowContent(true);
       }
       if (event.key === 'ArrowLeft' || event.key === 'k') {
+        event.preventDefault();
         setCurrentIndex((index) => Math.max(index - 1, 0));
         setShowContent(true);
       }
@@ -107,7 +112,7 @@ export function ReviewGallery() {
     const next = reviewOnce(current.review, rating, Date.now());
     setMutations((previous) => ({ ...previous, [current.id]: next }));
 
-    await supabase.from('reviews').upsert({
+    const { error: reviewError } = await supabase.from('reviews').upsert({
       item_id: current.id,
       state: next.state,
       due: next.due,
@@ -121,6 +126,11 @@ export function ReviewGallery() {
       suspended: next.suspended || false,
     });
 
+    if (reviewError) {
+      console.error('Failed to save review:', reviewError);
+      return;
+    }
+
     if (currentIndex < items.length - 1) {
       setCurrentIndex((index) => index + 1);
       setShowContent(true);
@@ -131,47 +141,72 @@ export function ReviewGallery() {
     return (
       <div className="flex h-full min-h-0 flex-col">
         <SpaceHeader
-          leftContent={loadingMore ? 'Loading items…' : 'No items'}
+          leftContent={refreshing || loadingMore ? 'Updating items…' : 'No items'}
           onEditorToggle={() => setEditorOpen(!editorOpen)}
           isEditorOpen={editorOpen}
         />
         <div className="p-4 text-muted-foreground">
-          {loadingMore ? 'Loading items…' : 'No items to review'}
+          {error ? (
+            <div className="flex max-w-xl items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm text-foreground" role="alert">
+              <span>{error}</span>
+              <Button variant="outline" size="sm" onClick={() => void reload()}>
+                Retry
+              </Button>
+            </div>
+          ) : refreshing || loadingMore ? (
+            'Updating items…'
+          ) : (
+            'No items to review'
+          )}
         </div>
       </div>
     );
   }
 
+  const progress = `${currentIndex + 1} / ${items.length}${hasMore ? '+' : ''}${refreshing ? ' · Updating' : ''}`;
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <SpaceHeader
-        leftContent={`${currentIndex + 1} / ${items.length}${hasMore ? '+' : ''}`}
+        leftContent={progress}
         onEditorToggle={() => setEditorOpen(!editorOpen)}
         isEditorOpen={editorOpen}
         rightContent={
           isAdmin ? (
             <>
               <Button asChild variant="outline" size="sm">
-                <Link href={`/space/edit/${current.slug}`}>edit</Link>
+                <Link href={`/space/edit/${current.slug}`} prefetch>edit</Link>
               </Button>
               <Button asChild variant="outline" size="sm">
-                <Link href={`/space/add?duplicate=${current.slug}`}>duplicate</Link>
+                <Link href={`/space/add?duplicate=${current.slug}`} prefetch>duplicate</Link>
               </Button>
             </>
           ) : undefined
         }
       />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-6">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3 sm:p-6">
+        {error ? (
+          <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm" role="alert">
+            <span className="min-w-0">{error}</span>
+            <Button variant="outline" size="sm" className="shrink-0" onClick={() => void reload()}>
+              Retry
+            </Button>
+          </div>
+        ) : null}
+
         <h1 className="mb-4 text-2xl font-bold text-foreground">{current.title}</h1>
 
         {current.versions.length > 1 && (
-          <div className="mb-4 flex gap-2 text-sm">
+          <div className="mb-4 flex flex-wrap gap-2 text-sm">
             {current.versions.map((version, index) => (
               <button
                 key={index}
+                type="button"
                 onMouseEnter={() => setActiveIdx(index)}
-                className={`rounded border px-3 py-1.5 transition-colors ${
+                onFocus={() => setActiveIdx(index)}
+                onClick={() => setActiveIdx(index)}
+                className={`rounded border px-3 py-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                   index === activeIdx
                     ? 'border-accent bg-accent text-accent-foreground'
                     : 'border-border hover:bg-muted'
@@ -184,8 +219,8 @@ export function ReviewGallery() {
         )}
 
         {showContent && active && (
-          <div className="flex min-h-0 flex-1 gap-4 overflow-hidden">
-            <div className="flex-1 overflow-auto rounded border border-border bg-white p-4 dark:border-sidebar-border dark:bg-sidebar">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto lg:flex-row lg:overflow-hidden">
+            <div className="min-h-48 min-w-0 flex-1 overflow-auto rounded border border-border bg-white p-4 dark:border-sidebar-border dark:bg-sidebar">
               <div className="prose prose-sm max-w-none dark:prose-invert">
                 <MarkdownContent
                   html={active.contentHtml}
@@ -197,13 +232,13 @@ export function ReviewGallery() {
           </div>
         )}
 
-        <div className="mt-4 flex items-center justify-between">
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
           <div className="text-sm text-muted-foreground">
             ← → or j/k to navigate · Space to {showContent ? 'hide' : 'show'} content
           </div>
 
           {isAdmin && current.review && (
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <button
                 onClick={() => void onReview(Rating.Again)}
                 className="rounded border border-border px-3 py-1 transition-colors hover:bg-muted"

--- a/components/space/search-command.tsx
+++ b/components/space/search-command.tsx
@@ -17,6 +17,7 @@ import { parseQuery } from '@/app/lib/searchlang';
 import { searchItems } from '@/app/lib/item-search';
 import type { Item } from '@/app/lib/item-types';
 import { Download, Plus, Search } from 'lucide-react';
+import { startNavigationFeedback } from '@/components/navigation-feedback';
 
 function filterItems(allItems: Item[], search: string, nowMs: number): Item[] {
   if (!search) return allItems.slice(0, 50);
@@ -71,15 +72,19 @@ export function SearchCommand() {
   const filteredItems = filterItems(items, search, nowMs);
 
   const handleSelect = (item: Item) => {
+    const href = `/space/review?item=${item.id}`;
     setOpen(false);
     setSearch('');
-    router.push(`/space/review?item=${item.id}`);
+    startNavigationFeedback(href, 'review');
+    router.push(href);
   };
 
   const handleSearchWithQuery = () => {
     if (!search) return;
+    const href = `/space?tags=${encodeURIComponent(search)}`;
     setOpen(false);
-    router.push(`/space?tags=${encodeURIComponent(search)}`);
+    startNavigationFeedback(href, 'filtered list');
+    router.push(href);
     setSearch('');
   };
 
@@ -130,6 +135,7 @@ export function SearchCommand() {
             <CommandItem
               onSelect={() => {
                 setOpen(false);
+                startNavigationFeedback('/space/add', 'new item');
                 router.push('/space/add');
               }}
             >

--- a/components/space/space-shell-skeleton.tsx
+++ b/components/space/space-shell-skeleton.tsx
@@ -1,0 +1,84 @@
+function Line({ className = '' }: { className?: string }) {
+  return <span className={`block rounded bg-black/10 dark:bg-white/10 ${className}`} aria-hidden="true" />;
+}
+
+function SidebarRows({ count }: { count: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: count }, (_, index) => (
+        <div key={index} className="flex h-9 items-center gap-2 rounded-md px-3">
+          <Line className="h-4 w-4 shrink-0 rounded-sm" />
+          <Line className={`h-4 ${index % 3 === 0 ? 'w-28' : index % 3 === 1 ? 'w-20' : 'w-24'}`} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ItemRow({ index }: { index: number }) {
+  return (
+    <li className="rounded border border-border bg-white p-3 dark:border-sidebar-border dark:bg-sidebar">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <Line className={`h-5 ${index % 2 === 0 ? 'w-44' : 'w-56'} max-w-full`} />
+            <Line className="h-7 w-12" />
+            <Line className="h-7 w-14" />
+          </div>
+          <Line className="mt-2 h-3 w-64 max-w-full" />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Line className="h-3 w-14" />
+          <Line className="h-4 w-4" />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function SpaceShellSkeleton() {
+  return (
+    <div className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground motion-safe:animate-pulse" role="status" aria-label="Loading Space">
+      <aside className="hidden h-full w-64 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground md:flex">
+        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
+          <span className="text-lg font-bold leading-none">teamleaderleo</span>
+          <Line className="h-8 w-8 rounded-md" />
+        </div>
+        <div className="shrink-0 border-b p-3">
+          <div className="flex h-10 items-center gap-2 rounded-md bg-muted/60 px-3">
+            <Line className="h-4 w-4" />
+            <Line className="h-4 w-20" />
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden py-3">
+          <p className="px-4 text-xs font-medium text-muted-foreground">View</p>
+          <SidebarRows count={2} />
+          <p className="mt-4 px-4 text-xs font-medium text-muted-foreground">Shortcuts</p>
+          <SidebarRows count={6} />
+        </div>
+        <div className="shrink-0 space-y-2 border-t p-3">
+          <Line className="h-4 w-36" />
+          <Line className="h-9 w-full" />
+        </div>
+      </aside>
+
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <header className="flex h-12 shrink-0 items-center justify-between border-b bg-background px-3 sm:px-4">
+          <div className="flex items-center gap-3">
+            <Line className="h-8 w-8 rounded-md md:hidden" />
+            <Line className="h-4 w-24" />
+          </div>
+          <Line className="h-8 w-20" />
+        </header>
+
+        <main className="min-h-0 flex-1 overflow-hidden px-3 py-3 sm:p-4">
+          <ul className="space-y-2">
+            {Array.from({ length: 7 }, (_, index) => (
+              <ItemRow key={index} index={index} />
+            ))}
+          </ul>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -31,6 +31,9 @@ export function SpaceView() {
     hasMore,
     loadMore,
     loadingMore,
+    refreshing,
+    error,
+    reload,
   } = useItems();
   const nowMs = useNow(initialNowMs, 30_000);
 
@@ -60,6 +63,7 @@ export function SpaceView() {
   const totalPages = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
   const itemCount = `${items.length}${hasMore ? '+' : ''}`;
   const headerStatus = tagsParam ? `${itemCount} · ${tagsParam}` : `${itemCount} items`;
+  const visibleHeaderStatus = refreshing ? `${headerStatus} · Updating` : headerStatus;
 
   useEffect(() => {
     if (page >= totalPages && hasMore && !loadingMore) {
@@ -111,14 +115,14 @@ export function SpaceView() {
 
       setMutations((previous) => ({ ...previous, [id]: initialReview }));
 
-      const { error } = await supabase.from('reviews').insert({
+      const { error: enrollError } = await supabase.from('reviews').insert({
         item_id: id,
         user_id: user?.id || null,
         ...initialReview,
       });
 
-      if (error) {
-        console.error('Failed to enroll:', error);
+      if (enrollError) {
+        console.error('Failed to enroll:', enrollError);
         setMutations((previous) => {
           const { [id]: _removed, ...rest } = previous;
           return rest;
@@ -139,7 +143,7 @@ export function SpaceView() {
       debugCard(next, 'AFTER');
       setMutations((previous) => ({ ...previous, [id]: next }));
 
-      const { error } = await supabase.from('reviews').upsert({
+      const { error: reviewError } = await supabase.from('reviews').upsert({
         item_id: id,
         user_id: user?.id || null,
         state: next.state,
@@ -154,7 +158,7 @@ export function SpaceView() {
         suspended: next.suspended || false,
       });
 
-      if (error) console.error('Failed to save review:', error);
+      if (reviewError) console.error('Failed to save review:', reviewError);
     },
     [allItems, mutations, nowMs, supabase],
   );
@@ -162,11 +166,20 @@ export function SpaceView() {
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <SpaceHeader
-        leftContent={headerStatus}
+        leftContent={visibleHeaderStatus}
         onEditorToggle={() => setEditorOpen(!editorOpen)}
         isEditorOpen={editorOpen}
       />
       <main className="min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:p-4">
+        {error ? (
+          <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm" role="alert">
+            <span className="min-w-0">{error}</span>
+            <Button variant="outline" size="sm" className="shrink-0" onClick={() => void reload()}>
+              Retry
+            </Button>
+          </div>
+        ) : null}
+
         <ResultsClient
           items={paginatedItems}
           onReview={onReview}

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -6,7 +6,7 @@ import CurrentTimeDisplay from './current-time-display';
 import { isDSTActive } from '@/app/lib/dst-utils';
 
 const DAY_GRADIENT =
-  'linear-gradient(90deg, #151720 0%, #252438 9%, #4d3c59 18%, #806073 28%, #bc8476 38%, #e0b982 46%, #eee2b8 50%, #dfba82 56%, #bd8577 64%, #806073 73%, #4d3c59 82%, #252438 91%, #151720 100%)';
+  'linear-gradient(90deg, #151720 0%, #252938 9%, #493f55 18%, #715767 28%, #9f6f68 38%, #bd916c 46%, #c9a574 50%, #bd916c 56%, #9f6f68 64%, #715767 73%, #493f55 82%, #252938 91%, #151720 100%)';
 
 export default function UTCTimeVisualizer() {
   const [localTime, setLocalTime] = useState(0);
@@ -49,23 +49,16 @@ export default function UTCTimeVisualizer() {
             : 'Night';
 
   return (
-    <div className="relative mx-auto flex min-h-full w-full max-w-5xl items-center px-4 py-8 sm:px-6">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-20"
-        style={{
-          backgroundImage:
-            'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
-          backgroundSize: '28px 28px',
-        }}
-      />
-
-      <div className="relative w-full rounded-[1.5rem] border border-black/12 bg-[#dedcd6]/82 p-5 shadow-[0_22px_60px_rgba(24,24,26,0.11)] dark:border-white/10 dark:bg-[#18191d]/92 dark:shadow-[0_24px_70px_rgba(0,0,0,0.34)] sm:p-7">
+    <div className="mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-5xl items-center px-4 py-8 sm:px-6">
+      <div className="w-full rounded-[1.5rem] border border-black/12 bg-[#dedcd6] p-5 shadow-[0_18px_46px_rgba(24,24,26,0.1)] dark:border-white/10 dark:bg-[#18191d] dark:shadow-[0_20px_48px_rgba(0,0,0,0.3)] sm:p-7">
         <CurrentTimeDisplay onJumpToTime={setLocalTime} />
 
         <div className="mt-7">
           <div className="mb-3 flex items-center justify-between gap-3">
-            <label htmlFor="time-of-day" className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/50 dark:text-white/48">
+            <label
+              htmlFor="time-of-day"
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/50 dark:text-white/48"
+            >
               Local time of day
             </label>
             <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/45 dark:text-white/42">
@@ -82,7 +75,7 @@ export default function UTCTimeVisualizer() {
             onChange={(event) => setLocalTime(Number.parseInt(event.target.value, 10))}
             aria-label="Local time of day"
             aria-valuetext={`${formatTime(localHours, localMinutes)} ${timeOfDay}`}
-            className="time-day-slider h-16 w-full cursor-pointer rounded-full"
+            className="time-day-slider h-14 w-full cursor-pointer rounded-full"
             style={{ background: DAY_GRADIENT }}
           />
           <div className="mt-2 flex justify-between font-mono text-[10px] text-black/45 dark:text-white/42">
@@ -95,7 +88,7 @@ export default function UTCTimeVisualizer() {
         </div>
 
         <div className="mt-7 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
-          <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-4 dark:border-white/10 dark:bg-white/[0.035]">
+          <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-4 dark:border-white/10 dark:bg-[#202126]">
             <div className="flex items-end gap-3">
               <p className="font-mono text-5xl font-semibold tabular-nums tracking-[-0.05em] sm:text-6xl">
                 {formatTime(localHours, localMinutes)}
@@ -108,17 +101,17 @@ export default function UTCTimeVisualizer() {
           </div>
 
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+            <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-3 dark:border-white/10 dark:bg-[#202126]">
               <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">UTC</p>
               <p className="mt-1 text-2xl font-semibold tabular-nums">{formatTime(utcHours, utcMinutes)}</p>
             </div>
-            <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+            <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-3 dark:border-white/10 dark:bg-[#202126]">
               <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">Eastern</p>
               <p className="mt-1 text-2xl font-semibold tabular-nums">
                 {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
               </p>
             </div>
-            <div className="rounded-xl border border-black/10 bg-[#f1eee7]/64 p-3 dark:border-white/10 dark:bg-white/[0.035]">
+            <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-3 dark:border-white/10 dark:bg-[#202126]">
               <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">Pacific</p>
               <p className="mt-1 text-2xl font-semibold tabular-nums">
                 {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}

--- a/components/viewport-page-shell.tsx
+++ b/components/viewport-page-shell.tsx
@@ -14,17 +14,23 @@ export default function ViewportPageShell({
   contentClassName = '',
   scroll = 'page',
 }: ViewportPageShellProps) {
-  const overflowClass =
-    scroll === 'locked'
-      ? 'overflow-hidden'
-      : 'overflow-x-hidden overflow-y-auto overscroll-contain';
+  if (scroll === 'locked') {
+    return (
+      <div
+        className={`grid h-dvh min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden ${className}`}
+      >
+        <SiteNav />
+        <main className={`min-h-0 min-w-0 overflow-hidden ${contentClassName}`}>
+          {children}
+        </main>
+      </div>
+    );
+  }
 
   return (
-    <main
-      className={`grid h-dvh min-w-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden ${className}`}
-    >
+    <div className={`min-h-dvh min-w-0 overflow-x-clip ${className}`}>
       <SiteNav />
-      <div className={`min-h-0 min-w-0 ${overflowClass} ${contentClassName}`}>{children}</div>
-    </main>
+      <main className={`min-w-0 ${contentClassName}`}>{children}</main>
+    </div>
   );
 }

--- a/drizzle/0008_proxy_health.sql
+++ b/drizzle/0008_proxy_health.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS "proxy_health_status" (
+  "host" text PRIMARY KEY NOT NULL,
+  "payload" jsonb NOT NULL,
+  "checked_at" timestamp with time zone,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "proxy_health_samples" (
+  "id" bigserial PRIMARY KEY NOT NULL,
+  "host" text NOT NULL,
+  "checked_at" timestamp with time zone NOT NULL,
+  "mode" text,
+  "rx_bytes" bigint,
+  "tx_bytes" bigint,
+  "public_latency_ms" double precision,
+  "wg_latency_ms" double precision,
+  "shanghai_bandwagon_ms" double precision,
+  "shanghai_linode_ms" double precision,
+  "payload" jsonb NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "proxy_health_samples_host_checked_idx"
+ON "proxy_health_samples" USING btree ("host", "checked_at" DESC NULLS LAST);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1722738392923,
       "tag": "0007_rich_boom_boom",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1785081600000,
+      "tag": "0008_proxy_health",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/github-activity-utils.ts
+++ b/lib/github-activity-utils.ts
@@ -1,4 +1,4 @@
-const DISPLAY_TIME_ZONE = 'America/Los_Angeles';
+const DISPLAY_TIME_ZONE = 'UTC';
 
 export function dateKeyInTimeZone(date: Date, timeZone = DISPLAY_TIME_ZONE): string {
   const parts = new Intl.DateTimeFormat('en-CA', {

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -29,15 +29,15 @@ describe('parsePublicContributionHtml', () => {
 });
 
 describe('getRecentDateKeys', () => {
-  it('uses Pacific calendar dates before local midnight', () => {
+  it('uses the GitHub UTC contribution date', () => {
     const days = getRecentDateKeys(new Date('2026-07-25T06:30:00Z'));
-    expect(days.at(-1)).toBe('2026-07-24');
+    expect(days.at(-1)).toBe('2026-07-25');
     expect(days).toHaveLength(7);
   });
 
-  it('rolls over at Pacific midnight', () => {
-    const days = getRecentDateKeys(new Date('2026-07-25T07:30:00Z'));
-    expect(days.at(-1)).toBe('2026-07-25');
+  it('rolls over at UTC midnight', () => {
+    expect(getRecentDateKeys(new Date('2026-07-24T23:59:59Z')).at(-1)).toBe('2026-07-24');
+    expect(getRecentDateKeys(new Date('2026-07-25T00:00:01Z')).at(-1)).toBe('2026-07-25');
   });
 
   it('supports the 35-day homepage window', () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
   webServer: {
     command: 'pnpm dev',

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -52,6 +52,33 @@ for (const route of publicRoutes) {
   });
 }
 
+test('slow navigation keeps the current page visible with immediate feedback', async ({ page }) => {
+  let releaseNavigation!: () => void;
+  const navigationGate = new Promise<void>((resolve) => {
+    releaseNavigation = resolve;
+  });
+
+  await page.route(
+    (url) => url.pathname === '/time',
+    async (route) => {
+      await navigationGate;
+      await route.continue();
+    },
+  );
+
+  await page.goto('/');
+  const activity = page.locator('[aria-label="Four weeks of GitHub activity"]');
+  await expect(activity).toBeVisible();
+
+  await page.getByRole('link', { name: /Open the time converter/i }).click();
+  await expect(page.getByText('Opening time')).toBeVisible();
+  await expect(activity).toBeVisible();
+
+  releaseNavigation();
+  await expect(page.locator('input[type="range"]')).toBeVisible();
+  await expect(page.getByText('Opening time')).toBeHidden();
+});
+
 test('homepage wheel scrolls over the activity grid', async ({ page }) => {
   await expectWheelScrollsDocument(page, '/', '[aria-label="Four weeks of GitHub activity"]');
 });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const publicRoutes = ['/', '/time', '/blog', '/gallery', '/atelier'];
+const idleDigitTransform = 'translate3d(0px, 0px, 0px) rotateX(0deg) rotateY(0deg)';
 
 async function expectNoHorizontalOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({
@@ -39,6 +40,24 @@ async function expectWheelScrollsDocument(page: Page, route: string, selector: s
     .toBeGreaterThan(scrollState.top);
 }
 
+async function moveActivityDigits(page: Page) {
+  const digits = page.locator('[data-activity-digit]');
+  await expect(digits).toHaveCount(4);
+  const container = digits.first().locator('..');
+  const box = await container.boundingBox();
+  expect(box).toBeTruthy();
+
+  await container.dispatchEvent('pointermove', {
+    bubbles: true,
+    clientX: box!.x + box!.width * 0.14,
+    clientY: box!.y + box!.height * 0.22,
+    pointerId: 1,
+    pointerType: 'mouse',
+  });
+
+  return digits;
+}
+
 for (const route of publicRoutes) {
   test(`${route} renders`, async ({ page }) => {
     const response = await page.goto(route);
@@ -70,13 +89,18 @@ test('slow navigation keeps the current page visible with immediate feedback', a
   const activity = page.locator('[aria-label="Four weeks of GitHub activity"]');
   await expect(activity).toBeVisible();
 
-  await page
-    .getByRole('link', { name: /Open the time converter/i })
-    .evaluate((link: HTMLAnchorElement) => link.click());
-  await expect(page.getByText('Opening time')).toBeVisible();
-  await expect(activity).toBeVisible();
+  try {
+    const timeLink = page.getByRole('link', { name: /Open the time converter/i });
+    const box = await timeLink.boundingBox();
+    expect(box).toBeTruthy();
+    await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
 
-  releaseNavigation();
+    await expect(page.getByText('Opening time')).toBeVisible();
+    await expect(activity).toBeVisible();
+  } finally {
+    releaseNavigation();
+  }
+
   await expect(page.locator('input[type="range"]')).toBeVisible();
   await expect(page.getByText('Opening time')).toBeHidden();
 });
@@ -94,34 +118,30 @@ test('gallery wheel scrolls over the canvas', async ({ page }) => {
 });
 
 test('homepage counter uses four independently reactive digits', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
   await page.goto('/');
-  const digits = page.locator('[data-activity-digit]');
-  await expect(digits).toHaveCount(4);
+  const digits = await moveActivityDigits(page);
 
-  const firstBox = await digits.first().boundingBox();
-  expect(firstBox).toBeTruthy();
-  await page.mouse.move(firstBox!.x + firstBox!.width * 0.82, firstBox!.y + firstBox!.height * 0.28);
-  await page.waitForTimeout(200);
+  await expect
+    .poll(() => digits.first().evaluate((element) => (element as HTMLElement).style.transform))
+    .not.toBe(idleDigitTransform);
 
   const transforms = await digits.evaluateAll((elements) =>
     elements.map((element) => (element as HTMLElement).style.transform),
   );
+  expect(new Set(transforms).size).toBeGreaterThan(1);
   expect(transforms[0]).not.toEqual(transforms[3]);
 });
 
 test('homepage counter respects reduced motion', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/');
-  const digits = page.locator('[data-activity-digit]');
-  const firstBox = await digits.first().boundingBox();
-  expect(firstBox).toBeTruthy();
-  await page.mouse.move(firstBox!.x + firstBox!.width * 0.82, firstBox!.y + firstBox!.height * 0.28);
-  await page.waitForTimeout(100);
+  const digits = await moveActivityDigits(page);
 
   const transforms = await digits.evaluateAll((elements) =>
     elements.map((element) => (element as HTMLElement).style.transform),
   );
-  expect(new Set(transforms)).toEqual(new Set(['translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)']));
+  expect(new Set(transforms)).toEqual(new Set([idleDigitTransform]));
 });
 
 test('homepage activity stays inside a mobile viewport', async ({ page }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -70,7 +70,7 @@ test('slow navigation keeps the current page visible with immediate feedback', a
   const activity = page.locator('[aria-label="Four weeks of GitHub activity"]');
   await expect(activity).toBeVisible();
 
-  await page.getByRole('link', { name: /Open the time converter/i }).click();
+  await page.getByRole('link', { name: /Open the time converter/i }).click({ noWaitAfter: true });
   await expect(page.getByText('Opening time')).toBeVisible();
   await expect(activity).toBeVisible();
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -70,7 +70,9 @@ test('slow navigation keeps the current page visible with immediate feedback', a
   const activity = page.locator('[aria-label="Four weeks of GitHub activity"]');
   await expect(activity).toBeVisible();
 
-  await page.getByRole('link', { name: /Open the time converter/i }).click({ noWaitAfter: true });
+  await page
+    .getByRole('link', { name: /Open the time converter/i })
+    .evaluate((link: HTMLAnchorElement) => link.click());
   await expect(page.getByText('Opening time')).toBeVisible();
   await expect(activity).toBeVisible();
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,6 +1,43 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 const publicRoutes = ['/', '/time', '/blog', '/gallery', '/atelier'];
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    viewport: document.documentElement.clientWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+
+  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+}
+
+async function expectWheelScrollsDocument(page: Page, route: string, selector: string) {
+  await page.setViewportSize({ width: 900, height: 420 });
+  const response = await page.goto(route);
+  expect(response?.ok()).toBe(true);
+
+  const target = page.locator(selector).first();
+  await expect(target).toBeVisible();
+  await target.scrollIntoViewIfNeeded();
+
+  const scrollState = await page.evaluate(() => {
+    const element = document.scrollingElement;
+    if (!element) throw new Error('Missing document scrolling element');
+    const max = element.scrollHeight - element.clientHeight;
+    if (element.scrollTop >= max - 8) element.scrollTop = Math.max(0, max - 120);
+    return { top: element.scrollTop, max };
+  });
+
+  expect(scrollState.max).toBeGreaterThan(0);
+  const box = await target.boundingBox();
+  expect(box).toBeTruthy();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.wheel(0, 280);
+
+  await expect
+    .poll(() => page.evaluate(() => document.scrollingElement?.scrollTop ?? 0))
+    .toBeGreaterThan(scrollState.top);
+}
 
 for (const route of publicRoutes) {
   test(`${route} renders`, async ({ page }) => {
@@ -8,52 +45,84 @@ for (const route of publicRoutes) {
     expect(response?.ok()).toBe(true);
     await expect(page.locator('body')).toBeVisible();
   });
+
+  test(`${route} has no horizontal overflow`, async ({ page }) => {
+    await page.goto(route);
+    await expectNoHorizontalOverflow(page);
+  });
 }
 
-test('homepage fits within the viewport', async ({ page }) => {
+test('homepage wheel scrolls over the activity grid', async ({ page }) => {
+  await expectWheelScrollsDocument(page, '/', '[aria-label="Four weeks of GitHub activity"]');
+});
+
+test('time page wheel scrolls over the slider', async ({ page }) => {
+  await expectWheelScrollsDocument(page, '/time', 'input[type="range"]');
+});
+
+test('gallery wheel scrolls over the canvas', async ({ page }) => {
+  await expectWheelScrollsDocument(page, '/gallery', 'canvas');
+});
+
+test('homepage counter uses four independently reactive digits', async ({ page }) => {
   await page.goto('/');
+  const digits = page.locator('[data-activity-digit]');
+  await expect(digits).toHaveCount(4);
 
-  const dimensions = await page.evaluate(() => ({
-    viewport: window.innerHeight,
-    document: document.documentElement.scrollHeight,
-  }));
+  const firstBox = await digits.first().boundingBox();
+  expect(firstBox).toBeTruthy();
+  await page.mouse.move(firstBox!.x + firstBox!.width * 0.82, firstBox!.y + firstBox!.height * 0.28);
+  await page.waitForTimeout(200);
 
-  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport + 1);
+  const transforms = await digits.evaluateAll((elements) =>
+    elements.map((element) => (element as HTMLElement).style.transform),
+  );
+  expect(transforms[0]).not.toEqual(transforms[3]);
+});
+
+test('homepage counter respects reduced motion', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/');
+  const digits = page.locator('[data-activity-digit]');
+  const firstBox = await digits.first().boundingBox();
+  expect(firstBox).toBeTruthy();
+  await page.mouse.move(firstBox!.x + firstBox!.width * 0.82, firstBox!.y + firstBox!.height * 0.28);
+  await page.waitForTimeout(100);
+
+  const transforms = await digits.evaluateAll((elements) =>
+    elements.map((element) => (element as HTMLElement).style.transform),
+  );
+  expect(new Set(transforms)).toEqual(new Set(['translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)']));
 });
 
 test('homepage activity stays inside a mobile viewport', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');
   await page.locator('[aria-label="Four weeks of GitHub activity"] button').last().click();
-
-  const dimensions = await page.evaluate(() => ({
-    viewport: window.innerWidth,
-    document: document.documentElement.scrollWidth,
-  }));
-
-  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport + 1);
+  await expectNoHorizontalOverflow(page);
 });
 
-test('cube stays inside a mobile viewport', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto('/gallery');
-
-  const dimensions = await page.evaluate(() => ({
-    viewport: window.innerWidth,
-    document: document.documentElement.scrollWidth,
-  }));
-
-  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport + 1);
-});
+for (const width of [320, 375, 390, 430]) {
+  test(`gallery stays inside a ${width}px viewport`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 844 });
+    await page.goto('/gallery');
+    await expectNoHorizontalOverflow(page);
+  });
+}
 
 test.describe('connected-data routes', () => {
   test.skip(!process.env.PLAYWRIGHT_FULL_APP, 'Requires connected app environment variables');
 
   for (const route of ['/space', '/proxy-dashboard']) {
-    test(`${route} renders`, async ({ page }) => {
+    test(`${route} renders without horizontal overflow`, async ({ page }) => {
       const response = await page.goto(route);
       expect(response?.ok()).toBe(true);
       await expect(page.locator('body')).toBeVisible();
+      await expectNoHorizontalOverflow(page);
     });
   }
+
+  test('proxy dashboard wheel scrolls over its main content', async ({ page }) => {
+    await expectWheelScrollsDocument(page, '/proxy-dashboard', 'main');
+  });
 });


### PR DESCRIPTION
## What changed

### Navigation and loading
- keeps the current page visible while a destination is unresolved
- adds immediate opaque `Opening …` feedback and click/tap response
- prefetches internal routes on visibility, hover, focus, and pointer intent
- prerenders deployment-local blog posts and categories
- lazy-loads Three.js behind an exact-size gallery placeholder
- replaces blank or mismatched route states with accurate opaque Space and proxy shells
- adds a readable route-level retry/back error state

### Live data
- refreshes homepage GitHub activity without replacing visible content
- follows GitHub UTC contribution-calendar boundaries
- preserves the previous activity snapshot when GitHub is unavailable
- preserves Space items during focus refreshes, aborts superseded requests, and shows non-destructive errors
- keeps Shift-to-expand behavior unchanged

### Proxy dashboard
- moves table and index creation to a migration instead of request-time DDL
- distinguishes configuration errors, read failures, genuinely empty data, current reports, and stale reports
- displays payload time, row-update time, age, and stale status
- adds protected diagnostics and request IDs

### Interaction and presentation
- restores native document scrolling on ordinary public pages
- replaces the whole-panel homepage tilt with four independently reactive digits
- improves reduced-motion behavior
- reduces the time-page glow and noon brightness
- makes navigation, gallery, activity details, and atelier text surfaces opaque and more readable

## Validation
- lint: passed
- TypeScript: passed
- unit tests: passed
- Next.js production build: passed
- Chromium Playwright regressions: passed
- WebKit Playwright regressions: passed
- production proxy ingest is currently returning 200 responses; production dashboard requests return 200/304

## Deployment note
Production still serves `main` at commit `082fb1b751d273913c38a309f5f4630bfd7fe1e6`. This PR is ready to merge and deploy.