### PR TITLE
fix: make the gallery importer runner boot reliably

### DIFF
--- a/.github/workflows/import-gallery-asset.yml
+++ b/.github/workflows/import-gallery-asset.yml
@@ -59,16 +59,18 @@ jobs:
           fi
 
       - name: Check out the target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary

Fix the manual gallery asset importer before it reaches Drive authentication.

- specify pnpm 10, matching the normal Scrapbook CI contract
- upgrade `actions/checkout`, `pnpm/action-setup`, and `actions/setup-node` to their current Node 24-based major versions
- leave the Drive secret, download, image optimisation, and branch-commit behaviour unchanged

## Failure fixed

Run `30199890080` stopped at `pnpm/action-setup` with `No pnpm version is specified`. The accompanying Node.js 20 messages were runtime deprecation warnings from the older action majors, not Drive authentication errors.

## Validation

Draft until the normal lint, type-checking, unit tests, production build, and browser regressions pass.