### PR TITLE
Make homepage activity tactile, readable, and compact

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -3,6 +3,8 @@ import { connection } from 'next/server';
 import { getRecentDateKeys, parsePublicContributionHtml } from '@/lib/github-activity-utils';
 
 const GITHUB_USERNAME = 'teamleaderleo';
+const CLIENT_REFRESH_SECONDS = 60;
+const UPSTREAM_CACHE_SECONDS = 300;
 
 export async function GET() {
   await connection();
@@ -42,7 +44,9 @@ export async function GET() {
       },
       {
         headers: {
-          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+          'Cache-Control': `public, s-maxage=${UPSTREAM_CACHE_SECONDS}, stale-while-revalidate=3600`,
+          'X-Activity-Refresh-Seconds': String(CLIENT_REFRESH_SECONDS),
+          'X-Upstream-Cache-Seconds': String(UPSTREAM_CACHE_SECONDS),
           'X-Request-Id': requestId,
         },
       },

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,95 +8,95 @@ html {
 
 @layer base {
   :root {
-    --background: 42 14% 94%;
-    --foreground: 240 6% 10%;
+    --background: 42 12% 87%;
+    --foreground: 240 6% 11%;
 
-    --card: 42 18% 97%;
-    --card-foreground: 240 6% 10%;
+    --card: 42 14% 91%;
+    --card-foreground: 240 6% 11%;
 
-    --popover: 42 18% 97%;
-    --popover-foreground: 240 6% 10%;
+    --popover: 42 14% 90%;
+    --popover-foreground: 240 6% 11%;
 
-    --primary: 252 14% 88%;
-    --primary-foreground: 250 10% 20%;
+    --primary: 252 13% 82%;
+    --primary-foreground: 250 10% 18%;
 
-    --secondary: 40 8% 90%;
-    --secondary-foreground: 240 6% 16%;
+    --secondary: 40 8% 84%;
+    --secondary-foreground: 240 6% 15%;
 
-    --muted: 40 8% 90%;
-    --muted-foreground: 240 4% 40%;
+    --muted: 40 8% 83%;
+    --muted-foreground: 240 5% 34%;
 
-    --accent: 252 12% 90%;
-    --accent-foreground: 250 10% 20%;
+    --accent: 252 11% 84%;
+    --accent-foreground: 250 10% 18%;
 
-    --destructive: 0 72% 54%;
+    --destructive: 0 72% 50%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 40 7% 80%;
-    --input: 40 7% 80%;
-    --ring: 252 12% 62%;
+    --border: 40 7% 70%;
+    --input: 40 7% 70%;
+    --ring: 252 12% 52%;
 
     --radius: 0.5rem;
 
-    --sidebar-background: 42 12% 93%;
-    --sidebar-foreground: 240 5% 24%;
-    --sidebar-primary: 252 14% 86%;
-    --sidebar-primary-foreground: 240 6% 12%;
-    --sidebar-accent: 40 8% 89%;
-    --sidebar-accent-foreground: 240 6% 14%;
-    --sidebar-border: 40 7% 80%;
-    --sidebar-ring: 252 12% 62%;
+    --sidebar-background: 42 11% 86%;
+    --sidebar-foreground: 240 5% 22%;
+    --sidebar-primary: 252 13% 81%;
+    --sidebar-primary-foreground: 240 6% 11%;
+    --sidebar-accent: 40 8% 82%;
+    --sidebar-accent-foreground: 240 6% 13%;
+    --sidebar-border: 40 7% 70%;
+    --sidebar-ring: 252 12% 52%;
 
-    --chart-1: 252 18% 62%;
-    --chart-2: 168 34% 42%;
-    --chart-3: 28 58% 54%;
-    --chart-4: 214 28% 46%;
-    --chart-5: 344 28% 54%;
+    --chart-1: 252 18% 57%;
+    --chart-2: 168 34% 38%;
+    --chart-3: 28 58% 48%;
+    --chart-4: 214 28% 41%;
+    --chart-5: 344 28% 49%;
   }
 
   .dark {
-    --background: 240 5% 7%;
-    --foreground: 40 10% 92%;
+    --background: 240 6% 8%;
+    --foreground: 40 12% 94%;
 
-    --card: 240 5% 10%;
-    --card-foreground: 40 10% 92%;
+    --card: 240 6% 13%;
+    --card-foreground: 40 12% 94%;
 
-    --popover: 240 5% 10%;
-    --popover-foreground: 40 10% 92%;
+    --popover: 240 6% 14%;
+    --popover-foreground: 40 12% 94%;
 
-    --primary: 252 10% 28%;
-    --primary-foreground: 252 14% 88%;
+    --primary: 252 12% 34%;
+    --primary-foreground: 252 16% 93%;
 
-    --secondary: 240 5% 15%;
-    --secondary-foreground: 40 10% 90%;
+    --secondary: 240 6% 20%;
+    --secondary-foreground: 40 12% 93%;
 
-    --muted: 240 5% 15%;
-    --muted-foreground: 240 5% 66%;
+    --muted: 240 6% 19%;
+    --muted-foreground: 240 7% 74%;
 
-    --accent: 252 8% 18%;
-    --accent-foreground: 252 14% 88%;
+    --accent: 252 10% 24%;
+    --accent-foreground: 252 16% 94%;
 
-    --destructive: 0 52% 34%;
+    --destructive: 0 54% 38%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 240 5% 24%;
-    --input: 240 5% 24%;
-    --ring: 252 10% 54%;
+    --border: 240 6% 31%;
+    --input: 240 6% 31%;
+    --ring: 252 12% 66%;
 
-    --sidebar-background: 240 5% 9%;
-    --sidebar-foreground: 40 8% 88%;
-    --sidebar-primary: 252 10% 28%;
-    --sidebar-primary-foreground: 252 14% 88%;
-    --sidebar-accent: 240 5% 15%;
-    --sidebar-accent-foreground: 40 8% 90%;
-    --sidebar-border: 240 5% 22%;
-    --sidebar-ring: 252 10% 54%;
+    --sidebar-background: 240 6% 11%;
+    --sidebar-foreground: 40 10% 92%;
+    --sidebar-primary: 252 12% 34%;
+    --sidebar-primary-foreground: 252 16% 94%;
+    --sidebar-accent: 240 6% 20%;
+    --sidebar-accent-foreground: 40 10% 94%;
+    --sidebar-border: 240 6% 29%;
+    --sidebar-ring: 252 12% 66%;
 
-    --chart-1: 252 18% 66%;
-    --chart-2: 168 34% 48%;
-    --chart-3: 28 58% 60%;
-    --chart-4: 214 34% 60%;
-    --chart-5: 344 34% 64%;
+    --chart-1: 252 22% 72%;
+    --chart-2: 168 38% 58%;
+    --chart-3: 28 62% 66%;
+    --chart-4: 214 38% 68%;
+    --chart-5: 344 38% 70%;
   }
 }
 
@@ -199,6 +199,10 @@ input[type='number']::-webkit-outer-spin-button {
     @apply pointer-events-none float-left h-0 text-gray-400;
     content: attr(data-placeholder);
   }
+}
+
+.proxy-usage-dashboard > .grid > :first-child {
+  display: none;
 }
 
 .shiki,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,8 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ecebe6' },
-    { media: '(prefers-color-scheme: dark)', color: '#101115' },
+    { media: '(prefers-color-scheme: light)', color: '#dedbd3' },
+    { media: '(prefers-color-scheme: dark)', color: '#111216' },
   ],
   colorScheme: 'light dark',
 };
