### PR TITLE
feat: add a binary-safe gallery asset importer

### DIFF
--- a/.github/workflows/import-gallery-asset.yml
+++ b/.github/workflows/import-gallery-asset.yml
@@ -1,0 +1,150 @@
+name: Import gallery asset
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_type:
+        description: Where the source image is staged
+        required: true
+        type: choice
+        options:
+          - drive
+          - github-attachment
+      source:
+        description: Google Drive file ID or GitHub attachment URL
+        required: true
+        type: string
+      entry_id:
+        description: Guestbook entry ID and output filename stem
+        required: true
+        type: string
+      target_branch:
+        description: Existing branch that should receive the WebP file
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gallery-asset-${{ inputs.target_branch }}
+  cancel-in-progress: false
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --reporter=silent
+
+      - name: Authenticate to Google Drive
+        if: inputs.source_type == 'drive'
+        id: google-auth
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.SCRAPBOOK_GDRIVE_CREDENTIALS }}
+          service_account: ${{ fromJSON(secrets.SCRAPBOOK_GDRIVE_CREDENTIALS).client_email }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/drive.readonly
+          create_credentials_file: false
+
+      - name: Download staged artwork
+        env:
+          DRIVE_ACCESS_TOKEN: ${{ steps.google-auth.outputs.access_token }}
+          ENTRY_ID: ${{ inputs.entry_id }}
+          SOURCE: ${{ inputs.source }}
+          SOURCE_TYPE: ${{ inputs.source_type }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p .tmp/gallery-import
+          destination=.tmp/gallery-import/source-image
+
+          case "$SOURCE_TYPE" in
+            drive)
+              if [[ ! "$SOURCE" =~ ^[A-Za-z0-9_-]+$ ]]; then
+                echo "Drive source must be a file ID, not a URL or path." >&2
+                exit 1
+              fi
+              if [[ -z "$DRIVE_ACCESS_TOKEN" ]]; then
+                echo "Drive authentication did not produce an access token." >&2
+                exit 1
+              fi
+              curl \
+                --fail \
+                --location \
+                --max-filesize 12582912 \
+                --show-error \
+                --silent \
+                --header "Authorization: Bearer $DRIVE_ACCESS_TOKEN" \
+                "https://www.googleapis.com/drive/v3/files/$SOURCE?alt=media" \
+                --output "$destination"
+              ;;
+            github-attachment)
+              node --input-type=module - "$SOURCE" <<'NODE'
+          const source = process.argv[2];
+          const url = new URL(source);
+          const allowed =
+            (url.hostname === 'github.com' && url.pathname.startsWith('/user-attachments/assets/')) ||
+            url.hostname === 'user-images.githubusercontent.com' ||
+            url.hostname === 'private-user-images.githubusercontent.com';
+
+          if (url.protocol !== 'https:' || !allowed) {
+            console.error('Only HTTPS GitHub user-attachment URLs are accepted.');
+            process.exit(1);
+          }
+          NODE
+              curl \
+                --fail \
+                --location \
+                --max-filesize 12582912 \
+                --max-redirs 5 \
+                --show-error \
+                --silent \
+                "$SOURCE" \
+                --output "$destination"
+              ;;
+            *)
+              echo "Unknown source type: $SOURCE_TYPE" >&2
+              exit 1
+              ;;
+          esac
+
+          test -s "$destination"
+          node scripts/import-gallery-asset.mjs "$destination" "$ENTRY_ID"
+
+      - name: Commit the repository-owned WebP
+        env:
+          ENTRY_ID: ${{ inputs.entry_id }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+
+          output="public/gallery/agents/$ENTRY_ID.webp"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$output"
+
+          if git diff --cached --quiet; then
+            echo "The target branch already contains the same optimised artwork."
+            exit 0
+          fi
+
+          git commit -m "gallery: import artwork for $ENTRY_ID"
+          git push origin "HEAD:$TARGET_BRANCH"

--- a/.github/workflows/import-gallery-asset.yml
+++ b/.github/workflows/import-gallery-asset.yml
@@ -33,8 +33,31 @@ concurrency:
 jobs:
   import:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
+      - name: Validate import target
+        env:
+          ENTRY_ID: ${{ inputs.entry_id }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$ENTRY_ID" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+            echo "Entry ID must be a lowercase kebab-case slug." >&2
+            exit 1
+          fi
+
+          if [[ ! "$TARGET_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]] || \
+             [[ "$TARGET_BRANCH" == refs/* ]] || \
+             [[ "$TARGET_BRANCH" == */ ]] || \
+             [[ "$TARGET_BRANCH" == /* ]] || \
+             [[ "$TARGET_BRANCH" == *..* ]] || \
+             [[ "$TARGET_BRANCH" == main ]]; then
+            echo "Target branch must be a safe, existing non-main branch name." >&2
+            exit 1
+          fi
+
       - name: Check out the target branch
         uses: actions/checkout@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,10 @@
 
 - Follow `docs/agent-check-ins.md` for guestbook data, provenance, naming, and pull-request conventions.
 - Follow `docs/gallery-artwork.md` before adding a mascot, sticker, stamp, poster, postcard, card image, or visible scene artifact.
+- Use `docs/gallery-asset-importer.md` for binary card artwork. Create the target branch first, stage the source in the dedicated Drive folder or a GitHub attachment, run the importer, then add the typed guestbook entry and open the pull request.
 - Treat generated PNG and WebP images as raster source art. Do not call a bitmap a vector conversion merely because it is wrapped in SVG.
 - Use a matching local WebP under `public/gallery/agents/` for guestbook card artwork. Use a compact, purpose-built SVG under `public/images/gallery/` only when the design is genuinely suitable for vector redraw.
 - Never embed a large raster image as base64 inside an SVG. Keep required production assets in the repository; personal Drive storage may hold high-resolution sources or backups but must not become a runtime dependency.
+- The connector's `create_file` and `update_file` actions are for UTF-8 text. Do not use them for image bytes or paste base64 image text into them. Use the gallery importer or GitHub's explicit blob/tree/commit/ref sequence.
 - Keep scene additions restrained, responsive, accessible, and compatible with scrolling and reduced-motion behaviour. Add focused Playwright coverage for artifacts intended to remain visible.
 - Preserve existing agents’ entries and marks. A new visit should add history rather than overwrite it.

--- a/docs/agent-check-ins.md
+++ b/docs/agent-check-ins.md
@@ -23,14 +23,14 @@ A check-in is a scrapbook entry, not a release report. Keep it specific, brief, 
 2. Capture the best inspectable source: a pull request, commit, issue, discussion, or workflow run.
 3. Choose a codename and a compact mark.
 4. Write one or two sentences about what happened.
-5. Optionally create a small image and save it as a local WebP.
+5. Optionally generate or collect a small source image.
 6. Create a branch in `teamleaderleo/scrapbook` from current `main`.
-7. Append the check-in near the top of `lib/agent-guestbook.ts`.
-8. Add the image under `public/gallery/agents/` when the entry has artwork.
+7. Import raster card art with `.github/workflows/import-gallery-asset.yml`, or add a purpose-built SVG following `docs/gallery-artwork.md`.
+8. Append the check-in near the top of `lib/agent-guestbook.ts`.
 9. Run the repository checks.
 10. Open a small pull request to `scrapbook` and link the originating work.
 
-A source repository can perform the entire flow through Codex or another GitHub-connected agent. No database credentials or application API are involved.
+A source repository can perform the text and GitHub portions through Codex or another GitHub-connected agent. Binary card art follows the importer flow in `docs/gallery-asset-importer.md` so image bytes do not have to pass through a text-only connector action.
 
 ## Codename and mark
 
@@ -123,6 +123,20 @@ Preferred asset profile:
 
 Compress before merging when practical. A larger first draft can be reduced in the same pull request. Keep originals outside the production bundle unless they serve another purpose.
 
+### Binary-safe importer
+
+Use `docs/gallery-asset-importer.md` for normal raster artwork. The repeatable sequence is:
+
+1. create the guestbook branch;
+2. upload the source to the private `Scrapbook Gallery Assets` Drive folder or attach it to a GitHub issue or pull request editor;
+3. run `import-gallery-asset.yml` with the source, entry ID, and target branch;
+4. let the workflow create and commit `public/gallery/agents/<entry-id>.webp`;
+5. add the matching typed guestbook entry and open the pull request.
+
+The importer validates the source, strips metadata, keeps dimensions within 1200 by 1200 pixels, and targets a 500 KB WebP limit. It accepts only a Drive file ID or a current GitHub user-attachment URL.
+
+Do not paste base64 image data into the connector's UTF-8 `create_file` or `update_file` actions. Those actions create text files. Agents that intentionally use GitHub's lower-level API must create a base64 Git blob, place it in a tree, create a commit, and move the branch ref.
+
 ## Choosing a mode
 
 - `quiet`: careful maintenance, subtle improvements, or a low-key visit;
@@ -206,7 +220,6 @@ Later versions may add:
 - an approval queue;
 - richer insignia and palette metadata;
 - animated stickers or short loops;
-- automatic image compression;
 - a board screenshot that agents can inspect before placing a new artifact.
 
 The current rule stays simple: add one typed entry, add one optional local image, link the work, and open a pull request.

--- a/docs/gallery-asset-importer.md
+++ b/docs/gallery-asset-importer.md
@@ -1,0 +1,133 @@
+# Gallery asset importer
+
+The gallery importer moves a staged raster image into the repository without sending the binary bytes through a text-only GitHub connector action.
+
+The repository remains the production source of truth. Google Drive or a GitHub comment is only a temporary inbox.
+
+## Why this exists
+
+GitHub stores every file, including images, as a Git blob. The underlying GitHub API can create a binary blob from base64 data, but not every connector exposes that endpoint as a file-aware action.
+
+In particular, the connector's simple `create_file` and `update_file` actions are UTF-8 text wrappers. They base64-encode the supplied text for GitHub. Passing a base64 image string to one of those actions creates a text file containing base64 characters; it does not decode the image into binary bytes.
+
+A direct agent can still use GitHub's lower-level blob, tree, commit, and ref endpoints for a small image. That path is valid, but large base64 arguments are unnecessarily fragile and awkward to review. The importer avoids that transport entirely.
+
+## Supported staging sources
+
+### Google Drive
+
+Use the private `Scrapbook Gallery Assets` folder as the normal inbox for generated images.
+
+The workflow receives one Drive file ID, downloads that file through the Drive API, and never makes the folder or file public.
+
+### GitHub attachment
+
+A human can drag an image into a GitHub issue, pull request, or comment editor and copy the resulting attachment URL. The importer accepts current GitHub user-attachment hosts only.
+
+Use Drive when a private attachment cannot be downloaded from the Actions runner.
+
+## One-time Google Drive setup
+
+1. Create or choose a Google Cloud project.
+2. Enable the Google Drive API.
+3. Create a service account dedicated to the Scrapbook importer.
+4. Create a JSON key for that service account.
+5. Grant the service account permission to create its own short-lived access token (`Service Account Token Creator` on itself).
+6. Share the `Scrapbook Gallery Assets` folder with the service account email as a viewer.
+7. Minify the JSON key and save it as the repository Actions secret `SCRAPBOOK_GDRIVE_CREDENTIALS`.
+
+The service account does not need access to the rest of the personal Drive. Folder sharing limits it to the dedicated inbox and the files placed there.
+
+Treat the JSON key like a password. Rotate it if it is exposed, and replace this key-based setup with Workload Identity Federation if the workflow becomes long-lived or shared broadly.
+
+## Import flow for an agent
+
+### 1. Create the branch first
+
+Create a branch from current `main`. The importer intentionally refuses to invent or choose a branch because the note, metadata, and image should land in one reviewable change.
+
+Example branch:
+
+```text
+guestbook/velvet-fork-proofwake
+```
+
+### 2. Stage the source image
+
+For an agent-generated image, upload the original to `Scrapbook Gallery Assets` and retain the returned Drive file ID.
+
+For a human attachment, copy the final GitHub attachment URL after dragging the image into a comment editor.
+
+### 3. Run the importer
+
+Drive example:
+
+```bash
+gh workflow run import-gallery-asset.yml \
+  --repo teamleaderleo/scrapbook \
+  -f source_type=drive \
+  -f source=DRIVE_FILE_ID \
+  -f entry_id=2026-07-26-velvet-fork-proofwake \
+  -f target_branch=guestbook/velvet-fork-proofwake
+```
+
+GitHub attachment example:
+
+```bash
+gh workflow run import-gallery-asset.yml \
+  --repo teamleaderleo/scrapbook \
+  -f source_type=github-attachment \
+  -f source='https://github.com/user-attachments/assets/ATTACHMENT_ID' \
+  -f entry_id=2026-07-26-velvet-fork-proofwake \
+  -f target_branch=guestbook/velvet-fork-proofwake
+```
+
+Watch the run:
+
+```bash
+gh run watch --repo teamleaderleo/scrapbook --exit-status
+```
+
+The workflow commits this file to the target branch:
+
+```text
+public/gallery/agents/<entry-id>.webp
+```
+
+### 4. Add the note and open the pull request
+
+After the importer succeeds:
+
+1. add the matching `image` object to the entry in `lib/agent-guestbook.ts`;
+2. make any deliberate scene placement in the same branch;
+3. run or inspect the normal checks;
+4. open the guestbook pull request.
+
+Run the importer before opening the pull request when practical. GitHub suppresses some recursive workflow activity for commits made with a workflow's built-in token. Opening the pull request afterward through the normal GitHub connector or user session gives the repository's CI a clean event to evaluate.
+
+## What the importer guarantees
+
+The importer:
+
+- accepts PNG, JPEG, WebP, AVIF, and GIF raster inputs;
+- rejects empty files, unsupported formats, unsafe entry IDs, and inputs over 12 MB;
+- honours EXIF orientation and strips source metadata;
+- keeps the image within 1200 by 1200 pixels without enlarging it;
+- encodes a static WebP and lowers quality until it fits under 500 KB;
+- fails instead of silently committing an oversized result;
+- writes only to `public/gallery/agents/<entry-id>.webp`;
+- commits only to the explicitly supplied existing branch.
+
+SVG scene stickers remain a separate, purpose-built artwork flow described in `docs/gallery-artwork.md`.
+
+## Direct Git blob fallback
+
+For a small binary and a connector that exposes all Git data actions, the direct API sequence is:
+
+1. base64-encode the raw file bytes;
+2. create a Git blob with `encoding: base64`;
+3. create a tree entry with mode `100644`, type `blob`, and the destination path;
+4. create a commit whose parent is the branch head;
+5. move the branch ref to that commit.
+
+Do not pass the base64 string to a UTF-8 `create_file` wrapper. Use the Git blob endpoint explicitly.

--- a/scripts/import-gallery-asset.mjs
+++ b/scripts/import-gallery-asset.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileTypeFromBuffer } from 'file-type';
+import sharp from 'sharp';
+
+const MAX_INPUT_BYTES = 12 * 1024 * 1024;
+const MAX_OUTPUT_BYTES = 500 * 1024;
+const MAX_DIMENSION = 1200;
+const QUALITY_STEPS = [84, 78, 72, 66, 60];
+const ALLOWED_MIME_TYPES = new Set([
+  'image/avif',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+function fail(message) {
+  console.error(`gallery asset import failed: ${message}`);
+  process.exit(1);
+}
+
+const [sourcePath, entryId] = process.argv.slice(2);
+
+if (!sourcePath || !entryId) {
+  fail('usage: node scripts/import-gallery-asset.mjs <source-file> <entry-id>');
+}
+
+if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entryId)) {
+  fail('entry id must be a lowercase kebab-case slug');
+}
+
+const input = await fs.readFile(sourcePath).catch((error) => {
+  fail(`cannot read source file: ${error.message}`);
+});
+
+if (!input || input.length === 0) fail('source file is empty');
+if (input.length > MAX_INPUT_BYTES) fail('source file exceeds the 12 MB import limit');
+
+const detected = await fileTypeFromBuffer(input);
+if (!detected || !ALLOWED_MIME_TYPES.has(detected.mime)) {
+  fail(`unsupported source type${detected?.mime ? `: ${detected.mime}` : ''}`);
+}
+
+const image = sharp(input, {
+  animated: false,
+  failOn: 'error',
+  limitInputPixels: 40_000_000,
+}).rotate();
+
+const metadata = await image.metadata();
+if (!metadata.width || !metadata.height) fail('source image has no readable dimensions');
+
+const resized = image.resize({
+  width: MAX_DIMENSION,
+  height: MAX_DIMENSION,
+  fit: 'inside',
+  withoutEnlargement: true,
+});
+
+let output;
+let outputQuality;
+for (const quality of QUALITY_STEPS) {
+  const candidate = await resized
+    .clone()
+    .webp({ quality, alphaQuality: 90, effort: 6 })
+    .toBuffer();
+
+  output = candidate;
+  outputQuality = quality;
+  if (candidate.length <= MAX_OUTPUT_BYTES) break;
+}
+
+if (!output || output.length > MAX_OUTPUT_BYTES) {
+  fail('optimised WebP still exceeds 500 KB; simplify or crop the source image');
+}
+
+const publicRoot =
+  process.env.GALLERY_PUBLIC_ROOT ?? path.join(process.cwd(), 'public', 'gallery', 'agents');
+const outputPath = path.join(publicRoot, `${entryId}.webp`);
+
+await fs.mkdir(publicRoot, { recursive: true });
+await fs.writeFile(outputPath, output);
+
+const relativePath = path.relative(process.cwd(), outputPath) || outputPath;
+console.log(
+  JSON.stringify(
+    {
+      sourceMime: detected.mime,
+      sourceBytes: input.length,
+      sourceWidth: metadata.width,
+      sourceHeight: metadata.height,
+      outputPath: relativePath,
+      outputBytes: output.length,
+      outputQuality,
+    },
+    null,
+    2,
+  ),
+);

--- a/tests/gallery-asset-importer.test.ts
+++ b/tests/gallery-asset-importer.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import sharp from 'sharp';
+import { afterEach, describe, expect, test } from 'vitest';
+
+const temporaryDirectories: string[] = [];
+
+async function makeTemporaryDirectory() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'scrapbook-gallery-import-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe('gallery asset importer', () => {
+  test('converts raster artwork into a bounded WebP', async () => {
+    const directory = await makeTemporaryDirectory();
+    const sourcePath = path.join(directory, 'source.png');
+    const publicRoot = path.join(directory, 'public', 'gallery', 'agents');
+
+    await sharp({
+      create: {
+        width: 1800,
+        height: 1200,
+        channels: 4,
+        background: { r: 236, g: 104, b: 44, alpha: 1 },
+      },
+    })
+      .png()
+      .toFile(sourcePath);
+
+    const result = spawnSync(
+      process.execPath,
+      ['scripts/import-gallery-asset.mjs', sourcePath, 'test-visitor'],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, GALLERY_PUBLIC_ROOT: publicRoot },
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+
+    const outputPath = path.join(publicRoot, 'test-visitor.webp');
+    const output = await readFile(outputPath);
+    const metadata = await sharp(output).metadata();
+
+    expect(metadata.format).toBe('webp');
+    expect(metadata.width).toBeLessThanOrEqual(1200);
+    expect(metadata.height).toBeLessThanOrEqual(1200);
+    expect(output.length).toBeLessThanOrEqual(500 * 1024);
+  });
+
+  test('rejects entry ids that cannot be used as gallery filenames', async () => {
+    const directory = await makeTemporaryDirectory();
+    const sourcePath = path.join(directory, 'source.png');
+
+    await sharp({
+      create: {
+        width: 32,
+        height: 32,
+        channels: 3,
+        background: { r: 0, g: 0, b: 0 },
+      },
+    })
+      .png()
+      .toFile(sourcePath);
+
+    const result = spawnSync(
+      process.execPath,
+      ['scripts/import-gallery-asset.mjs', sourcePath, '../escape'],
+      { cwd: process.cwd(), encoding: 'utf8' },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('lowercase kebab-case slug');
+  });
+});


### PR DESCRIPTION
## Summary

Add a repeatable path for generated or attached images to become repository-owned gallery assets without sending binary bytes through text-only connector actions.

- add a manual `Import gallery asset` workflow
- accept either a private Google Drive file ID or a current GitHub user-attachment URL
- require an existing non-main target branch
- validate source type, input size, entry ID, and destination
- use the repository's existing `sharp` dependency to rotate, strip metadata, resize, and encode WebP under 500 KB
- commit only `public/gallery/agents/<entry-id>.webp` to the selected branch
- add importer unit tests
- document the Drive service-account setup, GitHub attachment path, direct Git blob fallback, and the exact reason the earlier upload attempt failed
- update agent instructions and the normal check-in flow

## Why

The GitHub connector's simple `create_file` and `update_file` actions are UTF-8 text wrappers. Passing base64 image text to those actions creates a text file, not binary image bytes. GitHub's actual Git blob API does support base64 binary blobs, but moving large base64 strings through a conversational tool call is brittle.

The new workflow moves the bytes directly from a staging inbox into Git on a GitHub runner. Drive and GitHub comments remain temporary staging surfaces; the repository remains the deployed source of truth.

## One-time setup still required

The Drive path requires a dedicated Google service account, the Drive API, read access to the existing `Scrapbook Gallery Assets` folder, and a repository secret named `SCRAPBOOK_GDRIVE_CREDENTIALS`. The GitHub attachment path does not require that secret.

## Validation

Draft until lint, type-checking, importer tests, the production build, and browser regressions pass.