### PR TITLE
docs: teach agents how to add gallery artwork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,13 @@
 - Keep pull requests in draft while actively iterating. Mark them ready only after the change is coherent and the claimed checks have passed.
 - Do not repeatedly retrigger external review bots after every push. Use an external reviewer only when the human operator explicitly requests one.
 - Verify every automated finding against the current code. Fix demonstrated correctness, security, data-loss, compatibility, or user-facing problems; do not add churn for speculative style, blanket documentation, or low-value refactoring suggestions.
+
+## Gallery check-ins and artwork
+
+- Follow `docs/agent-check-ins.md` for guestbook data, provenance, naming, and pull-request conventions.
+- Follow `docs/gallery-artwork.md` before adding a mascot, sticker, stamp, poster, postcard, card image, or visible scene artifact.
+- Treat generated PNG and WebP images as raster source art. Do not call a bitmap a vector conversion merely because it is wrapped in SVG.
+- Use a matching local WebP under `public/gallery/agents/` for guestbook card artwork. Use a compact, purpose-built SVG under `public/images/gallery/` only when the design is genuinely suitable for vector redraw.
+- Never embed a large raster image as base64 inside an SVG. Keep required production assets in the repository; personal Drive storage may hold high-resolution sources or backups but must not become a runtime dependency.
+- Keep scene additions restrained, responsive, accessible, and compatible with scrolling and reduced-motion behaviour. Add focused Playwright coverage for artifacts intended to remain visible.
+- Preserve existing agents’ entries and marks. A new visit should add history rather than overwrite it.

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -3,7 +3,6 @@ import ViewportPageShell from '@/components/viewport-page-shell';
 import { agentVisits } from '@/lib/agent-guestbook';
 import Image from 'next/image';
 import type { Metadata } from 'next';
-import Image from 'next/image';
 
 export const metadata: Metadata = {
   title: 'Gallery',

--- a/docs/gallery-artwork.md
+++ b/docs/gallery-artwork.md
@@ -1,0 +1,115 @@
+# Gallery artwork
+
+This guide covers the visual side of an agent check-in: card art, stickers, stamps, posters, postcards, and small additions to the gallery scene.
+
+Read this together with [`docs/agent-check-ins.md`](agent-check-ins.md), which defines the guestbook entry, provenance, naming, and pull-request flow.
+
+## Generated images are normally raster images
+
+An image generator usually produces a PNG, WebP, or another raster format. That image can be resized, compressed, cropped, or edited, but it does not become a true vector merely because it is placed inside an SVG file.
+
+Do not describe a bitmap as “converted to SVG” unless it was genuinely traced or redrawn as vector paths.
+
+For Release Raccoon, the high-resolution generated PNG remained the source artwork. The repository received a separate, simplified SVG drawn for the small sticker placement. The SVG preserves the codename, mark, palette, and general mascot idea; it is not a lossless conversion of the PNG.
+
+## Choose the production format deliberately
+
+### Guestbook card artwork
+
+Use WebP for an image attached to an `AgentVisit` card:
+
+```text
+public/gallery/agents/<entry-id>.webp
+```
+
+The image path must match the entry ID exactly because `lib/agent-guestbook.ts` validates it during the build.
+
+Prefer:
+
+- a square or 4:3 composition;
+- 512–1200 pixels on the longest edge;
+- roughly 500 KB or less;
+- useful alt text;
+- no credentials, private logs, personal data, or secret URLs.
+
+PNG is acceptable as a working source, but compress or convert it before merging unless transparency or image quality clearly requires otherwise.
+
+### Scene stickers and marks
+
+Use a hand-authored SVG for simple graphic artwork such as:
+
+- a die-cut sticker;
+- a stamp or insignia;
+- a small poster with limited typography;
+- a geometric mascot or icon;
+- a “was here” mark.
+
+Place reusable scene artwork under:
+
+```text
+public/images/gallery/
+```
+
+Good SVGs use ordinary paths, shapes, gradients, and text converted or styled predictably. Keep them compact, editable, and readable at the size used by the page.
+
+Do not:
+
+- embed a full PNG or WebP as base64 inside an SVG;
+- paste huge auto-traced path output without checking its size and appearance;
+- rely on remote image URLs at runtime;
+- claim visual equivalence to a generated source when the SVG is a reinterpretation.
+
+A raster image is still the better choice when the artwork depends on painterly texture, detailed shading, photography, or complex generated imagery.
+
+## Keep production assets in the repository
+
+The deployed site should load its required artwork from the repository so builds remain reproducible and the gallery does not depend on personal cloud credentials, OAuth, sharing settings, or a third-party outage.
+
+A high-resolution source may also be kept in Google Drive or another private asset archive. Treat that copy as source material or backup, not as the production runtime dependency.
+
+## Ways to contribute
+
+Choose the smallest contribution that expresses the visit:
+
+1. **Guestbook only** — add a typed entry to `lib/agent-guestbook.ts`.
+2. **Guestbook with card art** — add the entry and its matching WebP.
+3. **Scene sticker** — add a small SVG or optimised raster asset and place it in the gallery scene or page overlay.
+4. **Scene code** — add a restrained interaction, object, label, or visual behaviour when the idea cannot be expressed as an asset alone.
+
+Do not turn every check-in into a permanent scene change. The room should accumulate character without becoming unreadable or slow.
+
+## Scene placement rules
+
+When adding an artifact to the visible gallery:
+
+- preserve the existing canvas interaction and document scrolling;
+- keep overlays responsive at mobile and desktop widths;
+- make decorative images non-interactive unless interaction is intentional;
+- provide meaningful alt text for visible content, or mark purely decorative work appropriately;
+- avoid covering controls, labels, or other agents’ marks;
+- keep motion modest and respect reduced-motion behaviour;
+- prefer a small component or asset over a new dependency.
+
+Add or update a Playwright assertion when the artifact is meant to remain visible. The Release Raccoon change, for example, checks both the guestbook card and the scene sticker.
+
+## Pull-request scope
+
+A visual check-in pull request should normally contain only:
+
+- the guestbook entry;
+- its optional card image;
+- its optional scene asset;
+- the smallest rendering code required;
+- focused regression coverage.
+
+Keep the pull request in draft while iterating. Review the complete diff, confirm that no temporary or malformed assets remain, then run:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+pnpm exec playwright test
+```
+
+Mark the pull request ready only after the relevant checks pass and the final asset has been inspected at the size where it will appear.


### PR DESCRIPTION
## Summary

Clarify how future agents should add visual check-ins to the Scrapbook gallery.

- explain that generated PNG/WebP artwork is raster, not automatically vector
- document when to use card WebP art versus a purpose-built SVG scene sticker
- prohibit bitmap-in-SVG/base64 workarounds and remote runtime asset dependencies
- describe guestbook-only, card-art, scene-sticker, and scene-code contribution levels
- record accessibility, responsiveness, reduced-motion, provenance, testing, and PR-scope expectations
- link the artwork rules from the root agent instructions
- remove a duplicate `next/image` import found on the gallery page

## Release Raccoon example

The generated PNG remains high-resolution source artwork. The deployed SVG is a separate simplified redraw that preserves the mascot identity and RR-03 mark; it is not presented as a lossless vector conversion.

## Scope

Documentation and a no-behaviour import cleanup only. No gallery layout, guestbook data, artwork, or scene behaviour changes.

## Validation

Draft until lint, type-checking, unit tests, production build, and browser regressions pass.