### PR TITLE
Reserve Vercel previews for visual branches

### DIFF
--- a/docs/deployment-workflow.md
+++ b/docs/deployment-workflow.md
@@ -1,0 +1,43 @@
+# Deployment workflow
+
+Vercel Hobby accounts can create 100 deployments in a rolling 86,400-second window. The Git integration creates a preview deployment for each push to an ordinary non-production branch, and a production deployment for pushes to `main`.
+
+The quota counts deployments created. A deployment can consume quota even when its build is cancelled or later errors.
+
+## Branches that receive previews
+
+Use a normal feature branch when browser inspection provides useful evidence:
+
+- `feature/*` for visible product work;
+- `fix/*` for behaviour that needs a live reproduction;
+- `preview/*` for an explicit visual review pass.
+
+These branches continue to deploy automatically.
+
+## Branches that use GitHub CI only
+
+The root `vercel.json` disables automatic deployments for:
+
+- `docs/**`;
+- `chore/**`;
+- `internal/**`;
+- `audit/**`.
+
+Use these prefixes for prose, repository maintenance, investigations, and planning that can be judged through diffs and GitHub Actions.
+
+## Practical cadence
+
+1. Run local checks before pushing when local access is available.
+2. Accumulate related changes on one branch.
+3. Let GitHub CI answer lint, type, unit, and build questions.
+4. Push a visual branch when a live browser review will change the decision.
+5. Merge accepted work to `main` for the production deployment.
+
+Vercel's Ignored Build Step runs after a deployment has already been created. Cancelled builds from that mechanism still count toward deployment quotas, so branch-level `git.deploymentEnabled` rules are the useful control for this repository.
+
+## Sources
+
+- [Vercel limits](https://vercel.com/docs/limits)
+- [Deploying Git repositories with Vercel](https://vercel.com/docs/git)
+- [Git configuration](https://vercel.com/docs/project-configuration/git-configuration)
+- [Project settings and Ignored Build Step accounting](https://vercel.com/docs/project-configuration/project-settings)

--- a/docs/deployment-workflow.md
+++ b/docs/deployment-workflow.md
@@ -1,8 +1,15 @@
 # Deployment workflow
 
-Vercel Hobby accounts can create 100 deployments in a rolling 86,400-second window. The Git integration creates a preview deployment for each push to an ordinary non-production branch, and a production deployment for pushes to `main`.
+Vercel Hobby accounts have two rolling limits relevant to this repository:
 
-The quota counts deployments created. A deployment can consume quota even when its build is cancelled or later errors.
+- 32 builds per 3,600 seconds;
+- 100 deployments per 86,400 seconds.
+
+Using Next.js is classed as a build. The Git integration creates a preview deployment for each push to an ordinary non-production branch and a production deployment for pushes to `main`.
+
+The current failing GitHub checks point to Vercel's `build-rate-limit`, so the immediate lockout is the 32-build hourly limit. The daily deployment limit remains a second ceiling.
+
+The counters begin before a deployment succeeds. A deployment can consume quota when its build is cancelled or later errors.
 
 ## Branches that receive previews
 
@@ -33,7 +40,7 @@ Use these prefixes for prose, repository maintenance, investigations, and planni
 4. Push a visual branch when a live browser review will change the decision.
 5. Merge accepted work to `main` for the production deployment.
 
-Vercel's Ignored Build Step runs after a deployment has already been created. Cancelled builds from that mechanism still count toward deployment quotas, so branch-level `git.deploymentEnabled` rules are the useful control for this repository.
+Vercel's Ignored Build Step runs after a deployment has already been created. Cancelled builds from that mechanism still count toward deployment quotas and concurrent build slots, so branch-level `git.deploymentEnabled` rules are the useful control for this repository.
 
 ## Sources
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "docs/**": false,
+      "chore/**": false,
+      "internal/**": false,
+      "audit/**": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Reduces Hobby-plan deployment churn without removing previews from feature and fix work that benefits from browser inspection.

- adds `vercel.json` branch-level Git deployment rules
- disables automatic Vercel deployments for `docs/**`, `chore/**`, `internal/**`, and `audit/**`
- leaves `main`, `feature/**`, `fix/**`, `preview/**`, and every unspecified branch enabled
- documents both Hobby rolling limits: 32 builds per hour and 100 deployments per day
- records that the repository's current GitHub failures target Vercel's `build-rate-limit`, so the immediate ceiling is the hourly one
- explains why an Ignored Build Step is the wrong quota-saving mechanism: Vercel creates the deployment first, and cancelled ignored builds still count

GitHub CI remains the validation path for nonvisual branches. Production behaviour remains unchanged.