@@ -37,12 +37,12 @@ export default function RootLayout({
       <head>
         <style>{`
           html {
-            background-color: #ecebe6;
+            background-color: #dedbd3;
             color-scheme: light;
           }
 
           html.dark {
-            background-color: #101115;
+            background-color: #111216;
             color-scheme: dark;
           }
         `}</style>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,21 +18,21 @@ export default async function Page() {
 
   return (
     <ViewportPageShell
-      className="relative bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
+      className="relative bg-[#dedbd3] text-[#1b1b1e] dark:bg-[#111216] dark:text-[#f0ece5]"
       contentClassName="relative overflow-x-hidden text-inherit"
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-18"
+        className="pointer-events-none absolute inset-0 opacity-35 dark:opacity-16"
         style={{
           backgroundImage:
-            'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
+            'linear-gradient(rgba(30,30,34,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.04) 1px, transparent 1px)',
           backgroundSize: '28px 28px',
         }}
       />
 
-      <div className="relative mx-auto w-full max-w-5xl px-4 py-5 sm:px-6 sm:py-7">
-        <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
+      <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-5xl flex-col px-4 py-5 sm:px-6 sm:py-7">
+        <div className="flex min-w-0 flex-1 flex-col gap-4 sm:gap-5">
           <ActivityDashboard
             initial={{
               today: activity.today,
@@ -44,43 +44,41 @@ export default async function Page() {
             }}
           />
 
-          <section aria-labelledby="recent-systems-title" className="min-w-0">
-            <div className="flex items-end justify-between gap-4 px-0.5">
-              <div>
-                <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-black/48 dark:text-white/48">
-                  Recent systems
-                </p>
-                <h2 id="recent-systems-title" className="mt-1 text-lg font-semibold tracking-tight sm:text-xl">
-                  Tools that remember their boundaries
-                </h2>
-              </div>
-              <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.14em] text-black/42 dark:text-white/42">
+          <section aria-labelledby="recent-systems-title" className="flex min-w-0 flex-1 flex-col">
+            <div className="flex items-center justify-between gap-4 px-0.5">
+              <h2
+                id="recent-systems-title"
+                className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-black/58 dark:text-white/62"
+              >
+                Recent systems
+              </h2>
+              <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.14em] text-black/52 dark:text-white/56">
                 {activity.repositories.length} projects
               </span>
             </div>
 
-            <div className="mt-3 grid min-w-0 grid-cols-1 gap-3 md:grid-cols-3">
+            <div className="mt-3 grid min-w-0 flex-1 grid-cols-1 gap-3 md:grid-cols-3">
               {activity.repositories.map((repository) => (
                 <Link
                   key={repository.name}
                   href={repository.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex min-h-36 min-w-0 flex-col justify-between gap-5 rounded-xl border border-black/12 bg-[#f2f0ea] p-4 transition hover:-translate-y-0.5 hover:border-black/25 hover:bg-[#f7f4ed] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/35 dark:border-white/10 dark:bg-[#18191d] dark:hover:border-white/22 dark:hover:bg-[#1d1e23] dark:focus-visible:ring-white/45"
+                  className="group flex min-h-40 min-w-0 flex-col justify-between gap-5 rounded-xl border border-black/14 bg-[#e4e0d7] p-4 shadow-[0_8px_20px_rgba(24,24,26,0.05)] transition-[transform,background-color,border-color,box-shadow] duration-200 hover:-translate-y-1 hover:scale-[1.01] hover:border-black/28 hover:bg-[#e9e5dc] hover:shadow-[0_16px_30px_rgba(24,24,26,0.11)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40 dark:border-white/14 dark:bg-[#1b1c21] dark:shadow-[0_10px_24px_rgba(0,0,0,0.18)] dark:hover:border-white/28 dark:hover:bg-[#24252b] dark:hover:shadow-[0_18px_34px_rgba(0,0,0,0.32)] dark:focus-visible:ring-white/55"
                 >
                   <div>
                     <div className="flex items-center justify-between gap-3">
-                      <h3 className="truncate font-medium">{repository.name}</h3>
+                      <h3 className="truncate font-medium text-black/88 dark:text-white/92">{repository.name}</h3>
                       <ArrowUpRight
                         size={15}
-                        className="shrink-0 text-black/40 transition group-hover:text-black/75 dark:text-white/45 dark:group-hover:text-white/80"
+                        className="shrink-0 text-black/48 transition group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-black/82 dark:text-white/55 dark:group-hover:text-white/88"
                       />
                     </div>
-                    <p className="mt-3 text-sm leading-relaxed text-black/62 dark:text-white/62">
+                    <p className="mt-3 text-sm leading-relaxed text-black/68 dark:text-white/72">
                       {repository.note}
                     </p>
                   </div>
-                  <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-black/42 dark:text-white/42">
+                  <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-black/52 dark:text-white/56">
                     open repository
                   </span>
                 </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,7 @@ export default async function Page() {
               yearTotal: activity.total,
               days,
               unit,
+              generatedAt: activity.generatedAt,
             }}
           />
 

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -87,14 +87,14 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
     <div className="relative min-w-0">
       <div className="pointer-events-none absolute right-2 top-2 z-10 min-h-4" aria-live="polite">
         {updating ? (
-          <span className="flex items-center gap-1.5 rounded-full border border-black/10 bg-[#f4f1ea] px-2 py-1 font-mono text-[8px] font-semibold uppercase tracking-[0.12em] text-black/50 shadow-sm dark:border-white/10 dark:bg-[#202126] dark:text-white/50">
+          <span className="flex items-center gap-1.5 rounded-full border border-black/14 bg-[#ddd9d0] px-2 py-1 font-mono text-[8px] font-semibold uppercase tracking-[0.12em] text-black/62 shadow-sm dark:border-white/16 dark:bg-[#292a30] dark:text-white/68">
             <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current motion-reduce:animate-none" />
             Updating
           </span>
         ) : null}
       </div>
 
-      <div className="grid min-w-0 items-stretch gap-3 lg:grid-cols-[minmax(19rem,0.9fr)_minmax(20rem,1.1fr)]">
+      <div className="grid min-w-0 items-stretch gap-3 lg:grid-cols-[minmax(18rem,0.78fr)_minmax(24rem,1.22fr)]">
         <ActivityScoreboard
           today={activity.today}
           weekTotal={activity.weekTotal}

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -4,12 +4,15 @@ import { ActivityGrid, type ActivityGridDay } from '@/components/home/activity-g
 import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
 import { useEffect, useRef, useState } from 'react';
 
+const REFRESH_INTERVAL_MS = 60_000;
+
 type ActivitySnapshot = {
   today: number;
   weekTotal: number;
   yearTotal: number | null;
   days: ActivityGridDay[];
   unit: string;
+  generatedAt: string;
 };
 
 type LiveActivityResponse = {
@@ -17,18 +20,26 @@ type LiveActivityResponse = {
   weekTotal: number;
   yearTotal: number;
   days: ActivityGridDay[];
+  generatedAt: string;
 };
+
+function timestampOrNow(value: string) {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
 
 export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   const [activity, setActivity] = useState(initial);
   const [updating, setUpdating] = useState(false);
   const inFlight = useRef<AbortController | null>(null);
+  const lastSuccessAt = useRef(timestampOrNow(initial.generatedAt));
 
   useEffect(() => {
     let mounted = true;
 
     const refresh = async () => {
       if (document.visibilityState !== 'visible' || inFlight.current) return;
+      if (Date.now() - lastSuccessAt.current < REFRESH_INTERVAL_MS - 1_000) return;
 
       const controller = new AbortController();
       inFlight.current = controller;
@@ -43,6 +54,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
 
         const next = (await response.json()) as LiveActivityResponse;
         if (!mounted) return;
+        lastSuccessAt.current = timestampOrNow(next.generatedAt);
         setActivity({ ...next, unit: 'contributions' });
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') return;
@@ -53,8 +65,10 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       }
     };
 
-    const initialRefresh = window.setTimeout(() => void refresh(), 2_500);
-    const interval = window.setInterval(() => void refresh(), 75_000);
+    const age = Math.max(0, Date.now() - lastSuccessAt.current);
+    const firstDelay = Math.max(3_000, REFRESH_INTERVAL_MS - age);
+    const initialRefresh = window.setTimeout(() => void refresh(), firstDelay);
+    const interval = window.setInterval(() => void refresh(), REFRESH_INTERVAL_MS);
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') void refresh();
     };
@@ -70,21 +84,24 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   }, []);
 
   return (
-    <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
-      <div className="flex h-4 items-center justify-end" aria-live="polite">
+    <div className="relative min-w-0">
+      <div className="pointer-events-none absolute right-2 top-2 z-10 min-h-4" aria-live="polite">
         {updating ? (
-          <span className="flex items-center gap-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-black/50 dark:text-white/50">
+          <span className="flex items-center gap-1.5 rounded-full border border-black/10 bg-[#f4f1ea] px-2 py-1 font-mono text-[8px] font-semibold uppercase tracking-[0.12em] text-black/50 shadow-sm dark:border-white/10 dark:bg-[#202126] dark:text-white/50">
             <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current motion-reduce:animate-none" />
-            Updating activity
+            Updating
           </span>
         ) : null}
       </div>
-      <ActivityScoreboard
-        today={activity.today}
-        weekTotal={activity.weekTotal}
-        yearTotal={activity.yearTotal}
-      />
-      <ActivityGrid days={activity.days} unit={activity.unit} />
+
+      <div className="grid min-w-0 items-stretch gap-3 lg:grid-cols-[minmax(19rem,0.9fr)_minmax(20rem,1.1fr)]">
+        <ActivityScoreboard
+          today={activity.today}
+          weekTotal={activity.weekTotal}
+          yearTotal={activity.yearTotal}
+        />
+        <ActivityGrid days={activity.days} unit={activity.unit} />
+      </div>
     </div>
   );
 }

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export type ActivityGridDay = {
   date: string;
@@ -36,9 +36,12 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   const maximum = Math.max(...days.map((day) => day.count), 0);
   const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
   const [tooltipDate, setTooltipDate] = useState<string | null>(null);
-  const [tooltipPosition, setTooltipPosition] = useState({ x: 12, y: 12 });
+  const [tooltipVisible, setTooltipVisible] = useState(false);
   const [finePointer, setFinePointer] = useState(false);
   const previousLatest = useRef(days.at(-1)?.date ?? '');
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const hideTimerRef = useRef<number | null>(null);
+  const positionFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
     const media = window.matchMedia('(hover: hover) and (pointer: fine)');
@@ -59,6 +62,41 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     previousLatest.current = latest;
   }, [days]);
 
+  useEffect(() => {
+    return () => {
+      if (hideTimerRef.current !== null) window.clearTimeout(hideTimerRef.current);
+      if (positionFrameRef.current !== null) window.cancelAnimationFrame(positionFrameRef.current);
+    };
+  }, []);
+
+  const cancelHide = useCallback(() => {
+    if (hideTimerRef.current !== null) {
+      window.clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleHide = useCallback(() => {
+    cancelHide();
+    hideTimerRef.current = window.setTimeout(() => {
+      setTooltipVisible(false);
+      hideTimerRef.current = null;
+    }, 140);
+  }, [cancelHide]);
+
+  const placeTooltip = useCallback((clientX: number, clientY: number) => {
+    if (positionFrameRef.current !== null) window.cancelAnimationFrame(positionFrameRef.current);
+    positionFrameRef.current = window.requestAnimationFrame(() => {
+      const tooltip = tooltipRef.current;
+      if (!tooltip) return;
+      const width = tooltip.offsetWidth || 208;
+      const height = tooltip.offsetHeight || 40;
+      const x = Math.min(window.innerWidth - width - 12, Math.max(12, clientX + 14));
+      const y = Math.min(window.innerHeight - height - 12, Math.max(12, clientY + 14));
+      tooltip.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+    });
+  }, []);
+
   const selected = days.find((day) => day.date === selectedDate);
   const tooltipDay = days.find((day) => day.date === tooltipDate);
   const selectedLabel = useMemo(
@@ -67,78 +105,92 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   );
   const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
 
-  const placeTooltip = (clientX: number, clientY: number) => {
-    const maxX = Math.max(12, window.innerWidth - 220);
-    const maxY = Math.max(12, window.innerHeight - 56);
-    setTooltipPosition({
-      x: Math.min(maxX, Math.max(12, clientX + 14)),
-      y: Math.min(maxY, Math.max(12, clientY + 14)),
-    });
-  };
-
   return (
-    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-black/12 bg-[#dedcd6] p-4 shadow-[0_14px_35px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d] dark:shadow-none sm:p-5">
-      <div className="flex justify-end">
-        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/55 dark:text-white/55" aria-hidden="true">
+    <section
+      className="relative h-full min-w-0 rounded-[1.1rem] border border-black/12 bg-[#dedcd6] p-3 shadow-[0_12px_28px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d] dark:shadow-none"
+      onPointerEnter={cancelHide}
+      onPointerLeave={scheduleHide}
+      onPointerMove={(event) => {
+        if (finePointer && tooltipVisible) placeTooltip(event.clientX, event.clientY);
+      }}
+      onFocusCapture={cancelHide}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) scheduleHide();
+      }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/55 dark:text-white/55">
+          28D activity
+        </span>
+        <div className="flex items-center gap-1 font-mono text-[8px] uppercase tracking-[0.1em] text-black/48 dark:text-white/48" aria-hidden="true">
           <span>less</span>
-          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#a9a3af]" />
-          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#d4cddb]" />
-          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#faf8f2] ring-1 ring-inset ring-black/[0.05]" />
+          <span className="h-2 w-2 rounded-[2px] bg-[#a9a3af]" />
+          <span className="h-2 w-2 rounded-[2px] bg-[#d4cddb]" />
+          <span className="h-2 w-2 rounded-[2px] bg-[#faf8f2] ring-1 ring-inset ring-black/[0.05]" />
           <span>more</span>
         </div>
       </div>
 
-      <div className="mt-3 grid min-w-0 grid-cols-7 gap-2 sm:gap-2.5" aria-label="Four weeks of GitHub activity">
-        {days.map((day, index) => {
-          const label = labelForDay(day, unit);
-          const isSelected = day.date === selected?.date;
-          const isLatest = index === days.length - 1;
-
-          return (
-            <button
-              key={day.date}
-              type="button"
-              className={`aspect-square min-w-0 rounded-[0.5rem] transition duration-150 hover:-translate-y-0.5 hover:scale-[1.035] focus-visible:-translate-y-0.5 focus-visible:scale-[1.035] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/35 dark:focus-visible:ring-white/45 ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-black/20 dark:outline-white/25' : ''} ${isSelected ? 'brightness-[1.03] dark:brightness-110' : ''}`}
-              aria-label={label}
-              aria-pressed={isSelected}
-              onPointerEnter={(event) => {
-                setSelectedDate(day.date);
-                if (finePointer) {
-                  setTooltipDate(day.date);
-                  placeTooltip(event.clientX, event.clientY);
-                }
-              }}
-              onPointerMove={(event) => {
-                if (finePointer) placeTooltip(event.clientX, event.clientY);
-              }}
-              onPointerLeave={() => setTooltipDate(null)}
-              onFocus={(event) => {
-                setSelectedDate(day.date);
-                if (finePointer) {
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  setTooltipDate(day.date);
-                  placeTooltip(rect.right, rect.bottom);
-                }
-              }}
-              onBlur={() => setTooltipDate(null)}
-              onClick={() => setSelectedDate(day.date)}
-            />
-          );
-        })}
-      </div>
-
-      <div className="mt-3 flex min-h-9 items-center justify-center rounded-lg border border-black/12 bg-[#f4f1ea] px-3 py-2 text-center font-mono text-[10px] font-medium text-black/65 dark:border-white/12 dark:bg-[#202126] dark:text-white/68" aria-live="polite">
-        {selectedLabel}
-      </div>
-
-      {finePointer && tooltipLabel ? (
+      <div className="mt-2.5 grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3">
         <div
-          className="pointer-events-none fixed z-[90] max-w-[13rem] rounded-lg border border-black/18 bg-[#f4f1ea] px-2.5 py-1.5 font-mono text-[10px] font-semibold text-[#242328] shadow-[0_8px_24px_rgba(20,20,24,0.18)] dark:border-white/16 dark:bg-[#202126] dark:text-[#f0ece5]"
-          style={{ left: tooltipPosition.x, top: tooltipPosition.y }}
+          className="grid grid-flow-col grid-rows-7 gap-0.5"
+          aria-label="Four weeks of GitHub activity"
         >
-          {tooltipLabel}
+          {days.map((day, index) => {
+            const label = labelForDay(day, unit);
+            const isSelected = day.date === selected?.date;
+            const isLatest = index === days.length - 1;
+
+            return (
+              <button
+                key={day.date}
+                type="button"
+                data-activity-cell
+                className="group flex h-4 w-4 items-center justify-center rounded-[4px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/35 focus-visible:ring-offset-1 focus-visible:ring-offset-[#dedcd6] dark:focus-visible:ring-white/45 dark:focus-visible:ring-offset-[#18191d]"
+                aria-label={label}
+                aria-pressed={isSelected}
+                onPointerEnter={(event) => {
+                  setSelectedDate(day.date);
+                  if (finePointer) {
+                    cancelHide();
+                    setTooltipDate(day.date);
+                    setTooltipVisible(true);
+                    placeTooltip(event.clientX, event.clientY);
+                  }
+                }}
+                onFocus={(event) => {
+                  setSelectedDate(day.date);
+                  if (finePointer && event.currentTarget.matches(':focus-visible')) {
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    cancelHide();
+                    setTooltipDate(day.date);
+                    setTooltipVisible(true);
+                    placeTooltip(rect.right, rect.top + rect.height / 2);
+                  }
+                }}
+                onClick={() => setSelectedDate(day.date)}
+              >
+                <span
+                  className={`h-2.5 w-2.5 rounded-[3px] transition-transform duration-150 group-hover:scale-125 group-focus-visible:scale-125 motion-reduce:transition-none ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-1 outline-offset-1 outline-black/25 dark:outline-white/30' : ''} ${isSelected ? 'scale-110 brightness-[1.04] dark:brightness-110' : ''}`}
+                />
+              </button>
+            );
+          })}
         </div>
-      ) : null}
+
+        <div className="flex min-w-0 items-center rounded-lg border border-black/10 bg-[#f4f1ea] px-3 py-2 font-mono text-[9px] font-medium leading-relaxed text-black/62 dark:border-white/10 dark:bg-[#202126] dark:text-white/66" aria-live="polite">
+          {selectedLabel}
+        </div>
+      </div>
+
+      <div
+        ref={tooltipRef}
+        data-activity-tooltip
+        className={`pointer-events-none fixed left-0 top-0 z-[90] max-w-[13rem] rounded-lg border border-black/18 bg-[#f4f1ea] px-2.5 py-1.5 font-mono text-[10px] font-semibold text-[#242328] shadow-[0_8px_24px_rgba(20,20,24,0.18)] transition-opacity duration-100 dark:border-white/16 dark:bg-[#202126] dark:text-[#f0ece5] ${finePointer && tooltipVisible && tooltipLabel ? 'visible opacity-100' : 'invisible opacity-0'}`}
+        aria-hidden="true"
+      >
+        {tooltipLabel}
+      </div>
     </section>
   );
 }

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -8,7 +8,7 @@ export type ActivityGridDay = {
 };
 
 function formatDay(date: string): string {
-  return new Intl.DateTimeFormat('en-US', {
+  return new Intl.DateTimeFormat('en-GB', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -17,19 +17,19 @@ function formatDay(date: string): string {
 }
 
 function activityClass(count: number, maximum: number): string {
-  const base = 'ring-1 ring-inset ring-black/[0.05] dark:ring-white/[0.07]';
-  if (count === 0) return `${base} bg-[#c9c7c1] dark:bg-[#292a2f]`;
+  const base = 'ring-1 ring-inset ring-black/[0.08] dark:ring-white/[0.12]';
+  if (count === 0) return `${base} bg-[#b9b6ae] dark:bg-[#303138]`;
 
   const ratio = maximum === 0 ? 0 : count / maximum;
-  if (ratio > 0.8) return `${base} bg-[#faf8f2] dark:bg-[#eeeaf2]`;
-  if (ratio > 0.55) return `${base} bg-[#e8e2ec] dark:bg-[#c9c2d0]`;
-  if (ratio > 0.3) return `${base} bg-[#d4cddb] dark:bg-[#8e8798]`;
-  if (ratio > 0.12) return `${base} bg-[#bfb8c7] dark:bg-[#66606d]`;
-  return `${base} bg-[#a9a3af] dark:bg-[#4b4750]`;
+  if (ratio > 0.8) return `${base} bg-[#ece8de] dark:bg-[#eee9f1]`;
+  if (ratio > 0.55) return `${base} bg-[#d8d1dc] dark:bg-[#c8c0cf]`;
+  if (ratio > 0.3) return `${base} bg-[#beb5c6] dark:bg-[#958a9e]`;
+  if (ratio > 0.12) return `${base} bg-[#a79dae] dark:bg-[#706777]`;
+  return `${base} bg-[#8f8797] dark:bg-[#514b57]`;
 }
 
 function labelForDay(day: ActivityGridDay, unit: string) {
-  return `${formatDay(day.date)} · ${day.count.toLocaleString('en-US')} ${unit}`;
+  return `${formatDay(day.date)} · ${day.count.toLocaleString('en-GB')} ${unit}`;
 }
 
 export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: string }) {
@@ -81,7 +81,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     hideTimerRef.current = window.setTimeout(() => {
       setTooltipVisible(false);
       hideTimerRef.current = null;
-    }, 140);
+    }, 90);
   }, [cancelHide]);
 
   const placeTooltip = useCallback((clientX: number, clientY: number) => {
@@ -89,8 +89,8 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     positionFrameRef.current = window.requestAnimationFrame(() => {
       const tooltip = tooltipRef.current;
       if (!tooltip) return;
-      const width = tooltip.offsetWidth || 208;
-      const height = tooltip.offsetHeight || 40;
+      const width = tooltip.offsetWidth || 240;
+      const height = tooltip.offsetHeight || 34;
       const x = Math.min(window.innerWidth - width - 12, Math.max(12, clientX + 14));
       const y = Math.min(window.innerHeight - height - 12, Math.max(12, clientY + 14));
       tooltip.style.transform = `translate3d(${x}px, ${y}px, 0)`;
@@ -107,7 +107,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
 
   return (
     <section
-      className="relative h-full min-w-0 rounded-[1.1rem] border border-black/12 bg-[#dedcd6] p-3 shadow-[0_12px_28px_rgba(24,24,26,0.07)] dark:border-white/10 dark:bg-[#18191d] dark:shadow-none"
+      className="relative flex h-full min-w-0 flex-col rounded-[1.1rem] border border-black/16 bg-[#d6d3cb] p-3 shadow-[0_12px_28px_rgba(24,24,26,0.09)] dark:border-white/14 dark:bg-[#1b1c21] dark:shadow-[0_14px_34px_rgba(0,0,0,0.24)]"
       onPointerEnter={cancelHide}
       onPointerLeave={scheduleHide}
       onPointerMove={(event) => {
@@ -119,78 +119,75 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
       }}
     >
       <div className="flex items-center justify-between gap-3">
-        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/55 dark:text-white/55">
+        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/64 dark:text-white/68">
           28D activity
         </span>
-        <div className="flex items-center gap-1 font-mono text-[8px] uppercase tracking-[0.1em] text-black/48 dark:text-white/48" aria-hidden="true">
+        <div className="flex items-center gap-1 font-mono text-[8px] uppercase tracking-[0.1em] text-black/56 dark:text-white/58" aria-hidden="true">
           <span>less</span>
-          <span className="h-2 w-2 rounded-[2px] bg-[#a9a3af]" />
-          <span className="h-2 w-2 rounded-[2px] bg-[#d4cddb]" />
-          <span className="h-2 w-2 rounded-[2px] bg-[#faf8f2] ring-1 ring-inset ring-black/[0.05]" />
+          <span className="h-2 w-2 rounded-[2px] bg-[#8f8797]" />
+          <span className="h-2 w-2 rounded-[2px] bg-[#beb5c6]" />
+          <span className="h-2 w-2 rounded-[2px] bg-[#ece8de] ring-1 ring-inset ring-black/[0.08]" />
           <span>more</span>
         </div>
       </div>
 
-      <div className="mt-2.5 grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3">
-        <div
-          className="grid grid-flow-col justify-self-start gap-0.5"
-          style={{
-            gridTemplateColumns: 'repeat(4, 1rem)',
-            gridTemplateRows: 'repeat(7, 1rem)',
-          }}
-          aria-label="Four weeks of GitHub activity"
-        >
-          {days.map((day, index) => {
-            const label = labelForDay(day, unit);
-            const isSelected = day.date === selected?.date;
-            const isLatest = index === days.length - 1;
+      <div
+        className="mt-3 grid min-h-0 flex-1 grid-cols-7 gap-1.5 sm:gap-2"
+        aria-label="Four weeks of GitHub activity"
+      >
+        {days.map((day, index) => {
+          const label = labelForDay(day, unit);
+          const isSelected = day.date === selected?.date;
+          const isLatest = index === days.length - 1;
 
-            return (
-              <button
-                key={day.date}
-                type="button"
-                data-activity-cell
-                className="group flex h-4 w-4 items-center justify-center rounded-[4px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/35 focus-visible:ring-offset-1 focus-visible:ring-offset-[#dedcd6] dark:focus-visible:ring-white/45 dark:focus-visible:ring-offset-[#18191d]"
-                aria-label={label}
-                aria-pressed={isSelected}
-                onPointerEnter={(event) => {
-                  setSelectedDate(day.date);
-                  if (finePointer) {
-                    cancelHide();
-                    setTooltipDate(day.date);
-                    setTooltipVisible(true);
-                    placeTooltip(event.clientX, event.clientY);
-                  }
-                }}
-                onFocus={(event) => {
-                  setSelectedDate(day.date);
-                  if (finePointer && event.currentTarget.matches(':focus-visible')) {
-                    const rect = event.currentTarget.getBoundingClientRect();
-                    cancelHide();
-                    setTooltipDate(day.date);
-                    setTooltipVisible(true);
-                    placeTooltip(rect.right, rect.top + rect.height / 2);
-                  }
-                }}
-                onClick={() => setSelectedDate(day.date)}
-              >
-                <span
-                  className={`h-2.5 w-2.5 rounded-[3px] transition-transform duration-150 group-hover:scale-125 group-focus-visible:scale-125 motion-reduce:transition-none ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-1 outline-offset-1 outline-black/25 dark:outline-white/30' : ''} ${isSelected ? 'scale-110 brightness-[1.04] dark:brightness-110' : ''}`}
-                />
-              </button>
-            );
-          })}
-        </div>
+          return (
+            <button
+              key={day.date}
+              type="button"
+              data-activity-cell
+              className="group relative flex min-h-8 min-w-0 items-center justify-center rounded-lg border border-black/8 bg-black/[0.025] p-1 transition-[transform,background-color] duration-150 hover:-translate-y-0.5 hover:bg-black/[0.055] focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40 focus-visible:ring-offset-1 focus-visible:ring-offset-[#d6d3cb] dark:border-white/8 dark:bg-white/[0.025] dark:hover:bg-white/[0.07] dark:focus-visible:ring-white/55 dark:focus-visible:ring-offset-[#1b1c21]"
+              aria-label={label}
+              aria-pressed={isSelected}
+              onPointerEnter={(event) => {
+                setSelectedDate(day.date);
+                if (finePointer) {
+                  cancelHide();
+                  setTooltipDate(day.date);
+                  setTooltipVisible(true);
+                  placeTooltip(event.clientX, event.clientY);
+                }
+              }}
+              onFocus={(event) => {
+                setSelectedDate(day.date);
+                if (finePointer && event.currentTarget.matches(':focus-visible')) {
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  cancelHide();
+                  setTooltipDate(day.date);
+                  setTooltipVisible(true);
+                  placeTooltip(rect.right, rect.top + rect.height / 2);
+                }
+              }}
+              onClick={() => setSelectedDate(day.date)}
+            >
+              <span
+                className={`aspect-square w-[72%] max-w-10 rounded-[22%] transition-[transform,filter] duration-150 group-hover:scale-110 group-focus-visible:scale-110 motion-reduce:transition-none ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-1 outline-offset-2 outline-black/35 dark:outline-white/42' : ''} ${isSelected ? 'scale-105 brightness-[1.04] dark:brightness-110' : ''}`}
+              />
+            </button>
+          );
+        })}
+      </div>
 
-        <div className="flex min-w-0 items-center rounded-lg border border-black/10 bg-[#f4f1ea] px-3 py-2 font-mono text-[9px] font-medium leading-relaxed text-black/62 dark:border-white/10 dark:bg-[#202126] dark:text-white/66" aria-live="polite">
-          {selectedLabel}
-        </div>
+      <div
+        className={`mt-2.5 min-h-7 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg border border-black/10 bg-[#e3dfd6] px-3 py-1.5 font-mono text-[9px] font-medium text-black/70 transition-opacity duration-100 dark:border-white/12 dark:bg-[#25262c] dark:text-white/76 ${finePointer && !tooltipVisible ? 'opacity-0' : 'opacity-100'}`}
+        aria-live="polite"
+      >
+        {selectedLabel}
       </div>
 
       <div
         ref={tooltipRef}
         data-activity-tooltip
-        className={`pointer-events-none fixed left-0 top-0 z-[90] max-w-[13rem] rounded-lg border border-black/18 bg-[#f4f1ea] px-2.5 py-1.5 font-mono text-[10px] font-semibold text-[#242328] shadow-[0_8px_24px_rgba(20,20,24,0.18)] transition-opacity duration-100 dark:border-white/16 dark:bg-[#202126] dark:text-[#f0ece5] ${finePointer && tooltipVisible && tooltipLabel ? 'visible opacity-100' : 'invisible opacity-0'}`}
+        className={`pointer-events-none fixed left-0 top-0 z-[90] max-w-none whitespace-nowrap rounded-lg border border-black/20 bg-[#ddd9d0] px-2.5 py-1.5 font-mono text-[10px] font-semibold text-[#222328] shadow-[0_8px_24px_rgba(20,20,24,0.2)] transition-opacity duration-75 dark:border-white/18 dark:bg-[#292a30] dark:text-[#f3efe8] ${finePointer && tooltipVisible && tooltipLabel ? 'visible opacity-100' : 'invisible opacity-0'}`}
         aria-hidden="true"
       >
         {tooltipLabel}

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -133,7 +133,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
 
       <div className="mt-2.5 grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3">
         <div
-          className="grid grid-flow-col grid-rows-7 gap-0.5"
+          className="grid w-fit grid-flow-col grid-rows-7 auto-cols-[1rem] gap-0.5"
           aria-label="Four weeks of GitHub activity"
         >
           {days.map((day, index) => {

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -133,7 +133,11 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
 
       <div className="mt-2.5 grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-stretch gap-3">
         <div
-          className="grid w-fit grid-flow-col grid-rows-7 auto-cols-[1rem] gap-0.5"
+          className="grid grid-flow-col justify-self-start gap-0.5"
+          style={{
+            gridTemplateColumns: 'repeat(4, 1rem)',
+            gridTemplateRows: 'repeat(7, 1rem)',
+          }}
           aria-label="Four weeks of GitHub activity"
         >
           {days.map((day, index) => {

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -3,6 +3,8 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+const IDLE_TRANSFORM = 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1)';
+
 function countdownToUtcMidnight() {
   const now = new Date();
   const midnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
@@ -94,32 +96,67 @@ function ScoreDigits({ value }: { value: number }) {
     [value],
   );
   const digitRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const animationsRef = useRef<Array<Animation | null>>([]);
   const frameRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
       if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      for (const animation of animationsRef.current) animation?.cancel();
     };
   }, []);
 
-  const resetDigits = () => {
+  const resetImmediately = () => {
     if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
-    frameRef.current = window.requestAnimationFrame(() => {
-      for (const digit of digitRefs.current) {
-        if (digit) digit.style.transform = 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)';
-      }
+    for (const animation of animationsRef.current) animation?.cancel();
+    for (const digit of digitRefs.current) {
+      if (digit) digit.style.transform = IDLE_TRANSFORM;
+    }
+  };
+
+  const settleDigits = () => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      resetImmediately();
+      return;
+    }
+
+    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    digitRefs.current.forEach((digit, index) => {
+      if (!digit) return;
+      animationsRef.current[index]?.cancel();
+      const from = digit.style.transform || IDLE_TRANSFORM;
+      const direction = index % 2 === 0 ? -1 : 1;
+      const animation = digit.animate(
+        [
+          { transform: from, offset: 0 },
+          { transform: `translate3d(${direction * 1.5}px, -3px, 0) rotateX(-2deg) rotateY(${direction * 2.5}deg) rotateZ(${direction * 0.8}deg) scale(1.012)`, offset: 0.34 },
+          { transform: `translate3d(${direction * -0.6}px, 0.8px, 0) rotateX(0.7deg) rotateY(${direction * -0.8}deg) rotateZ(${direction * -0.25}deg) scale(0.998)`, offset: 0.72 },
+          { transform: IDLE_TRANSFORM, offset: 1 },
+        ],
+        {
+          duration: 520 + index * 35,
+          easing: 'cubic-bezier(0.2, 0.75, 0.2, 1)',
+          fill: 'forwards',
+        },
+      );
+      animation.onfinish = () => {
+        digit.style.transform = IDLE_TRANSFORM;
+        animation.cancel();
+      };
+      animationsRef.current[index] = animation;
     });
   };
 
   const moveDigits = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     const containerRect = currentTarget.getBoundingClientRect();
-    const influenceRadius = Math.max(90, containerRect.width * 0.55);
+    const influenceRadius = Math.max(130, containerRect.width * 0.48);
 
     if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
     frameRef.current = window.requestAnimationFrame(() => {
-      for (const digit of digitRefs.current) {
-        if (!digit) continue;
+      digitRefs.current.forEach((digit, index) => {
+        if (!digit) return;
+        animationsRef.current[index]?.cancel();
         const rect = digit.getBoundingClientRect();
         const centreX = rect.left + rect.width / 2;
         const centreY = rect.top + rect.height / 2;
@@ -127,25 +164,31 @@ function ScoreDigits({ value }: { value: number }) {
         const deltaY = clientY - centreY;
         const distance = Math.hypot(deltaX, deltaY);
         const influence = Math.max(0, 1 - distance / influenceRadius);
-        const moveX = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1))) * influence * 1.8;
-        const moveY = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1))) * influence * 1.3;
-        const rotateX = -moveY * 0.45;
-        const rotateY = moveX * 0.45;
+        const lift = Math.pow(influence, 1.45);
+        const horizontal = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1)));
+        const vertical = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1)));
+        const translateX = -horizontal * lift * 4.5;
+        const translateY = -lift * 14 + vertical * lift * 1.5;
+        const rotateX = (vertical * 7 - 3.5) * lift;
+        const rotateY = -horizontal * lift * 13;
+        const rotateZ = horizontal * lift * 2.4;
+        const scale = 1 + lift * 0.045;
 
-        digit.style.transform = `translate3d(${moveX.toFixed(2)}px, ${moveY.toFixed(2)}px, 0) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg)`;
-      }
+        digit.style.transform = `translate3d(${translateX.toFixed(2)}px, ${translateY.toFixed(2)}px, 0) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg) rotateZ(${rotateZ.toFixed(2)}deg) scale(${scale.toFixed(3)})`;
+      });
     });
   };
 
   return (
     <div
-      className="flex min-w-0 touch-pan-y gap-1.5 [perspective:720px]"
+      className="flex min-w-0 touch-pan-y gap-1.5 [perspective:780px]"
       aria-label={`${value} contributions today`}
+      data-wind-scoreboard
       onPointerMove={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
       onPointerDown={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
-      onPointerLeave={resetDigits}
-      onPointerCancel={resetDigits}
-      onPointerUp={resetDigits}
+      onPointerLeave={settleDigits}
+      onPointerCancel={settleDigits}
+      onPointerUp={settleDigits}
     >
       {digits.map((digit, index) => (
         <div
@@ -154,8 +197,8 @@ function ScoreDigits({ value }: { value: number }) {
             digitRefs.current[index] = element;
           }}
           data-activity-digit
-          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.45rem] border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(1.8rem,6.5vw,3.4rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-10px_18px_rgba(0,0,0,0.28),0_4px_10px_rgba(0,0,0,0.14)] transition-transform duration-150 ease-out [transform-style:preserve-3d] motion-reduce:transform-none"
-          style={{ transform: 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)' }}
+          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.45rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(1.8rem,6.5vw,3.4rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_5px_12px_rgba(0,0,0,0.18)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
+          style={{ transform: IDLE_TRANSFORM }}
         >
           <SplitFlapDigit digit={digit} index={index} />
         </div>
@@ -183,26 +226,26 @@ export function ActivityScoreboard({
   }, []);
 
   return (
-    <section className="h-full overflow-hidden rounded-[1.1rem] border border-black/15 bg-[#d8d5ce] shadow-[0_12px_28px_rgba(24,24,26,0.1)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_14px_34px_rgba(0,0,0,0.26)]">
-      <div className="border-b border-black/15 bg-[#c9c6bf] px-3 py-1.5 dark:border-white/10 dark:bg-[#18191d]">
-        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/60 dark:text-white/58">
+    <section className="group/score h-full overflow-hidden rounded-[1.1rem] border border-black/18 bg-[#d0cdc5] shadow-[0_12px_28px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_20px_38px_rgba(24,24,26,0.16)] dark:border-white/16 dark:bg-[#202126] dark:shadow-[0_14px_34px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_22px_44px_rgba(0,0,0,0.42)]">
+      <div className="border-b border-black/16 bg-[#bfbbb2] px-3 py-1.5 dark:border-white/12 dark:bg-[#292a30]">
+        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/68 dark:text-white/72">
           <span>Today</span>
           <span className="tabular-nums">UTC reset {countdown}</span>
         </div>
       </div>
 
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 p-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 p-3 sm:p-4">
         <ScoreDigits value={today} />
-        <div className="grid min-w-[4.6rem] gap-2 pb-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-black/52 dark:text-white/48">
+        <div className="grid min-w-[4.6rem] gap-2 pb-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-black/62 dark:text-white/64">
           <span className="grid gap-0.5">
             <span>7D</span>
-            <strong className="text-sm font-semibold leading-none text-black/80 dark:text-white/80">
+            <strong className="text-sm font-semibold leading-none text-black/88 dark:text-white/90">
               {weekTotal.toLocaleString('en-GB')}
             </strong>
           </span>
           <span className="grid gap-0.5" title="Calendar year to date, measured in UTC">
             <span>YTD</span>
-            <strong className="text-sm font-semibold leading-none text-black/80 dark:text-white/80">
+            <strong className="text-sm font-semibold leading-none text-black/88 dark:text-white/90">
               {yearTotal?.toLocaleString('en-GB') ?? '—'}
             </strong>
           </span>

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,16 +1,91 @@
 'use client';
 
+import { motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-function countdownToMidnight() {
+function countdownToUtcMidnight() {
   const now = new Date();
-  const midnight = new Date(now);
-  midnight.setHours(24, 0, 0, 0);
-  const seconds = Math.max(0, Math.floor((midnight.getTime() - now.getTime()) / 1000));
+  const midnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
+  const seconds = Math.max(0, Math.floor((midnight - now.getTime()) / 1000));
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const remainder = seconds % 60;
   return [hours, minutes, remainder].map((part) => String(part).padStart(2, '0')).join(':');
+}
+
+function StaticHalf({ digit, half }: { digit: string; half: 'top' | 'bottom' }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`absolute inset-x-0 h-1/2 overflow-hidden ${half === 'top' ? 'top-0' : 'bottom-0'}`}
+    >
+      <span
+        className={`absolute inset-x-0 flex h-[200%] items-center justify-center tabular-nums ${half === 'top' ? 'top-0' : 'bottom-0'}`}
+      >
+        {digit}
+      </span>
+    </span>
+  );
+}
+
+function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
+  const reduceMotion = useReducedMotion();
+  const [current, setCurrent] = useState(digit);
+  const [previous, setPrevious] = useState(digit);
+  const [sequence, setSequence] = useState(0);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    if (digit === current) return;
+    setPrevious(current);
+    setCurrent(digit);
+    setSequence((value) => value + 1);
+    setAnimating(!reduceMotion);
+  }, [current, digit, reduceMotion]);
+
+  const stagger = (3 - index) * 0.035;
+
+  return (
+    <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
+      <StaticHalf digit={current} half="top" />
+      <StaticHalf digit={current} half="bottom" />
+
+      {animating ? (
+        <>
+          <motion.span
+            key={`depart-${sequence}`}
+            aria-hidden="true"
+            className="absolute inset-x-0 top-0 z-20 h-1/2 origin-bottom overflow-hidden bg-[#1b1c20] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-8px_12px_rgba(0,0,0,0.2)] [backface-visibility:hidden] [transform-style:preserve-3d]"
+            initial={{ rotateX: 0 }}
+            animate={{ rotateX: -90 }}
+            transition={{ duration: 0.22, delay: stagger, ease: [0.55, 0.06, 0.68, 0.19] }}
+          >
+            <span className="absolute inset-x-0 top-0 flex h-[200%] items-center justify-center tabular-nums">
+              {previous}
+            </span>
+          </motion.span>
+          <motion.span
+            key={`arrive-${sequence}`}
+            aria-hidden="true"
+            className="absolute inset-x-0 bottom-0 z-30 h-1/2 origin-top overflow-hidden bg-[#15161a] shadow-[inset_0_8px_12px_rgba(0,0,0,0.34)] [backface-visibility:hidden] [transform-style:preserve-3d]"
+            initial={{ rotateX: 90 }}
+            animate={{ rotateX: 0 }}
+            transition={{ duration: 0.28, delay: stagger + 0.19, ease: [0.22, 1, 0.36, 1] }}
+            onAnimationComplete={() => setAnimating(false)}
+          >
+            <span className="absolute inset-x-0 bottom-0 flex h-[200%] items-center justify-center tabular-nums">
+              {current}
+            </span>
+          </motion.span>
+        </>
+      ) : null}
+
+      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px bg-black/80" />
+      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px -translate-y-px bg-white/[0.05]" />
+      <span aria-hidden="true" className="absolute left-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]" />
+      <span aria-hidden="true" className="absolute right-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]" />
+    </span>
+  );
 }
 
 function ScoreDigits({ value }: { value: number }) {
@@ -18,7 +93,7 @@ function ScoreDigits({ value }: { value: number }) {
     () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
     [value],
   );
-  const digitRefs = useRef<Array<HTMLSpanElement | null>>([]);
+  const digitRefs = useRef<Array<HTMLDivElement | null>>([]);
   const frameRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -52,10 +127,10 @@ function ScoreDigits({ value }: { value: number }) {
         const deltaY = clientY - centreY;
         const distance = Math.hypot(deltaX, deltaY);
         const influence = Math.max(0, 1 - distance / influenceRadius);
-        const moveX = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1))) * influence * 2.5;
-        const moveY = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1))) * influence * 2;
-        const rotateX = -moveY * 0.55;
-        const rotateY = moveX * 0.55;
+        const moveX = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1))) * influence * 1.8;
+        const moveY = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1))) * influence * 1.3;
+        const rotateX = -moveY * 0.45;
+        const rotateY = moveX * 0.45;
 
         digit.style.transform = `translate3d(${moveX.toFixed(2)}px, ${moveY.toFixed(2)}px, 0) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg)`;
       }
