### PR TITLE
Finish the homepage activity instrument panel

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -1,48 +1,40 @@
-import { NextResponse } from 'next/server';
+import { getGitHubHomeData } from '@/lib/github-home';
 import { connection } from 'next/server';
-import { getRecentDateKeys, parsePublicContributionHtml } from '@/lib/github-activity-utils';
+import { NextResponse } from 'next/server';
 
-const GITHUB_USERNAME = 'teamleaderleo';
+const CLIENT_REFRESH_SECONDS = 60;
+const UPSTREAM_CACHE_SECONDS = 300;
 
 export async function GET() {
   await connection();
   const requestId = crypto.randomUUID();
 
   try {
-    const response = await fetch(`https://github.com/users/${GITHUB_USERNAME}/contributions`, {
-      cache: 'no-store',
-      headers: {
-        Accept: 'text/html',
-        'User-Agent': 'teamleaderleo-scrapbook',
-      },
-      signal: AbortSignal.timeout(8_000),
-    });
+    const activity = await getGitHubHomeData();
 
-    if (!response.ok) throw new Error(`GitHub contribution page returned ${response.status}`);
-
-    const counts = parsePublicContributionHtml(await response.text());
-    if (counts.size === 0) throw new Error('GitHub contribution page could not be parsed');
-
-    const now = new Date();
-    const dateKeys = getRecentDateKeys(now, 35);
-    const todayKey = dateKeys.at(-1) ?? now.toISOString().slice(0, 10);
-    const days = dateKeys.map((date) => ({ date, count: counts.get(date) ?? 0 }));
-    const yearTotal = [...counts.entries()]
-      .filter(([date]) => date.startsWith(todayKey.slice(0, 4)) && date <= todayKey)
-      .reduce((sum, [, count]) => sum + count, 0);
+    if (activity.source === 'unavailable') {
+      return NextResponse.json(
+        { ok: false, error: 'GitHub activity is temporarily unavailable', requestId },
+        { status: 503, headers: { 'Cache-Control': 'no-store', 'X-Request-Id': requestId } },
+      );
+    }
 
     return NextResponse.json(
       {
-        source: 'public-profile',
-        generatedAt: now.toISOString(),
-        today: days.at(-1)?.count ?? 0,
-        weekTotal: days.slice(-7).reduce((sum, day) => sum + day.count, 0),
-        yearTotal,
-        days: days.slice(-28),
+        source: activity.source,
+        generatedAt: activity.generatedAt,
+        today: activity.today,
+        weekTotal: activity.weekTotal,
+        yearTotal: activity.periodLabel === 'this year' ? activity.total : null,
+        days: activity.days.slice(-28),
       },
       {
         headers: {
-          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300',
+          'Cache-Control': `public, s-maxage=${CLIENT_REFRESH_SECONDS}, stale-while-revalidate=3600`,
+          'X-Activity-Source': activity.source,
+          'X-Activity-Generated-At': activity.generatedAt,
+          'X-Client-Refresh-Seconds': String(CLIENT_REFRESH_SECONDS),
+          'X-Upstream-Cache-Seconds': String(UPSTREAM_CACHE_SECONDS),
           'X-Request-Id': requestId,
         },
       },
@@ -51,7 +43,7 @@ export async function GET() {
     console.error('Unable to refresh GitHub activity', { requestId, error });
     return NextResponse.json(
       { ok: false, error: 'GitHub activity is temporarily unavailable', requestId },
-      { status: 502, headers: { 'Cache-Control': 'no-store', 'X-Request-Id': requestId } },
+      { status: 503, headers: { 'Cache-Control': 'no-store', 'X-Request-Id': requestId } },
     );
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ export default async function Page() {
   const activity = await getGitHubHomeData();
   const unit = activity.source === 'public-events' ? 'public actions' : 'contributions';
   const days = activity.days.slice(-28);
+  const yearTotal = activity.periodLabel === 'this year' ? activity.total : null;
 
   return (
     <ViewportPageShell
@@ -37,9 +38,10 @@ export default async function Page() {
             initial={{
               today: activity.today,
               weekTotal: activity.weekTotal,
-              yearTotal: activity.total,
+              yearTotal,
               days,
               unit,
+              generatedAt: activity.generatedAt,
             }}
           />
 

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -4,31 +4,45 @@ import { ActivityGrid, type ActivityGridDay } from '@/components/home/activity-g
 import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
 import { useEffect, useRef, useState } from 'react';
 
+const REFRESH_INTERVAL_MS = 60_000;
+const MAX_FAILURE_BACKOFF_MS = 15 * 60_000;
+
 type ActivitySnapshot = {
   today: number;
   weekTotal: number;
   yearTotal: number | null;
   days: ActivityGridDay[];
   unit: string;
+  generatedAt: string;
 };
 
 type LiveActivityResponse = {
   today: number;
   weekTotal: number;
-  yearTotal: number;
+  yearTotal: number | null;
   days: ActivityGridDay[];
+  generatedAt: string;
 };
+
+function timestampOrNow(value: string) {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
 
 export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   const [activity, setActivity] = useState(initial);
   const [updating, setUpdating] = useState(false);
   const inFlight = useRef<AbortController | null>(null);
+  const nextAllowedAt = useRef(timestampOrNow(initial.generatedAt) + REFRESH_INTERVAL_MS);
+  const consecutiveFailures = useRef(0);
 
   useEffect(() => {
     let mounted = true;
+    let timer: number | null = null;
 
     const refresh = async () => {
       if (document.visibilityState !== 'visible' || inFlight.current) return;
+      if (Date.now() < nextAllowedAt.current) return;
 
       const controller = new AbortController();
       inFlight.current = controller;
@@ -43,9 +57,17 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
 
         const next = (await response.json()) as LiveActivityResponse;
         if (!mounted) return;
+        consecutiveFailures.current = 0;
+        nextAllowedAt.current = Date.now() + REFRESH_INTERVAL_MS;
         setActivity({ ...next, unit: 'contributions' });
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') return;
+        consecutiveFailures.current += 1;
+        const backoff = Math.min(
+          REFRESH_INTERVAL_MS * 2 ** (consecutiveFailures.current - 1),
+          MAX_FAILURE_BACKOFF_MS,
+        );
+        nextAllowedAt.current = Date.now() + backoff;
         console.error('Unable to update GitHub activity', error);
       } finally {
         if (inFlight.current === controller) inFlight.current = null;
@@ -53,24 +75,43 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       }
     };
 
-    const initialRefresh = window.setTimeout(() => void refresh(), 2_500);
-    const interval = window.setInterval(() => void refresh(), 75_000);
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') void refresh();
+    const scheduleNext = (minimumDelay = 1_000) => {
+      if (timer !== null) window.clearTimeout(timer);
+      const freshnessDelay = Math.max(0, nextAllowedAt.current - Date.now());
+      const delay =
+        document.visibilityState === 'visible'
+          ? Math.max(minimumDelay, freshnessDelay)
+          : REFRESH_INTERVAL_MS;
+
+      timer = window.setTimeout(async () => {
+        await refresh();
+        if (mounted) scheduleNext();
+      }, delay);
     };
 
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') {
+        scheduleNext();
+        return;
+      }
+
+      void refresh().finally(() => {
+        if (mounted) scheduleNext();
+      });
+    };
+
+    scheduleNext(3_000);
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => {
       mounted = false;
-      window.clearTimeout(initialRefresh);
-      window.clearInterval(interval);
+      if (timer !== null) window.clearTimeout(timer);
       document.removeEventListener('visibilitychange', onVisibilityChange);
       inFlight.current?.abort();
     };
   }, []);
 
   return (
-    <div className="relative grid min-w-0 gap-4 lg:grid-cols-[minmax(15rem,0.42fr)_minmax(0,1fr)] lg:items-start">
+    <div className="relative grid min-w-0 gap-4 lg:grid-cols-[minmax(15rem,0.42fr)_minmax(0,1fr)] lg:items-stretch">
       <span className="sr-only" aria-live="polite">
         {updating ? 'Updating GitHub activity' : ''}
       </span>

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,16 +1,93 @@
 'use client';
 
+import { motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-function countdownToMidnight() {
+const IDLE_TRANSFORM = 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1)';
+
+function countdownToUtcMidnight() {
   const now = new Date();
-  const midnight = new Date(now);
-  midnight.setHours(24, 0, 0, 0);
-  const seconds = Math.max(0, Math.floor((midnight.getTime() - now.getTime()) / 1000));
+  const midnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
+  const seconds = Math.max(0, Math.floor((midnight - now.getTime()) / 1000));
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const remainder = seconds % 60;
   return [hours, minutes, remainder].map((part) => String(part).padStart(2, '0')).join(':');
+}
+
+function StaticHalf({ digit, half }: { digit: string; half: 'top' | 'bottom' }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`absolute inset-x-0 h-1/2 overflow-hidden ${half === 'top' ? 'top-0' : 'bottom-0'}`}
+    >
+      <span
+        className={`absolute inset-x-0 flex h-[200%] items-center justify-center tabular-nums ${half === 'top' ? 'top-0' : 'bottom-0'}`}
+      >
+        {digit}
+      </span>
+    </span>
+  );
+}
+
+function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
+  const reduceMotion = useReducedMotion();
+  const [current, setCurrent] = useState(digit);
+  const [previous, setPrevious] = useState(digit);
+  const [sequence, setSequence] = useState(0);
+  const [animating, setAnimating] = useState(false);
+
+  useEffect(() => {
+    if (digit === current) return;
+    setPrevious(current);
+    setCurrent(digit);
+    setSequence((value) => value + 1);
+    setAnimating(!reduceMotion && document.visibilityState === 'visible');
+  }, [current, digit, reduceMotion]);
+
+  const stagger = (3 - index) * 0.035;
+
+  return (
+    <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
+      <StaticHalf digit={current} half="top" />
+      <StaticHalf digit={current} half="bottom" />
+
+      {animating ? (
+        <>
+          <motion.span
+            key={`depart-${sequence}`}
+            aria-hidden="true"
+            className="absolute inset-x-0 top-0 z-20 h-1/2 origin-bottom overflow-hidden bg-[#1b1c20] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-8px_12px_rgba(0,0,0,0.2)] [backface-visibility:hidden] [transform-style:preserve-3d]"
+            initial={{ rotateX: 0 }}
+            animate={{ rotateX: -90 }}
+            transition={{ duration: 0.22, delay: stagger, ease: [0.55, 0.06, 0.68, 0.19] }}
+          >
+            <span className="absolute inset-x-0 top-0 flex h-[200%] items-center justify-center tabular-nums">
+              {previous}
+            </span>
+          </motion.span>
+          <motion.span
+            key={`arrive-${sequence}`}
+            aria-hidden="true"
+            className="absolute inset-x-0 bottom-0 z-30 h-1/2 origin-top overflow-hidden bg-[#15161a] shadow-[inset_0_8px_12px_rgba(0,0,0,0.34)] [backface-visibility:hidden] [transform-style:preserve-3d]"
+            initial={{ rotateX: 90 }}
+            animate={{ rotateX: 0 }}
+            transition={{ duration: 0.28, delay: stagger + 0.19, ease: [0.22, 1, 0.36, 1] }}
+            onAnimationComplete={() => setAnimating(false)}
+          >
+            <span className="absolute inset-x-0 bottom-0 flex h-[200%] items-center justify-center tabular-nums">
+              {current}
+            </span>
+          </motion.span>
+        </>
+      ) : null}
+
+      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px bg-black/80" />
+      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px -translate-y-px bg-white/[0.05]" />
+      <span aria-hidden="true" className="absolute left-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]" />
+      <span aria-hidden="true" className="absolute right-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]" />
+    </span>
+  );
 }
 
 function ScoreDigits({ value }: { value: number }) {
@@ -18,33 +95,74 @@ function ScoreDigits({ value }: { value: number }) {
     () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
     [value],
   );
-  const digitRefs = useRef<Array<HTMLSpanElement | null>>([]);
+  const digitRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const animationsRef = useRef<Array<Animation | null>>([]);
   const frameRef = useRef<number | null>(null);
 
   useEffect(() => {
     return () => {
       if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+      for (const animation of animationsRef.current) animation?.cancel();
     };
   }, []);
 
-  const resetDigits = () => {
+  const resetImmediately = () => {
     if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
-    frameRef.current = window.requestAnimationFrame(() => {
-      for (const digit of digitRefs.current) {
-        if (digit) digit.style.transform = 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)';
-      }
+    for (const animation of animationsRef.current) animation?.cancel();
+    for (const digit of digitRefs.current) {
+      if (digit) digit.style.transform = IDLE_TRANSFORM;
+    }
+  };
+
+  const settleDigits = () => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      resetImmediately();
+      return;
+    }
+
+    if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
+    digitRefs.current.forEach((digit, index) => {
+      if (!digit) return;
+      animationsRef.current[index]?.cancel();
+      const from = digit.style.transform || IDLE_TRANSFORM;
+      const direction = index % 2 === 0 ? -1 : 1;
+      const animation = digit.animate(
+        [
+          { transform: from, offset: 0 },
+          {
+            transform: `translate3d(${direction * 1.5}px, -3px, 0) rotateX(-2deg) rotateY(${direction * 2.5}deg) rotateZ(${direction * 0.8}deg) scale(1.012)`,
+            offset: 0.34,
+          },
+          {
+            transform: `translate3d(${direction * -0.6}px, 0.8px, 0) rotateX(0.7deg) rotateY(${direction * -0.8}deg) rotateZ(${direction * -0.25}deg) scale(0.998)`,
+            offset: 0.72,
+          },
+          { transform: IDLE_TRANSFORM, offset: 1 },
+        ],
+        {
+          duration: 520 + index * 35,
+          easing: 'cubic-bezier(0.2, 0.75, 0.2, 1)',
+          fill: 'forwards',
+        },
+      );
+      animation.onfinish = () => {
+        digit.style.transform = IDLE_TRANSFORM;
+        animation.cancel();
+      };
+      animationsRef.current[index] = animation;
     });
   };
 
   const moveDigits = (clientX: number, clientY: number, currentTarget: HTMLElement) => {
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     const containerRect = currentTarget.getBoundingClientRect();
-    const influenceRadius = Math.max(90, containerRect.width * 0.55);
+    const influenceRadius = Math.max(130, containerRect.width * 0.48);
 
     if (frameRef.current !== null) window.cancelAnimationFrame(frameRef.current);
     frameRef.current = window.requestAnimationFrame(() => {
-      for (const digit of digitRefs.current) {
-        if (!digit) continue;
+      digitRefs.current.forEach((digit, index) => {
+        if (!digit) return;
+        animationsRef.current[index]?.cancel();
         const rect = digit.getBoundingClientRect();
         const centreX = rect.left + rect.width / 2;
         const centreY = rect.top + rect.height / 2;
@@ -52,40 +170,44 @@ function ScoreDigits({ value }: { value: number }) {
         const deltaY = clientY - centreY;
         const distance = Math.hypot(deltaX, deltaY);
         const influence = Math.max(0, 1 - distance / influenceRadius);
-        const moveX = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1))) * influence * 2.5;
-        const moveY = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1))) * influence * 2;
-        const rotateX = -moveY * 0.55;
-        const rotateY = moveX * 0.55;
+        const lift = Math.pow(influence, 1.45);
+        const horizontal = Math.max(-1, Math.min(1, deltaX / Math.max(rect.width, 1)));
+        const vertical = Math.max(-1, Math.min(1, deltaY / Math.max(rect.height, 1)));
+        const translateX = -horizontal * lift * 4.5;
+        const translateY = -lift * 14 + vertical * lift * 1.5;
+        const rotateX = (vertical * 7 - 3.5) * lift;
+        const rotateY = -horizontal * lift * 13;
+        const rotateZ = horizontal * lift * 2.4;
+        const scale = 1 + lift * 0.045;
 
-        digit.style.transform = `translate3d(${moveX.toFixed(2)}px, ${moveY.toFixed(2)}px, 0) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg)`;
-      }
+        digit.style.transform = `translate3d(${translateX.toFixed(2)}px, ${translateY.toFixed(2)}px, 0) rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg) rotateZ(${rotateZ.toFixed(2)}deg) scale(${scale.toFixed(3)})`;
+      });
     });
   };
 
   return (
     <div
-      className="flex min-w-0 touch-pan-y gap-1.5 sm:gap-2"
+      className="flex min-w-0 touch-pan-y gap-1.5 [perspective:780px]"
       aria-label={`${value} contributions today`}
+      data-wind-scoreboard
       onPointerMove={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
       onPointerDown={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
-      onPointerLeave={resetDigits}
-      onPointerCancel={resetDigits}
-      onPointerUp={resetDigits}
+      onPointerLeave={settleDigits}
+      onPointerCancel={settleDigits}
+      onPointerUp={settleDigits}
     >
       {digits.map((digit, index) => (
-        <span
+        <div
           key={index}
           ref={(element) => {
             digitRefs.current[index] = element;
           }}
           data-activity-digit
-          className="relative flex aspect-[0.76] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md border border-white/10 bg-[#17181b] px-1 font-mono text-[clamp(2.35rem,8vw,4.8rem)] font-semibold leading-none text-[#f1efe9] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-12px_22px_rgba(0,0,0,0.25),0_4px_12px_rgba(0,0,0,0.14)] transition-transform duration-150 ease-out motion-reduce:transform-none"
-          style={{ transform: 'translate3d(0, 0, 0) rotateX(0deg) rotateY(0deg)' }}
+          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.45rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(1.8rem,6.5vw,3.4rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_5px_12px_rgba(0,0,0,0.18)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
+          style={{ transform: IDLE_TRANSFORM }}
         >
-          <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px bg-black/70" />
-          <span aria-hidden="true" className="absolute inset-x-0 top-1/2 h-px -translate-y-px bg-white/[0.045]" />
-          <span className="relative -translate-y-[0.02em] tabular-nums">{digit}</span>
-        </span>
+          <SplitFlapDigit digit={digit} index={index} />
+        </div>
       ))}
     </div>
   );
@@ -103,29 +225,35 @@ export function ActivityScoreboard({
   const [countdown, setCountdown] = useState('--:--:--');
 
   useEffect(() => {
-    const update = () => setCountdown(countdownToMidnight());
+    const update = () => setCountdown(countdownToUtcMidnight());
     update();
     const interval = window.setInterval(update, 1000);
     return () => window.clearInterval(interval);
   }, []);
 
   return (
-    <section className="overflow-hidden rounded-[1.25rem] border border-black/15 bg-[#d8d5ce] shadow-[0_14px_34px_rgba(24,24,26,0.11)] dark:border-white/12 dark:bg-[#202126] dark:shadow-[0_16px_40px_rgba(0,0,0,0.28)]">
-      <div className="border-b border-black/15 bg-[#c9c6bf] px-4 py-2 dark:border-white/10 dark:bg-[#18191d]">
-        <div className="flex items-center justify-between gap-4 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-black/60 dark:text-white/58">
+    <section className="group/score h-full overflow-hidden rounded-[1.1rem] border border-black/18 bg-[#d0cdc5] shadow-[0_12px_28px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_20px_38px_rgba(24,24,26,0.16)] dark:border-white/16 dark:bg-[#202126] dark:shadow-[0_14px_34px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_22px_44px_rgba(0,0,0,0.42)]">
+      <div className="border-b border-black/16 bg-[#bfbbb2] px-3 py-1.5 dark:border-white/12 dark:bg-[#292a30]">
+        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/68 dark:text-white/72">
           <span>Today</span>
-          <span className="tabular-nums">resets in {countdown}</span>
+          <span className="tabular-nums">UTC reset {countdown}</span>
         </div>
       </div>
 
-      <div className="grid gap-3 p-3.5 sm:p-4">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 p-3 sm:p-4">
         <ScoreDigits value={today} />
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-0.5 font-mono text-[11px] uppercase tracking-[0.11em] text-black/55 dark:text-white/48">
-          <span>
-            7 days <strong className="ml-1 font-semibold text-black/78 dark:text-white/78">{weekTotal.toLocaleString('en-GB')}</strong>
+        <div className="grid min-w-[4.6rem] gap-2 pb-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-black/62 dark:text-white/64">
+          <span className="grid gap-0.5">
+            <span>7D</span>
+            <strong className="text-sm font-semibold leading-none text-black/88 dark:text-white/90">
+              {weekTotal.toLocaleString('en-GB')}
+            </strong>
           </span>
-          <span>
-            Year <strong className="ml-1 font-semibold text-black/78 dark:text-white/78">{yearTotal?.toLocaleString('en-GB') ?? '—'}</strong>
+          <span className="grid gap-0.5" title="Calendar year to date, measured in UTC">
+            <span>YTD</span>
+            <strong className="text-sm font-semibold leading-none text-black/88 dark:text-white/90">
+              {yearTotal?.toLocaleString('en-GB') ?? '—'}
+            </strong>
           </span>
         </div>
       </div>

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,7 +1,8 @@
 import { expect, test, type Page } from '@playwright/test';
 
 const publicRoutes = ['/', '/time', '/blog', '/gallery', '/atelier'];
-const idleDigitTransform = 'translate3d(0px, 0px, 0px) rotateX(0deg) rotateY(0deg)';
+const idleDigitTransform =
+  'translate3d(0px, 0px, 0px) rotateX(0deg) rotateY(0deg) rotateZ(0deg) scale(1)';
 
 async function expectNoHorizontalOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({
@@ -89,6 +90,15 @@ test('homepage highlights three recent systems', async ({ page }) => {
   await expect(page.getByRole('link', { name: /proofwake/i })).toBeVisible();
 });
 
+test('homepage counter uses UTC, 7D, and YTD instrument labels', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByText(/UTC reset \d{2}:\d{2}:\d{2}/)).toBeVisible();
+  await expect(page.getByText('7D', { exact: true })).toBeVisible();
+  await expect(page.getByText('YTD', { exact: true })).toBeVisible();
+  await expect(page.locator('[data-activity-digit] > span')).toHaveCount(4);
+});
+
 test('gallery credits the agents who worked here', async ({ page }) => {
   await page.goto('/gallery');
 
@@ -156,7 +166,7 @@ test('gallery wheel scrolls over the canvas', async ({ page }) => {
   await expectWheelScrollsDocument(page, '/gallery', 'canvas');
 });
 
-test('homepage counter uses four independently reactive digits', async ({ page }) => {
+test('homepage counter uses four independently reactive wind-lift digits', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'no-preference' });
   await page.goto('/');
   const digits = await moveActivityDigits(page);
@@ -170,6 +180,7 @@ test('homepage counter uses four independently reactive digits', async ({ page }
   );
   expect(new Set(transforms).size).toBeGreaterThan(1);
   expect(transforms[0]).not.toEqual(transforms[3]);
+  expect(transforms.some((transform) => /translate3d\([^,]+, -(?:[4-9]|\d{2})/.test(transform))).toBe(true);
 });
 
 test('homepage counter respects reduced motion', async ({ page }) => {


### PR DESCRIPTION
## Summary

Extracts the remaining useful homepage activity work from #365 onto current `main` without pulling the stale branch forward wholesale.

### Scoreboard
- replaces static digits with genuine split-flap halves and hinged value transitions
- animates only changed digits, staggered right to left
- adds stronger cursor-driven wind lift across neighbouring digits
- settles lifted digits with a brief weighted back-and-forth response
- skips value motion while the tab is hidden and preserves reduced-motion behaviour
- changes the period labels to `7D` and `YTD`
- changes the countdown to GitHub's UTC day boundary

### Activity refresh
- passes the server snapshot timestamp into the client
- schedules checks from actual freshness instead of refreshing immediately after mount
- checks roughly once per visible minute
- refreshes on tab return only when the snapshot is due
- deduplicates in-flight requests
- applies exponential failure backoff capped at fifteen minutes
- keeps the previous successful values visible through failures

### Shared upstream cache
- removes the second direct GitHub fetch implementation from `/api/github-activity`
- reuses the existing `getGitHubHomeData()` five-minute server cache used by SSR
- adds response metadata for source, generated time, client cadence, upstream cache duration, and request ID
- returns an unavailable response without clearing the existing client snapshot

### Coverage
- adds UTC, `7D`, `YTD`, and split-flap assertions
- strengthens wind-lift coverage
- preserves reduced-motion and existing scrolling/navigation coverage

Production remains untouched. Vercel preview creation may be rejected by the account's daily deployment cap; GitHub CI remains the validation path for this branch.

Tracks the homepage instrument-panel portion of #368 and supersedes the remaining homepage work in #365.