@@ -64,7 +139,7 @@ function ScoreDigits({ value }: { value: number }) {
 
   return (
     <div
-      className="flex min-w-0 touch-pan-y gap-1.5 sm:gap-2"
+      className="flex min-w-0 touch-pan-y gap-1.5 [perspective:720px]"
       aria-label={`${value} contributions today`}
       onPointerMove={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
       onPointerDown={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
@@ -73,19 +148,17 @@ function ScoreDigits({ value }: { value: number }) {
       onPointerUp={resetDigits}
     >
       {digits.map((digit, index) => (
-        <span
+        <div
           key={index}
           ref={(element) => {
             digitRefs.current[index] = element;
           }}
           data-activity-digit
-          className="relative flex aspect-[0.76] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(2.35rem,8vw,4.8rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-12px_22px_rgba(0,0,0,0.25),0_4px_12px_rgba(0,0,0,0.14)] transition-transform duration-150 ease-out motion-reduce:transform-none"
+          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.45rem] border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(1.8rem,6.5vw,3.4rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-10px_18px_rgba(0,0,0,0.28),0_4px_10px_rgba(0,0,0,0.14)] transition-transform duration-150 ease-out [transform-style:preserve-3d] motion-reduce:transform-none"
           style={{ transform: 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)' }}
         >
-          <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px bg-black/70" />
-          <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px -translate-y-px bg-white/[0.045]" />
-          <span className="relative -translate-y-[0.02em] tabular-nums">{digit}</span>
-        </span>
+          <SplitFlapDigit digit={digit} index={index} />
+        </div>
       ))}
     </div>
   );
@@ -103,29 +176,35 @@ export function ActivityScoreboard({
   const [countdown, setCountdown] = useState('--:--:--');
 
   useEffect(() => {
-    const update = () => setCountdown(countdownToMidnight());
+    const update = () => setCountdown(countdownToUtcMidnight());
     update();
     const interval = window.setInterval(update, 1000);
     return () => window.clearInterval(interval);
   }, []);
 
   return (
-    <section className="overflow-hidden rounded-[1.25rem] border border-black/15 bg-[#d8d5ce] shadow-[0_14px_34px_rgba(24,24,26,0.11)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_16px_40px_rgba(0,0,0,0.28)]">
-      <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2 dark:border-white/10 dark:bg-[#18191d]">
-        <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-black/60 dark:text-white/58">
+    <section className="h-full overflow-hidden rounded-[1.1rem] border border-black/15 bg-[#d8d5ce] shadow-[0_12px_28px_rgba(24,24,26,0.1)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_14px_34px_rgba(0,0,0,0.26)]">
+      <div className="border-b border-black/15 bg-[#c9c6bf] px-3 py-1.5 dark:border-white/10 dark:bg-[#18191d]">
+        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/60 dark:text-white/58">
           <span>Today</span>
-          <span className="tabular-nums">resets in {countdown}</span>
+          <span className="tabular-nums">UTC reset {countdown}</span>
         </div>
       </div>
 
-      <div className="grid gap-3 p-3.5 sm:p-4">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 p-3">
         <ScoreDigits value={today} />
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-0.5 font-mono text-[11px] uppercase tracking-[0.11em] text-black/55 dark:text-white/48">
-          <span>
-            7 days <strong className="ml-1 font-semibold text-black/78 dark:text-white/78">{weekTotal.toLocaleString('en-GB')}</strong>
+        <div className="grid min-w-[4.6rem] gap-2 pb-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-black/52 dark:text-white/48">
+          <span className="grid gap-0.5">
+            <span>7D</span>
+            <strong className="text-sm font-semibold leading-none text-black/80 dark:text-white/80">
+              {weekTotal.toLocaleString('en-GB')}
+            </strong>
           </span>
-          <span>
-            Year <strong className="ml-1 font-semibold text-black/78 dark:text-white/78">{yearTotal?.toLocaleString('en-GB') ?? '—'}</strong>
+          <span className="grid gap-0.5" title="Calendar year to date, measured in UTC">
+            <span>YTD</span>
+            <strong className="text-sm font-semibold leading-none text-black/80 dark:text-white/80">
+              {yearTotal?.toLocaleString('en-GB') ?? '—'}
+            </strong>
           </span>
         </div>
       </div>

--- a/components/proxy/usage-dashboard-container.tsx
+++ b/components/proxy/usage-dashboard-container.tsx
@@ -4,6 +4,15 @@ import type { ProxyHealthPayload, ProxyHealthSample } from '@/app/lib/proxy-heal
 import { readProxyHealth } from '@/app/lib/proxy-health-store';
 import { UsageDashboard } from './usage-dashboard';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type UsageValues = {
+  used: number | null;
+  limit: number | null;
+  remaining: number | null;
+  resetAt: string | null;
+};
+
 function usageLimitBytes() {
   const gb = Number(process.env.PROXY_USAGE_30D_LIMIT_GB ?? '1024');
   const safeGb = Number.isFinite(gb) && gb > 0 ? gb : 1024;
@@ -30,28 +39,150 @@ function latestStatusSample(payload: ProxyHealthPayload): ProxyHealthSample | nu
   };
 }
 
-function formatTimestamp(value: string | null) {
-  if (!value) return 'Unavailable';
+function providerUsage(payload: ProxyHealthPayload, fallbackLimit: number): UsageValues {
+  const usage = (payload as {
+    provider?: {
+      usage?: {
+        used_bytes?: unknown;
+        limit_bytes?: unknown;
+        remaining_bytes?: unknown;
+        reset_at?: unknown;
+      };
+    };
+  }).provider?.usage;
+
+  const used = numberOrNull(usage?.used_bytes);
+  const limit = numberOrNull(usage?.limit_bytes) ?? fallbackLimit;
+  const reportedRemaining = numberOrNull(usage?.remaining_bytes);
+  const remaining = reportedRemaining ?? (used !== null && limit !== null ? Math.max(0, limit - used) : null);
+
+  return {
+    used,
+    limit,
+    remaining,
+    resetAt: typeof usage?.reset_at === 'string' ? usage.reset_at : null,
+  };
+}
+
+function formatBytes(value: number | null) {
+  if (value === null) return '—';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = value;
+  let unit = 0;
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024;
+    unit += 1;
+  }
+  return `${size.toFixed(unit === 0 ? 0 : 2)} ${units[unit]}`;
+}
+
+function formatPercent(value: number | null) {
+  if (value === null) return '—';
+  if (value > 0 && value < 1) return '<1%';
+  return `${Math.round(value)}%`;
+}
+
+function formatReset(value: string | null) {
+  if (!value) return '—';
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return 'Unavailable';
+  if (Number.isNaN(date.getTime())) return '—';
   return new Intl.DateTimeFormat('en-GB', {
-    dateStyle: 'medium',
-    timeStyle: 'medium',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
     timeZone: 'UTC',
   }).format(date);
 }
 
-function reportAge(checkedAt: string | null) {
-  if (!checkedAt) return { label: 'Unknown', stale: true };
-  const checked = new Date(checkedAt).getTime();
-  if (!Number.isFinite(checked)) return { label: 'Unknown', stale: true };
+function previousMonthlyReset(reset: Date) {
+  const year = reset.getUTCFullYear();
+  const month = reset.getUTCMonth();
+  const requestedDay = reset.getUTCDate();
+  const finalDayOfPreviousMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return new Date(Date.UTC(
+    year,
+    month - 1,
+    Math.min(requestedDay, finalDayOfPreviousMonth),
+    reset.getUTCHours(),
+    reset.getUTCMinutes(),
+    reset.getUTCSeconds(),
+    reset.getUTCMilliseconds(),
+  ));
+}
 
-  const ageMs = Math.max(0, Date.now() - checked);
-  const staleAfterMinutes = Number(process.env.PROXY_HEALTH_STALE_AFTER_MINUTES ?? '15');
-  const staleAfterMs = (Number.isFinite(staleAfterMinutes) && staleAfterMinutes > 0 ? staleAfterMinutes : 15) * 60_000;
-  const minutes = Math.floor(ageMs / 60_000);
-  const label = minutes < 1 ? 'Under a minute' : minutes < 60 ? `${minutes} minutes` : `${Math.floor(minutes / 60)} hours`;
-  return { label, stale: ageMs > staleAfterMs };
+function cyclePercent(resetAt: string | null) {
+  if (!resetAt) return null;
+  const reset = new Date(resetAt);
+  if (Number.isNaN(reset.getTime())) return null;
+  const start = previousMonthlyReset(reset);
+  const span = reset.getTime() - start.getTime();
+  if (span <= 0) return null;
+  return Math.min(100, Math.max(0, ((Date.now() - start.getTime()) / span) * 100));
+}
+
+function quotaPercent(usage: UsageValues) {
+  if (usage.used === null || usage.limit === null || usage.limit <= 0) return null;
+  return Math.min(100, Math.max(0, (usage.used / usage.limit) * 100));
+}
+
+function roomPerDay(usage: UsageValues) {
+  if (usage.remaining === null || !usage.resetAt) return null;
+  const reset = new Date(usage.resetAt).getTime();
+  if (!Number.isFinite(reset)) return null;
+  const days = Math.max(1, Math.ceil((reset - Date.now()) / DAY_MS));
+  return usage.remaining / days;
+}
+
+function Metric({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="min-w-0 rounded-xl border bg-muted/35 px-3 py-3">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">{label}</div>
+      <div className="mt-1 truncate text-2xl font-semibold tracking-tight text-foreground">{value}</div>
+      <div className="mt-0.5 truncate text-xs text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+function ProxyUsageSummary({ payload, fallbackLimit }: { payload: ProxyHealthPayload; fallbackLimit: number }) {
+  const usage = providerUsage(payload, fallbackLimit);
+  const quota = quotaPercent(usage);
+  const cycle = cyclePercent(usage.resetAt);
+  const room = roomPerDay(usage);
+
+  return (
+    <section className="rounded-2xl border bg-background/90 p-3 shadow-sm" aria-label="Proxy quota and reset cycle">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <Metric
+          label="Quota used"
+          value={formatPercent(quota)}
+          detail={`${formatBytes(usage.used)} of ${formatBytes(usage.limit)}`}
+        />
+        <Metric
+          label="Cycle elapsed"
+          value={formatPercent(cycle)}
+          detail="calendar month between provider resets"
+        />
+        <Metric
+          label="Room / day"
+          value={formatBytes(room)}
+          detail={`${formatBytes(usage.remaining)} remaining`}
+        />
+        <Metric
+          label="Reset"
+          value={formatReset(usage.resetAt)}
+          detail="provider timestamp · UTC"
+        />
+      </div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2" aria-hidden="true">
+        <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+          <div className="h-full rounded-full bg-[#8d8299] transition-[width] duration-300 dark:bg-[#b8adc4]" style={{ width: `${quota ?? 0}%` }} />
+        </div>
+        <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+          <div className="h-full rounded-full bg-[#6f7d77] transition-[width] duration-300 dark:bg-[#9eb0a8]" style={{ width: `${cycle ?? 0}%` }} />
+        </div>
+      </div>
+    </section>
+  );
 }
 
 function StateCard({ title, body, requestId }: { title: string; body: string; requestId?: string }) {
@@ -84,38 +215,14 @@ export async function UsageDashboardContainer() {
   const { report, samples } = result;
   const fallbackSample = latestStatusSample(report.payload);
   const visibleSamples = samples.length > 0 || !fallbackSample ? samples : [fallbackSample];
-  const age = reportAge(report.checkedAt);
+  const fallbackLimit = usageLimitBytes();
 
   return (
     <div className="space-y-3">
-      <section className="rounded-xl border bg-background/80 px-4 py-3 shadow-sm" aria-label="Proxy report freshness">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Report freshness</p>
-            <p className="mt-1 text-sm">
-              Age <span className="font-medium">{age.label}</span>
-            </p>
-          </div>
-          <span
-            className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
-              age.stale ? 'border-amber-500/45 bg-amber-500/12' : 'border-emerald-500/45 bg-emerald-500/12'
-            }`}
-          >
-            {age.stale ? 'Stale' : 'Current'}
-          </span>
-        </div>
-        <dl className="mt-3 grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
-          <div>
-            <dt>Payload checked_at</dt>
-            <dd className="mt-0.5 font-mono text-foreground">{formatTimestamp(report.checkedAt)}</dd>
-          </div>
-          <div>
-            <dt>Row updated_at</dt>
-            <dd className="mt-0.5 font-mono text-foreground">{formatTimestamp(report.updatedAt)}</dd>
-          </div>
-        </dl>
-      </section>
-      <UsageDashboard samples={visibleSamples} status={report} limitBytes={usageLimitBytes()} />
+      <ProxyUsageSummary payload={report.payload} fallbackLimit={fallbackLimit} />
+      <div className="proxy-usage-dashboard">
+        <UsageDashboard samples={visibleSamples} status={report} limitBytes={fallbackLimit} />
+      </div>
     </div>
   );
 }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const publicRoutes = ['/', '/time', '/blog', '/gallery', '/atelier'];
-const idleDigitTransform = 'translate3d(0px, 0px, 0px) rotateX(0deg) rotateY(0deg)';
+const idleDigitTransform = 'translate3d(0px, 0px, 0px) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1)';
 
 async function expectNoHorizontalOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({
@@ -78,18 +78,17 @@ for (const route of publicRoutes) {
   });
 }
 
-test('homepage highlights three recent systems', async ({ page }) => {
+test('homepage highlights three recent systems without an extra slogan', async ({ page }) => {
   await page.goto('/');
 
-  await expect(
-    page.getByRole('heading', { name: 'Tools that remember their boundaries' }),
-  ).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Recent systems' })).toBeVisible();
+  await expect(page.getByText('Tools that remember their boundaries')).toHaveCount(0);
   await expect(page.getByRole('link', { name: /smolrunner/i })).toBeVisible();
   await expect(page.getByRole('link', { name: /stensibly/i })).toBeVisible();
   await expect(page.getByRole('link', { name: /proofwake/i })).toBeVisible();
 });
 
-test('homepage presents activity as a compact YTD matrix', async ({ page }) => {
+test('homepage presents activity as a wide YTD matrix', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByText('YTD', { exact: true })).toBeVisible();
@@ -99,10 +98,10 @@ test('homepage presents activity as a compact YTD matrix', async ({ page }) => {
 
   const box = await grid.boundingBox();
   expect(box).toBeTruthy();
-  expect(box!.height).toBeGreaterThan(box!.width);
+  expect(box!.width).toBeGreaterThan(box!.height);
 });
 
-test('homepage activity tooltip stays continuous between cells', async ({ page }) => {
+test('homepage activity tooltip stays continuous, single-line, and fades on exit', async ({ page }) => {
   await page.goto('/');
   await waitForClientHydration(page);
 
@@ -111,10 +110,14 @@ test('homepage activity tooltip stays continuous between cells', async ({ page }
   await cells.nth(0).hover();
   await expect(tooltip).toBeVisible();
   const firstLabel = await tooltip.textContent();
+  expect(await tooltip.evaluate((element) => getComputedStyle(element).whiteSpace)).toBe('nowrap');
 
   await cells.nth(1).hover();
   await expect(tooltip).toBeVisible();
   await expect.poll(() => tooltip.textContent()).not.toBe(firstLabel);
+
+  await page.mouse.move(2, 2);
+  await expect(tooltip).toBeHidden({ timeout: 1_000 });
 });
 
 test('gallery credits the agents who worked here', async ({ page }) => {
@@ -182,7 +185,7 @@ test('gallery wheel scrolls over the canvas', async ({ page }) => {
   await expectWheelScrollsDocument(page, '/gallery', 'canvas');
 });
 
-test('homepage counter uses four independently reactive digits', async ({ page }) => {
+test('homepage counter uses four independently reactive wind-lift digits', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'no-preference' });
   await page.goto('/');
   const digits = await moveActivityDigits(page);
@@ -196,6 +199,7 @@ test('homepage counter uses four independently reactive digits', async ({ page }
   );
   expect(new Set(transforms).size).toBeGreaterThan(1);
   expect(transforms[0]).not.toEqual(transforms[3]);
+  expect(transforms.some((transform) => /translate3d\([^,]+, -(?:[4-9]|\d{2})/.test(transform))).toBe(true);
 });
 
 test('homepage counter respects reduced motion', async ({ page }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -89,6 +89,34 @@ test('homepage highlights three recent systems', async ({ page }) => {
   await expect(page.getByRole('link', { name: /proofwake/i })).toBeVisible();
 });
 
+test('homepage presents activity as a compact YTD matrix', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByText('YTD', { exact: true })).toBeVisible();
+  const grid = page.locator('[aria-label="Four weeks of GitHub activity"]');
+  const cells = grid.locator('[data-activity-cell]');
+  await expect(cells).toHaveCount(28);
+
+  const box = await grid.boundingBox();
+  expect(box).toBeTruthy();
+  expect(box!.height).toBeGreaterThan(box!.width);
+});
+
+test('homepage activity tooltip stays continuous between cells', async ({ page }) => {
+  await page.goto('/');
+  await waitForClientHydration(page);
+
+  const cells = page.locator('[data-activity-cell]');
+  const tooltip = page.locator('[data-activity-tooltip]');
+  await cells.nth(0).hover();
+  await expect(tooltip).toBeVisible();
+  const firstLabel = await tooltip.textContent();
+
+  await cells.nth(1).hover();
+  await expect(tooltip).toBeVisible();
+  await expect.poll(() => tooltip.textContent()).not.toBe(firstLabel);
+});
+
 test('gallery credits the agents who worked here', async ({ page }) => {
   await page.goto('/gallery');
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -23,6 +23,7 @@ async function expectWheelScrollsDocument(page: Page, route: string, selector: s
   await page.setViewportSize({ width: 900, height: 420 });
   const response = await page.goto(route);
   expect(response?.ok()).toBe(true);
+  await waitForClientHydration(page);
 
   const target = page.locator(selector).first();
   await expect(target).toBeVisible();


### PR DESCRIPTION
## Summary

### Homepage mechanics
- keeps the real split-flap value transition and adds a much stronger cursor-driven wind-lift response across neighbouring digits
- settles the digits with a damped back-and-forth motion instead of snapping flat
- preserves independent digit response and reduced-motion behaviour

### Contribution panel
- changes the 28-day view to seven day-columns by four week-rows so it fills the card instead of leaving a wide empty strip
- enlarges the cells and gives the contribution panel the dominant share of the desktop layout
- keeps the hover label on one line, preserves one continuous tooltip between cells, and fades it quickly after pointer exit
- retains UTC contribution dates, UTC reset countdown, YTD labelling, and visible-minute refreshes backed by shared CDN caching

### Colour and layout
- replaces the near-white light palette with muted warm greys
- raises dark-mode foreground, muted-text, border, popover, and card contrast to avoid black-on-black states
- removes the "Tools that remember their boundaries" slogan
- lets the recent-project shelf use the remaining viewport instead of leaving an unexplained lower blank band

### Proxy dashboard
- removes the separate Report freshness panel
- fixes the previous semantic mismatch where quota-used percentage was labelled as the billing cycle
- displays quota used, actual monthly cycle elapsed, room per day, and the exact provider reset timestamp as separate metrics
- calculates cycle elapsed from consecutive same-day monthly resets, including a reset on the 28th, rather than assuming a fixed 30-day cycle
- keeps the detailed bandwidth and latency views below the corrected summary

## Proxy diagnosis

Production ingest is accepting reports with HTTP 200 and no current runtime errors. That confirms the application ingestion path is alive. It does not prove Bandwagon's upstream raw usage counter is advancing; the corrected summary exposes the provider values directly so upstream staleness is no longer obscured by a mislabeled ring.

## Validation

- ESLint
- TypeScript
- unit tests
- Next.js production build
- Chromium Playwright suite
- WebKit Playwright suite

The PR remains unmerged and production is unchanged.