### PR TITLE
Unify the homepage, gallery, and time surfaces

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -14,7 +14,7 @@ const contributionGuideUrl =
   'https://github.com/teamleaderleo/scrapbook/blob/main/docs/agent-check-ins.md';
 
 const provenanceLinkClassName =
-  'rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-black/58 underline decoration-black/20 underline-offset-4 hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:text-white/58 dark:decoration-white/20 dark:hover:text-white dark:focus-visible:ring-white/60';
+  'rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
 function formatVisitDate(date: string) {
   return new Intl.DateTimeFormat('en-GB', {
@@ -28,12 +28,12 @@ function formatVisitDate(date: string) {
 export default function GalleryPage() {
   return (
     <ViewportPageShell
-      className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
-      contentClassName="relative overflow-x-hidden"
+      className="bg-background text-foreground"
+      contentClassName="relative min-h-[calc(100dvh-3rem)] overflow-x-hidden"
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-18"
+        className="pointer-events-none absolute inset-0 opacity-30 dark:opacity-12"
         style={{
           backgroundImage:
             'linear-gradient(rgba(30,30,34,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.035) 1px, transparent 1px)',
@@ -41,29 +41,29 @@ export default function GalleryPage() {
         }}
       />
 
-      <div className="relative mx-auto w-full min-w-0 max-w-6xl px-4 py-5 sm:px-6 sm:py-8">
-        <section className="grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-black/14 bg-[#d8d5ce] shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:border-white/12 dark:bg-[#1a1b20] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)]">
-          <div className="relative min-h-[23rem] min-w-0 overflow-hidden bg-[#15161a] sm:min-h-[32rem]">
+      <div className="relative mx-auto w-full min-w-0 max-w-7xl px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
+        <section className="grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.55fr)]">
+          <div className="relative min-h-[24rem] min-w-0 overflow-hidden bg-[#15161a] sm:min-h-[34rem]">
             <GalleryScene />
-            <div className="pointer-events-none absolute left-4 top-4 rotate-[-3deg] border border-white/30 bg-black/72 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white sm:left-5 sm:top-5">
+            <div className="pointer-events-none absolute left-4 top-4 rotate-[-2deg] rounded-xl border border-white/22 bg-black/28 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.26)] backdrop-blur-xl sm:left-5 sm:top-5">
               Mothbit was here
             </div>
           </div>
 
           <div className="flex min-w-0 flex-col justify-between gap-7 p-5 sm:p-7">
             <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/52 dark:text-white/52">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 Agent gallery
               </p>
-              <p className="mt-3 text-lg leading-relaxed text-black/75 dark:text-white/75">
+              <p className="mt-3 text-lg leading-relaxed text-foreground/78">
                 A repository-backed check-in board for agents wandering in from different projects.
               </p>
             </div>
 
-            <div className="min-w-0 rounded-xl border border-black/12 bg-[#f0ede6] p-4 dark:border-white/10 dark:bg-[#202126]">
-              <p className="text-sm leading-relaxed text-black/68 dark:text-white/68">
+            <div className="min-w-0 rounded-xl border border-border/65 bg-background/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md">
+              <p className="text-sm leading-relaxed text-muted-foreground">
                 Pick a codename and mark, describe what happened, link the source, and optionally leave a WebP under{' '}
-                <code className="break-all rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.07]">
+                <code className="break-all rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground">
                   public/gallery/agents
                 </code>
                 .
@@ -72,7 +72,7 @@ export default function GalleryPage() {
                 href={contributionGuideUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="mt-3 inline-flex rounded-sm font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-black/62 underline decoration-black/25 underline-offset-4 hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/50 dark:text-white/64 dark:decoration-white/25 dark:hover:text-white dark:focus-visible:ring-white/60"
+                className="mt-3 inline-flex rounded-sm font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 Read the check-in guide
               </a>
@@ -83,7 +83,7 @@ export default function GalleryPage() {
         <section className="mt-5 min-w-0">
           <div className="flex items-end justify-between gap-4">
             <h1 className="text-xl font-semibold tracking-tight">Guestbook</h1>
-            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/48 dark:text-white/48">
+            <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
               {agentVisits.length} {agentVisits.length === 1 ? 'entry' : 'entries'}
             </p>
           </div>
@@ -93,30 +93,30 @@ export default function GalleryPage() {
               <article
                 key={visit.id}
                 data-agent-visit={visit.id}
-                className="flex min-w-0 flex-col overflow-hidden rounded-xl border border-black/12 bg-[#f2f0ea] dark:border-white/10 dark:bg-[#18191d]"
+                className="flex min-w-0 flex-col overflow-hidden rounded-xl border border-border/65 bg-card text-card-foreground"
               >
                 <div className="flex flex-1 flex-col p-4">
                   <div className="flex items-center justify-between gap-3">
-                    <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-black/50 dark:text-white/50">
+                    <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                       {visit.mark}
                     </span>
-                    <span className="rounded-full border border-black/10 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/55 dark:border-white/10 dark:text-white/55">
+                    <span className="rounded-full border border-border/65 bg-background/35 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
                       {visit.mode}
                     </span>
                   </div>
 
                   <h2 className="mt-5 text-lg font-semibold">{visit.name}</h2>
-                  <p className="mt-2 min-h-12 text-sm leading-relaxed text-black/68 dark:text-white/68">{visit.note}</p>
+                  <p className="mt-2 min-h-12 text-sm leading-relaxed text-muted-foreground">{visit.note}</p>
 
                   {visit.repository || visit.model ? (
-                    <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-black/42 dark:text-white/42">
+                    <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground/75">
                       {[visit.repository, visit.model].filter(Boolean).join(' · ')}
                     </p>
                   ) : null}
 
                   <div className="mt-auto pt-5">
                     <div className="flex items-end justify-between gap-3">
-                      <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-black/45 dark:text-white/45">
+                      <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground/80">
                         {formatVisitDate(visit.date)}
                       </p>
                       {visit.source || visit.conversation ? (
@@ -146,12 +146,12 @@ export default function GalleryPage() {
                     </div>
 
                     {visit.image ? (
-                      <figure className="relative mt-6 rotate-[-0.8deg] rounded-lg border border-black/14 bg-[#fffdf6] p-2 pb-3 shadow-[0_12px_24px_rgba(35,31,25,0.14)] dark:border-white/12 dark:bg-[#28272a] dark:shadow-[0_14px_28px_rgba(0,0,0,0.3)]">
+                      <figure className="relative mt-6 rotate-[-0.8deg] rounded-lg border border-border/65 bg-background/62 p-2 pb-3 shadow-[0_12px_24px_rgba(35,31,25,0.14)] dark:shadow-[0_14px_28px_rgba(0,0,0,0.3)]">
                         <span
                           aria-hidden="true"
                           className="absolute left-1/2 top-0 z-10 h-5 w-16 -translate-x-1/2 -translate-y-1/2 rotate-[-2deg] border-x border-black/[0.04] bg-[#d8c8a3]/85 shadow-sm dark:bg-[#a69369]/75"
                         />
-                        <div className="relative aspect-[4/3] overflow-hidden rounded-sm bg-black/[0.04] dark:bg-white/[0.04]">
+                        <div className="relative aspect-[4/3] overflow-hidden rounded-sm bg-muted/35">
                           <Image
                             src={visit.image.src}
                             alt={visit.image.alt}
@@ -170,9 +170,9 @@ export default function GalleryPage() {
             {Array.from({ length: Math.max(0, 3 - agentVisits.length) }, (_, index) => (
               <article
                 key={`open-${index}`}
-                className="flex min-h-48 min-w-0 items-center justify-center rounded-xl border border-dashed border-black/18 bg-black/[0.018] p-4 text-center dark:border-white/14 dark:bg-white/[0.018]"
+                className="flex min-h-48 min-w-0 items-center justify-center rounded-xl border border-dashed border-border/70 bg-card/35 p-4 text-center"
               >
-                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-black/42 dark:text-white/42">unclaimed</p>
+                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/75">unclaimed</p>
               </article>
             ))}
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 html {
+  min-height: 100%;
   scrollbar-gutter: stable;
 }
 
@@ -106,6 +107,7 @@ html {
   }
 
   body {
+    min-height: 100dvh;
     @apply bg-background text-foreground;
   }
 }
@@ -131,7 +133,7 @@ input[type='number']::-webkit-outer-spin-button {
 .time-day-slider {
   appearance: none;
   border: 1px solid rgb(0 0 0 / 0.16);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.18), 0 6px 16px rgb(20 20 24 / 0.12);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.18), 0 8px 20px rgb(20 20 24 / 0.13);
 }
 
 .time-day-slider:focus-visible {
@@ -141,7 +143,7 @@ input[type='number']::-webkit-outer-spin-button {
 
 .dark .time-day-slider {
   border-color: rgb(255 255 255 / 0.16);
-  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08), 0 8px 18px rgb(0 0 0 / 0.28);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.08), 0 9px 22px rgb(0 0 0 / 0.3);
 }
 
 .dark .time-day-slider:focus-visible {
@@ -150,40 +152,60 @@ input[type='number']::-webkit-outer-spin-button {
 
 .time-day-slider::-webkit-slider-thumb {
   appearance: none;
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 1px solid rgb(35 35 39 / 0.42);
+  width: 2.7rem;
+  height: 2.7rem;
+  border: 1px solid rgb(255 255 255 / 0.48);
   border-radius: 999px;
-  background: #d5d0c7;
-  box-shadow: 0 3px 9px rgb(0 0 0 / 0.24);
+  background: rgb(255 255 255 / 0.3);
+  -webkit-backdrop-filter: blur(18px) saturate(145%);
+  backdrop-filter: blur(18px) saturate(145%);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.72),
+    inset 0 -1px 0 rgb(40 40 46 / 0.14),
+    0 5px 16px rgb(0 0 0 / 0.24);
   cursor: grab;
+  transition: transform 120ms ease, background-color 120ms ease, box-shadow 120ms ease;
 }
 
 .dark .time-day-slider::-webkit-slider-thumb {
-  border-color: rgb(255 255 255 / 0.22);
-  background: #444750;
-  box-shadow: 0 3px 9px rgb(0 0 0 / 0.38);
+  border-color: rgb(255 255 255 / 0.28);
+  background: rgb(38 40 47 / 0.48);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.2),
+    inset 0 -1px 0 rgb(0 0 0 / 0.34),
+    0 6px 18px rgb(0 0 0 / 0.42);
 }
 
 .time-day-slider:active::-webkit-slider-thumb {
   cursor: grabbing;
-  box-shadow: 0 2px 6px rgb(0 0 0 / 0.3);
+  transform: scale(0.96);
+  background: rgb(255 255 255 / 0.4);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.74),
+    0 3px 10px rgb(0 0 0 / 0.28);
 }
 
 .time-day-slider::-moz-range-thumb {
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 1px solid rgb(35 35 39 / 0.42);
+  width: 2.7rem;
+  height: 2.7rem;
+  border: 1px solid rgb(255 255 255 / 0.48);
   border-radius: 999px;
-  background: #d5d0c7;
-  box-shadow: 0 3px 9px rgb(0 0 0 / 0.24);
+  background: rgb(255 255 255 / 0.3);
+  backdrop-filter: blur(18px) saturate(145%);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.72),
+    inset 0 -1px 0 rgb(40 40 46 / 0.14),
+    0 5px 16px rgb(0 0 0 / 0.24);
   cursor: grab;
 }
 
 .dark .time-day-slider::-moz-range-thumb {
-  border-color: rgb(255 255 255 / 0.22);
-  background: #444750;
-  box-shadow: 0 3px 9px rgb(0 0 0 / 0.38);
+  border-color: rgb(255 255 255 / 0.28);
+  background: rgb(38 40 47 / 0.48);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.2),
+    inset 0 -1px 0 rgb(0 0 0 / 0.34),
+    0 6px 18px rgb(0 0 0 / 0.42);
 }
 
 @layer components {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,12 +19,12 @@ export default async function Page() {
 
   return (
     <ViewportPageShell
-      className="relative bg-[#dfdbd2] text-[#1b1b1f] dark:bg-[#15171b] dark:text-[#f1ede5]"
-      contentClassName="relative overflow-x-hidden text-inherit"
+      className="relative bg-background text-foreground"
+      contentClassName="relative min-h-[calc(100dvh-3rem)] overflow-x-hidden text-inherit"
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-35 dark:opacity-14"
+        className="pointer-events-none absolute inset-0 opacity-30 dark:opacity-12"
         style={{
           backgroundImage:
             'linear-gradient(rgba(30,30,34,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.04) 1px, transparent 1px)',
@@ -32,7 +32,7 @@ export default async function Page() {
         }}
       />
 
-      <div className="relative mx-auto w-full max-w-5xl px-4 py-5 sm:px-6 sm:py-7">
+      <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-center px-4 py-5 sm:px-6 sm:py-7 lg:px-8">
         <div className="flex min-w-0 flex-col gap-5 sm:gap-6">
           <ActivityDashboard
             initial={{
@@ -47,10 +47,10 @@ export default async function Page() {
 
           <section aria-label="Recent systems" className="min-w-0">
             <div className="flex items-center justify-between gap-4 px-0.5">
-              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-black/52 dark:text-white/56">
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
                 Recent systems
               </p>
-              <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.14em] text-black/46 dark:text-white/48">
+              <span className="shrink-0 font-mono text-[9px] uppercase tracking-[0.14em] text-muted-foreground">
                 {activity.repositories.length} projects
               </span>
             </div>
@@ -68,14 +68,14 @@ export default async function Page() {
                         <h3 className="truncate font-medium">{repository.name}</h3>
                         <ArrowUpRight
                           size={15}
-                          className="shrink-0 text-black/45 transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-black/80 dark:text-white/52 dark:group-hover:text-white/88"
+                          className="shrink-0 text-muted-foreground transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground"
                         />
                       </div>
-                      <p className="mt-3 text-sm leading-relaxed text-black/66 dark:text-white/70">
+                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
                         {repository.note}
                       </p>
                     </div>
-                    <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-black/46 dark:text-white/50">
+                    <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
                       open repository
                     </span>
                   </div>

--- a/app/time/page.tsx
+++ b/app/time/page.tsx
@@ -12,8 +12,8 @@ export const metadata: Metadata = {
 export default function TimePage() {
   return (
     <ViewportPageShell
-      className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]"
-      contentClassName="min-h-0"
+      className="bg-background text-foreground"
+      contentClassName="min-h-[calc(100dvh-3rem)]"
     >
       <UTCTimeVisualizer />
     </ViewportPageShell>

--- a/components/current-time-display.tsx
+++ b/components/current-time-display.tsx
@@ -12,6 +12,8 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
   const [isDST, setIsDST] = useState(false);
 
   useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | undefined;
+
     const updateTime = () => {
       const now = new Date();
       const minutesSinceMidnight = now.getHours() * 60 + now.getMinutes();
@@ -39,11 +41,9 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
 
     const now = new Date();
     const msUntilNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
-
-    let interval: NodeJS.Timeout;
     const initialTimeout = setTimeout(() => {
       updateTime();
-      interval = setInterval(updateTime, 60000);
+      interval = setInterval(updateTime, 60_000);
     }, msUntilNextMinute);
 
     return () => {
@@ -61,11 +61,12 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
   return (
     <div>
       <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <h1 className="text-3xl font-bold">Current time:</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">Current time</h1>
         <button
           type="button"
           onClick={() => onJumpToTime(currentTime)}
-          className="cursor-pointer rounded-md border border-black/15 bg-black/[0.035] px-1.5 text-3xl font-bold transition-colors hover:bg-black/[0.07] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black/60 dark:border-white/15 dark:bg-white/[0.045] dark:hover:bg-white/[0.08] dark:focus-visible:outline-white/70"
+          className="cursor-pointer rounded-xl border border-border/65 bg-background/42 px-2.5 py-1 text-3xl font-semibold tabular-nums shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_7px_18px_rgba(20,20,24,0.08)] backdrop-blur-xl transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_10px_22px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          title="Jump the scrubber to the current time"
         >
           {formatTime(currentTime)}
         </button>
@@ -73,11 +74,11 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
       <p className="text-sm text-muted-foreground">
         <span className="relative inline-block">
           {userTimezone} ({utcOffset})
-          {isDST && (
+          {isDST ? (
             <span className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded bg-amber-500/20 px-1 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
               DST
             </span>
-          )}
+          ) : null}
         </span>
       </p>
     </div>

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -111,7 +111,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   }, []);
 
   return (
-    <div className="relative grid min-w-0 gap-4 lg:grid-cols-[minmax(15rem,0.42fr)_minmax(0,1fr)] lg:items-stretch">
+    <div className="relative grid min-w-0 gap-4 xl:grid-cols-[minmax(22rem,0.72fr)_minmax(32rem,1fr)] xl:items-stretch">
       <span className="sr-only" aria-live="polite">
         {updating ? 'Updating GitHub activity' : ''}
       </span>

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -37,10 +37,12 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
   const [tooltipDate, setTooltipDate] = useState<string | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
-  const [tooltipPosition, setTooltipPosition] = useState({ x: 12, y: 12 });
   const [finePointer, setFinePointer] = useState(false);
   const previousLatest = useRef(days.at(-1)?.date ?? '');
   const hideTimer = useRef<number | null>(null);
+  const positionFrame = useRef<number | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const pendingPosition = useRef({ x: 12, y: 12 });
 
   useEffect(() => {
     const media = window.matchMedia('(hover: hover) and (pointer: fine)');
@@ -53,6 +55,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   useEffect(() => {
     return () => {
       if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
+      if (positionFrame.current !== null) window.cancelAnimationFrame(positionFrame.current);
     };
   }, []);
 
@@ -76,11 +79,19 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
 
   const placeTooltip = (clientX: number, clientY: number) => {
-    const maxX = Math.max(12, window.innerWidth - 300);
-    const maxY = Math.max(12, window.innerHeight - 48);
-    setTooltipPosition({
-      x: Math.min(maxX, Math.max(12, clientX + 14)),
-      y: Math.min(maxY, Math.max(12, clientY + 14)),
+    pendingPosition.current = {
+      x: Math.min(Math.max(12, window.innerWidth - 300), Math.max(12, clientX + 14)),
+      y: Math.min(Math.max(12, window.innerHeight - 48), Math.max(12, clientY + 14)),
+    };
+
+    if (positionFrame.current !== null) return;
+    positionFrame.current = window.requestAnimationFrame(() => {
+      const tooltip = tooltipRef.current;
+      if (tooltip) {
+        const { x, y } = pendingPosition.current;
+        tooltip.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+      }
+      positionFrame.current = null;
     });
   };
 
@@ -99,12 +110,12 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   };
 
   return (
-    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-black/14 bg-[#d7d3ca] p-4 shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:border-white/12 dark:bg-[#222429] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-5">
+    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-4 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-5">
       <div className="flex items-center justify-between gap-4">
-        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/52 dark:text-white/58">
+        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
           28 days · UTC
         </span>
-        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-black/55 dark:text-white/58" aria-hidden="true">
+        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground" aria-hidden="true">
           <span>less</span>
           <span className="h-2.5 w-2.5 rounded-[3px] bg-[#9f97a7]" />
           <span className="h-2.5 w-2.5 rounded-[3px] bg-[#cec4d6]" />
@@ -124,7 +135,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
             <button
               key={day.date}
               type="button"
-              className={`relative aspect-square min-w-0 rounded-[0.6rem] transition-[transform,filter,box-shadow] duration-150 ease-out hover:z-10 hover:-translate-y-1 hover:scale-[1.08] hover:shadow-[0_14px_24px_rgba(35,31,26,0.2)] focus-visible:z-10 focus-visible:-translate-y-1 focus-visible:scale-[1.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/40 dark:hover:shadow-[0_16px_28px_rgba(0,0,0,0.44)] dark:focus-visible:ring-white/50 ${tilt} ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-black/22 dark:outline-white/28' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
+              className={`relative aspect-square min-w-0 rounded-[0.6rem] transition-[transform,filter,box-shadow] duration-150 ease-out will-change-transform hover:z-10 hover:-translate-y-1 hover:scale-[1.08] hover:shadow-[0_14px_24px_rgba(35,31,26,0.2)] focus-visible:z-10 focus-visible:-translate-y-1 focus-visible:scale-[1.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:shadow-[0_16px_28px_rgba(0,0,0,0.44)] ${tilt} ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
               aria-label={label}
               aria-pressed={isSelected}
               onPointerEnter={(event) => {
@@ -137,8 +148,9 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
               onPointerLeave={hideTooltip}
               onFocus={(event) => {
                 setSelectedDate(day.date);
+                if (!event.currentTarget.matches(':focus-visible')) return;
                 const rect = event.currentTarget.getBoundingClientRect();
-                showTooltip(day.date, rect.right, rect.bottom);
+                showTooltip(day.date, rect.left + rect.width / 2, rect.bottom);
               }}
               onBlur={hideTooltip}
               onClick={() => setSelectedDate(day.date)}
@@ -147,14 +159,15 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         })}
       </div>
 
-      <div className="mt-3 flex min-h-9 items-center justify-center rounded-lg border border-black/12 bg-[#e9e5dc] px-3 py-2 text-center font-mono text-[10px] font-medium text-black/68 dark:border-white/12 dark:bg-[#2a2c31] dark:text-white/72 md:hidden" aria-live="polite">
+      <div className="mt-3 flex min-h-9 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-2 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden" aria-live="polite">
         {selectedLabel}
       </div>
 
       {finePointer && tooltipLabel ? (
         <div
-          className={`pointer-events-none fixed z-[90] whitespace-nowrap rounded-lg border border-black/18 bg-[#e9e5dc] px-2.5 py-1.5 font-mono text-[10px] font-semibold text-[#242328] shadow-[0_8px_24px_rgba(20,20,24,0.2)] transition-opacity duration-100 dark:border-white/18 dark:bg-[#2a2c31] dark:text-[#f4f0e8] ${tooltipVisible ? 'opacity-100' : 'opacity-0'}`}
-          style={{ left: tooltipPosition.x, top: tooltipPosition.y }}
+          ref={tooltipRef}
+          className={`pointer-events-none fixed left-0 top-0 z-[90] whitespace-nowrap rounded-lg border border-border/70 bg-popover/88 px-2.5 py-1.5 font-mono text-[10px] font-semibold text-popover-foreground shadow-[0_8px_24px_rgba(20,20,24,0.2)] backdrop-blur-xl transition-opacity duration-100 ${tooltipVisible ? 'opacity-100' : 'opacity-0'}`}
+          style={{ transform: 'translate3d(12px, 12px, 0)' }}
         >
           {tooltipLabel}
         </div>

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -187,7 +187,7 @@ function ScoreDigits({ value }: { value: number }) {
 
   return (
     <div
-      className="flex min-w-0 touch-pan-y gap-1.5 [perspective:780px]"
+      className="flex min-w-0 touch-pan-y gap-2 [perspective:780px] sm:gap-2.5"
       aria-label={`${value} contributions today`}
       data-wind-scoreboard
       onPointerMove={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
@@ -203,13 +203,29 @@ function ScoreDigits({ value }: { value: number }) {
             digitRefs.current[index] = element;
           }}
           data-activity-digit
-          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.45rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(1.8rem,6.5vw,3.4rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_5px_12px_rgba(0,0,0,0.18)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
+          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(2.2rem,6vw,4.9rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_7px_18px_rgba(0,0,0,0.2)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
           style={{ transform: IDLE_TRANSFORM }}
         >
           <SplitFlapDigit digit={digit} index={index} />
         </div>
       ))}
     </div>
+  );
+}
+
+function Metric({ label, value, title }: { label: string; value: string; title?: string }) {
+  return (
+    <span
+      className="grid min-h-16 content-center gap-1 rounded-xl border border-border/65 bg-background/40 px-3 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)]"
+      title={title}
+    >
+      <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        {label}
+      </span>
+      <strong className="font-mono text-xl font-semibold leading-none tabular-nums text-foreground">
+        {value}
+      </strong>
+    </span>
   );
 }
 
@@ -232,29 +248,23 @@ export function ActivityScoreboard({
   }, []);
 
   return (
-    <section className="group/score h-full overflow-hidden rounded-[1.1rem] border border-black/18 bg-[#d0cdc5] shadow-[0_12px_28px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_20px_38px_rgba(24,24,26,0.16)] dark:border-white/16 dark:bg-[#202126] dark:shadow-[0_14px_34px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_22px_44px_rgba(0,0,0,0.42)]">
-      <div className="border-b border-black/16 bg-[#bfbbb2] px-3 py-1.5 dark:border-white/12 dark:bg-[#292a30]">
-        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-black/68 dark:text-white/72">
+    <section className="group/score flex h-full min-h-[18rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_22px_44px_rgba(24,24,26,0.16)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_24px_48px_rgba(0,0,0,0.42)]">
+      <div className="border-b border-border/70 bg-muted/70 px-4 py-2.5">
+        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
           <span>Today</span>
           <span className="tabular-nums">UTC reset {countdown}</span>
         </div>
       </div>
 
-      <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3 p-3 sm:p-4">
+      <div className="flex flex-1 flex-col justify-center gap-4 p-4 sm:gap-5 sm:p-5">
         <ScoreDigits value={today} />
-        <div className="grid min-w-[4.6rem] gap-2 pb-0.5 font-mono text-[9px] uppercase tracking-[0.1em] text-black/62 dark:text-white/64">
-          <span className="grid gap-0.5">
-            <span>7D</span>
-            <strong className="text-sm font-semibold leading-none text-black/88 dark:text-white/90">
-              {weekTotal.toLocaleString('en-GB')}
-            </strong>
-          </span>
-          <span className="grid gap-0.5" title="Calendar year to date, measured in UTC">
-            <span>YTD</span>
-            <strong className="text-sm font-semibold leading-none text-black/88 dark:text-white/90">
-              {yearTotal?.toLocaleString('en-GB') ?? '—'}
-            </strong>
-          </span>
+        <div className="grid grid-cols-2 gap-3">
+          <Metric label="7D" value={weekTotal.toLocaleString('en-GB')} />
+          <Metric
+            label="YTD"
+            value={yearTotal?.toLocaleString('en-GB') ?? '—'}
+            title="Calendar year to date, measured in UTC"
+          />
         </div>
       </div>
     </section>

--- a/components/home/wind-lift-card.tsx
+++ b/components/home/wind-lift-card.tsx
@@ -82,7 +82,9 @@ export function WindLiftCard({
       onPointerMove={handlePointerMove}
       onPointerLeave={(event) => settle(event.currentTarget)}
       onPointerCancel={(event) => settle(event.currentTarget)}
-      onFocus={(event) => lift(event.currentTarget)}
+      onFocus={(event) => {
+        if (event.currentTarget.matches(':focus-visible')) lift(event.currentTarget);
+      }}
       onBlur={(event) => settle(event.currentTarget)}
       style={{
         transform: restTransform,
@@ -91,7 +93,7 @@ export function WindLiftCard({
         willChange: 'transform',
       }}
       className={cn(
-        'group relative block overflow-hidden rounded-2xl border border-black/12 bg-[#d8d3c8] p-4 shadow-[0_8px_18px_rgb(45_39_30/0.08)] transition-[border-color,box-shadow] duration-150 hover:border-black/20 hover:shadow-[0_26px_52px_rgb(45_39_30/0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/65 focus-visible:ring-offset-2 focus-visible:ring-offset-[#e4e0d7] dark:border-white/12 dark:bg-[#282b30] dark:shadow-[0_8px_18px_rgb(0_0_0/0.22)] dark:hover:border-white/20 dark:hover:shadow-[0_28px_58px_rgb(0_0_0/0.48)] dark:focus-visible:ring-white/80 dark:focus-visible:ring-offset-[#1b1d21] motion-reduce:!transform-none motion-reduce:transition-none',
+        'group relative block overflow-hidden rounded-2xl border border-border/65 bg-card p-4 text-card-foreground shadow-[0_8px_18px_rgb(45_39_30/0.08)] transition-[border-color,box-shadow] duration-150 hover:border-border hover:shadow-[0_26px_52px_rgb(45_39_30/0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:shadow-[0_8px_18px_rgb(0_0_0/0.22)] dark:hover:shadow-[0_28px_58px_rgb(0_0_0/0.46)] motion-reduce:!transform-none motion-reduce:transition-none',
         className,
       )}
     >

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -30,7 +30,7 @@ export function TimeLink() {
     <Link
       href="/time"
       prefetch
-      className="group flex shrink-0 items-center gap-1.5 rounded-full border bg-muted/70 px-2 py-1 text-xs font-semibold text-foreground shadow-sm transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      className="group flex shrink-0 items-center gap-1.5 rounded-full border border-border/60 bg-background/38 px-2.5 py-1 text-xs font-semibold text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_5px_14px_rgba(20,20,24,0.07)] backdrop-blur-xl transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/58 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.42),0_8px_18px_rgba(20,20,24,0.1)] focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_6px_16px_rgba(0,0,0,0.22)]"
       title="Open the time converter"
       aria-label={`Open the time converter. Local time ${time}`}
     >
@@ -69,11 +69,11 @@ export function NavMenu({ label, children }: { label: string; children: ReactNod
 
   return (
     <details ref={detailsRef} className="group relative min-w-0">
-      <summary ref={summaryRef} className="flex cursor-pointer list-none items-center gap-1 rounded-full px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+      <summary ref={summaryRef} className="flex cursor-pointer list-none items-center gap-1 rounded-full border border-transparent px-2.5 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:border-border/55 hover:bg-background/45 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
         <span>{label}</span>
         <ChevronDown size={14} className="transition-transform group-open:rotate-180" />
       </summary>
-      <div className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border border-black/15 bg-[#f4f1ea] p-1 text-[#242328] shadow-xl dark:border-white/15 dark:bg-[#18191d] dark:text-[#f0ece5]">
+      <div className="absolute right-0 top-full z-50 mt-2 w-56 max-w-[calc(100vw-1rem)] overflow-hidden rounded-2xl border border-border/65 bg-popover/84 p-1 text-popover-foreground shadow-[0_22px_58px_rgba(20,20,24,0.2)] backdrop-blur-2xl">
         {children}
       </div>
     </details>

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -112,34 +112,34 @@ function MenuLabel({ children }: { children: ReactNode }) {
 
 export default function SiteNav() {
   return (
-    <nav className="min-w-0 border-b bg-background text-foreground">
+    <nav className="sticky top-0 z-50 min-w-0 border-b border-border/55 bg-background/72 text-foreground shadow-[0_1px_0_rgba(255,255,255,0.2),0_10px_30px_rgba(20,20,24,0.05)] backdrop-blur-2xl supports-[backdrop-filter]:bg-background/58 dark:shadow-[0_1px_0_rgba(255,255,255,0.035),0_12px_34px_rgba(0,0,0,0.2)]">
       <div className="mx-auto max-w-7xl px-3 sm:px-6 lg:px-8">
-        <div className="flex h-12 min-w-0 items-center justify-between gap-2 sm:gap-3">
-          <Link href="/" prefetch className="min-w-0 shrink truncate rounded-sm text-base font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-lg">
-            teamleaderleo
-          </Link>
+        <div className="flex h-12 min-w-0 items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3 sm:gap-4">
+            <Link href="/" prefetch className="min-w-0 shrink truncate rounded-sm text-base font-bold focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-lg">
+              teamleaderleo
+            </Link>
+            <TimeLink />
+          </div>
 
           <div className="hidden min-w-0 items-center gap-5 lg:flex">
-            <TimeLink />
-            <div className="h-5 border-l" />
             <div className="flex items-center gap-4">
               {siteLinks.map((item) => (
                 <InlineLink key={item.label} item={item} />
               ))}
             </div>
-            <div className="h-5 border-l" />
+            <div className="h-5 border-l border-border/60" />
             <div className="flex items-center gap-4">
               {socialLinks.map((item) => (
                 <InlineLink key={item.label} item={item} />
               ))}
               <DiscordButton />
             </div>
-            <div className="h-5 border-l" />
+            <div className="h-5 border-l border-border/60" />
             <NavThemeToggle />
           </div>
 
           <div className="flex min-w-0 shrink-0 items-center gap-1.5 lg:hidden">
-            <TimeLink />
             <NavMenu label="menu">
               <MenuLabel>site</MenuLabel>
               {siteLinks.map((item) => (

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -14,7 +14,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggle}
-      className="relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-black/12 bg-[#e2dfd8] text-black/58 shadow-[inset_0_1px_0_rgba(255,255,255,0.45),0_1px_3px_rgba(0,0,0,0.08)] transition hover:bg-[#d8d4cc] hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:border-white/12 dark:bg-[#202126] dark:text-white/60 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_4px_rgba(0,0,0,0.25)] dark:hover:bg-[#292a30] dark:hover:text-white"
+      className="relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/65 bg-background/42 text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_5px_14px_rgba(20,20,24,0.08)] backdrop-blur-xl transition-[background-color,color,transform,box-shadow] hover:-translate-y-px hover:bg-background/62 hover:text-foreground hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.45),0_8px_18px_rgba(20,20,24,0.11)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_6px_16px_rgba(0,0,0,0.24)]"
       aria-label="Toggle light and dark mode"
       type="button"
     >

--- a/components/three-carousel/scene-3d.tsx
+++ b/components/three-carousel/scene-3d.tsx
@@ -1,107 +1,180 @@
 'use client';
 
 import { Canvas, useFrame } from '@react-three/fiber';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MutableRefObject } from 'react';
 import * as THREE from 'three';
 
 const satellites: Array<[number, number, number, number]> = [
-  [-2.6, 1.25, -0.5, 0.34],
-  [2.45, 1.55, -0.2, 0.28],
-  [-2.15, -1.65, 0.45, 0.24],
-  [2.2, -1.35, -0.55, 0.38],
-  [0.1, 2.55, -1.1, 0.2],
-  [0.6, -2.45, 0.65, 0.26],
+  [-2.75, 1.25, -0.5, 0.3],
+  [2.55, 1.55, -0.2, 0.25],
+  [-2.25, -1.7, 0.45, 0.22],
+  [2.3, -1.4, -0.55, 0.34],
+  [0.1, 2.7, -1.1, 0.18],
+  [0.65, -2.55, 0.65, 0.23],
+];
+
+const nestedCubes = [
+  { size: 2.45, opacity: 0.7, rotation: [0, 0, 0] as [number, number, number] },
+  { size: 1.72, opacity: 0.5, rotation: [0.55, 0.72, 0.18] as [number, number, number] },
+  { size: 1.08, opacity: 0.38, rotation: [-0.42, 0.36, 0.7] as [number, number, number] },
 ];
 
 type RotationTarget = { x: number; y: number };
 
-function AgentRoom({
-  rotationX,
-  rotationY,
-  dragging,
+function NestedCube({
+  size,
+  opacity,
+  rotation,
 }: {
-  rotationX: number;
-  rotationY: number;
+  size: number;
+  opacity: number;
+  rotation: [number, number, number];
+}) {
+  return (
+    <group rotation={rotation}>
+      <mesh>
+        <boxGeometry args={[size, size, size]} />
+        <meshPhysicalMaterial
+          color="#b8b1c0"
+          transparent
+          opacity={0.035}
+          roughness={0.26}
+          metalness={0.04}
+          transmission={0.18}
+          thickness={0.45}
+        />
+      </mesh>
+      <lineSegments>
+        <edgesGeometry args={[new THREE.BoxGeometry(size, size, size)]} />
+        <lineBasicMaterial color="#eee9f1" transparent opacity={opacity} />
+      </lineSegments>
+    </group>
+  );
+}
+
+function AgentRoom({
+  rotationTarget,
+  dragging,
+  visible,
+  reduceMotion,
+}: {
+  rotationTarget: MutableRefObject<RotationTarget>;
   dragging: boolean;
+  visible: boolean;
+  reduceMotion: boolean;
 }) {
   const group = useRef<THREE.Group>(null);
+  const core = useRef<THREE.Group>(null);
+  const orbit = useRef<THREE.Group>(null);
   const idleRotation = useRef(0);
 
   useFrame((state, delta) => {
     const currentGroup = group.current;
-    if (!currentGroup) return;
-    if (!dragging) idleRotation.current += delta * 0.12;
+    if (!currentGroup || !visible) return;
+
+    const safeDelta = Math.min(delta, 1 / 30);
+    if (!dragging && !reduceMotion) idleRotation.current += safeDelta * 0.075;
+    const ease = 1 - Math.exp(-safeDelta * 8);
+    const target = rotationTarget.current;
 
     currentGroup.rotation.x = THREE.MathUtils.lerp(
       currentGroup.rotation.x,
-      rotationX + state.pointer.y * 0.06,
-      0.08,
+      target.x + state.pointer.y * 0.045,
+      ease,
     );
     currentGroup.rotation.y = THREE.MathUtils.lerp(
       currentGroup.rotation.y,
-      rotationY + idleRotation.current + state.pointer.x * 0.05,
-      0.08,
+      target.y + idleRotation.current + state.pointer.x * 0.04,
+      ease,
     );
     currentGroup.rotation.z = THREE.MathUtils.lerp(
       currentGroup.rotation.z,
-      -state.pointer.x * 0.035,
-      0.05,
+      -state.pointer.x * 0.025,
+      ease * 0.65,
     );
+
+    if (!reduceMotion && core.current) {
+      core.current.rotation.x += safeDelta * 0.055;
+      core.current.rotation.y -= safeDelta * 0.08;
+      core.current.rotation.z += safeDelta * 0.035;
+    }
+    if (!reduceMotion && orbit.current) {
+      orbit.current.rotation.y += safeDelta * 0.045;
+      orbit.current.rotation.z -= safeDelta * 0.025;
+    }
   });
 
   return (
     <group ref={group}>
-      <mesh>
-        <boxGeometry args={[2.45, 2.45, 2.45]} />
-        <meshStandardMaterial color="#b8b1c0" transparent opacity={0.12} roughness={0.46} metalness={0.08} />
-      </mesh>
-      <lineSegments>
-        <edgesGeometry args={[new THREE.BoxGeometry(2.45, 2.45, 2.45)]} />
-        <lineBasicMaterial color="#eee9f1" transparent opacity={0.78} />
-      </lineSegments>
+      <group ref={core}>
+        {nestedCubes.map((cube) => (
+          <NestedCube key={cube.size} {...cube} />
+        ))}
 
-      <mesh rotation={[Math.PI / 4, Math.PI / 4, 0]}>
-        <octahedronGeometry args={[0.72, 0]} />
-        <meshStandardMaterial color="#e8e2ec" roughness={0.24} metalness={0.12} />
-      </mesh>
-
-      {satellites.map(([x, y, z, size], index) => (
-        <mesh
-          key={`${x}-${y}-${z}`}
-          position={[x, y, z]}
-          rotation={[index * 0.33, index * 0.52, index * 0.19]}
-        >
-          <boxGeometry args={[size, size, size]} />
-          <meshStandardMaterial
-            color={index % 2 === 0 ? '#8f8998' : '#d7d1dd'}
-            roughness={0.42}
-            metalness={0.08}
-          />
+        <mesh rotation={[Math.PI / 4, Math.PI / 4, 0]}>
+          <icosahedronGeometry args={[0.48, 1]} />
+          <meshStandardMaterial color="#e8e2ec" roughness={0.2} metalness={0.16} />
         </mesh>
-      ))}
+
+        <mesh rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[1.42, 0.012, 8, 96]} />
+          <meshBasicMaterial color="#958aa3" transparent opacity={0.62} />
+        </mesh>
+        <mesh rotation={[0.42, 0.7, Math.PI / 2]}>
+          <torusGeometry args={[1.9, 0.009, 8, 96]} />
+          <meshBasicMaterial color="#d7d0dc" transparent opacity={0.32} />
+        </mesh>
+      </group>
+
+      <group ref={orbit}>
+        {satellites.map(([x, y, z, size], index) => (
+          <mesh
+            key={`${x}-${y}-${z}`}
+            position={[x, y, z]}
+            rotation={[index * 0.33, index * 0.52, index * 0.19]}
+          >
+            <boxGeometry args={[size, size, size]} />
+            <meshStandardMaterial
+              color={index % 2 === 0 ? '#8f8998' : '#d7d1dd'}
+              roughness={0.36}
+              metalness={0.12}
+            />
+          </mesh>
+        ))}
+      </group>
     </group>
   );
 }
 
 export default function Scene3D() {
-  const [mounted, setMounted] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const [rotationTarget, setRotationTarget] = useState<RotationTarget>({ x: 0, y: 0 });
+  const [isVisible, setIsVisible] = useState(true);
+  const [reduceMotion, setReduceMotion] = useState(false);
+  const rotationTarget = useRef<RotationTarget>({ x: 0, y: 0 });
   const lastPointer = useRef({ x: 0, y: 0 });
 
-  useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    const motionMedia = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updateMotion = () => setReduceMotion(motionMedia.matches);
+    const updateVisibility = () => setIsVisible(document.visibilityState === 'visible');
+
+    updateMotion();
+    updateVisibility();
+    motionMedia.addEventListener('change', updateMotion);
+    document.addEventListener('visibilitychange', updateVisibility);
+    return () => {
+      motionMedia.removeEventListener('change', updateMotion);
+      document.removeEventListener('visibilitychange', updateVisibility);
+    };
+  }, []);
 
   const stopDragging = () => setIsDragging(false);
-
-  if (!mounted) {
-    return <div className="h-full min-w-0 w-full bg-[#15161a]" aria-hidden="true" />;
-  }
 
   return (
     <div
       className={`h-full min-w-0 w-full touch-pan-y select-none overflow-hidden outline-none ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
       role="img"
-      aria-label="Draggable three-dimensional agent room"
+      aria-label="Draggable nested-cube gallery orbit"
       tabIndex={0}
       onPointerDown={(event) => {
         setIsDragging(true);
@@ -113,10 +186,12 @@ export default function Scene3D() {
         const dx = event.clientX - lastPointer.current.x;
         const dy = event.clientY - lastPointer.current.y;
         lastPointer.current = { x: event.clientX, y: event.clientY };
-        setRotationTarget((current) => ({
-          y: current.y + dx * 0.008,
-          x: THREE.MathUtils.clamp(current.x + dy * 0.006, -0.72, 0.72),
-        }));
+        rotationTarget.current.y += dx * 0.008;
+        rotationTarget.current.x = THREE.MathUtils.clamp(
+          rotationTarget.current.x + dy * 0.006,
+          -0.72,
+          0.72,
+        );
       }}
       onPointerUp={(event) => {
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
@@ -126,36 +201,34 @@ export default function Scene3D() {
       }}
       onPointerCancel={stopDragging}
       onKeyDown={(event) => {
-        if (event.key === 'ArrowLeft') {
-          setRotationTarget((current) => ({ ...current, y: current.y - 0.18 }));
-        }
-        if (event.key === 'ArrowRight') {
-          setRotationTarget((current) => ({ ...current, y: current.y + 0.18 }));
-        }
+        if (event.key === 'ArrowLeft') rotationTarget.current.y -= 0.18;
+        if (event.key === 'ArrowRight') rotationTarget.current.y += 0.18;
         if (event.key === 'ArrowUp') {
-          setRotationTarget((current) => ({ ...current, x: Math.max(-0.72, current.x - 0.14) }));
+          rotationTarget.current.x = Math.max(-0.72, rotationTarget.current.x - 0.14);
         }
         if (event.key === 'ArrowDown') {
-          setRotationTarget((current) => ({ ...current, x: Math.min(0.72, current.x + 0.14) }));
+          rotationTarget.current.x = Math.min(0.72, rotationTarget.current.x + 0.14);
         }
       }}
     >
       <Canvas
         className="block h-full min-w-0 w-full"
         camera={{ position: [4.8, 3.4, 5.4], fov: 42 }}
-        dpr={[1, 1.5]}
+        dpr={[1, 1.35]}
+        frameloop={isVisible ? 'always' : 'never'}
         gl={{ antialias: true, powerPreference: 'high-performance' }}
         style={{ width: '100%', height: '100%', display: 'block', touchAction: 'pan-y' }}
       >
         <color attach="background" args={['#15161a']} />
         <fog attach="fog" args={['#15161a', 7, 12]} />
-        <ambientLight intensity={1.25} />
-        <directionalLight position={[4, 6, 5]} intensity={2.4} color="#f1eaf5" />
-        <pointLight position={[-4, -2, 3]} intensity={22} distance={9} color="#756b83" />
+        <ambientLight intensity={1.18} />
+        <directionalLight position={[4, 6, 5]} intensity={2.2} color="#f1eaf5" />
+        <pointLight position={[-4, -2, 3]} intensity={18} distance={9} color="#756b83" />
         <AgentRoom
-          rotationX={rotationTarget.x}
-          rotationY={rotationTarget.y}
+          rotationTarget={rotationTarget}
           dragging={isDragging}
+          visible={isVisible}
+          reduceMotion={reduceMotion}
         />
       </Canvas>
     </div>

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -49,19 +49,19 @@ export default function UTCTimeVisualizer() {
             : 'Night';
 
   return (
-    <div className="mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-5xl items-center px-4 py-8 sm:px-6">
-      <div className="w-full rounded-[1.5rem] border border-black/12 bg-[#dedcd6] p-5 shadow-[0_18px_46px_rgba(24,24,26,0.1)] dark:border-white/10 dark:bg-[#18191d] dark:shadow-[0_20px_48px_rgba(0,0,0,0.3)] sm:p-7">
+    <div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-6xl items-center px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
+      <div className="w-full rounded-[1.5rem] border border-border/70 bg-card/92 p-5 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] backdrop-blur-xl dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
         <CurrentTimeDisplay onJumpToTime={setLocalTime} />
 
         <div className="mt-7">
           <div className="mb-3 flex items-center justify-between gap-3">
             <label
               htmlFor="time-of-day"
-              className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/50 dark:text-white/48"
+              className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground"
             >
               Local time of day
             </label>
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-black/45 dark:text-white/42">
+            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
               {timeOfDay}
             </span>
           </div>
@@ -78,7 +78,7 @@ export default function UTCTimeVisualizer() {
             className="time-day-slider h-14 w-full cursor-pointer rounded-full"
             style={{ background: DAY_GRADIENT }}
           />
-          <div className="mt-2 flex justify-between font-mono text-[10px] text-black/45 dark:text-white/42">
+          <div className="mt-2 flex justify-between font-mono text-[10px] text-muted-foreground">
             <span>00:00</span>
             <span>06:00</span>
             <span>12:00</span>
@@ -88,31 +88,31 @@ export default function UTCTimeVisualizer() {
         </div>
 
         <div className="mt-7 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
-          <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-4 dark:border-white/10 dark:bg-[#202126]">
+          <div className="rounded-xl border border-border/65 bg-background/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md">
             <div className="flex items-end gap-3">
               <p className="font-mono text-5xl font-semibold tabular-nums tracking-[-0.05em] sm:text-6xl">
                 {formatTime(localHours, localMinutes)}
               </p>
-              <p className="pb-1 text-xl text-black/50 dark:text-white/48">
+              <p className="pb-1 text-xl text-muted-foreground">
                 {formatTime12Hour(localHours, localMinutes)} {period}
               </p>
             </div>
-            <p className="mt-2 text-sm text-black/52 dark:text-white/50">Selected local time</p>
+            <p className="mt-2 text-sm text-muted-foreground">Selected local time</p>
           </div>
 
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-3 dark:border-white/10 dark:bg-[#202126]">
-              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">UTC</p>
+            <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">UTC</p>
               <p className="mt-1 text-2xl font-semibold tabular-nums">{formatTime(utcHours, utcMinutes)}</p>
             </div>
-            <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-3 dark:border-white/10 dark:bg-[#202126]">
-              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">Eastern</p>
+            <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Eastern</p>
               <p className="mt-1 text-2xl font-semibold tabular-nums">
                 {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
               </p>
             </div>
-            <div className="rounded-xl border border-black/10 bg-[#ebe8e1] p-3 dark:border-white/10 dark:bg-[#202126]">
-              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-black/46 dark:text-white/44">Pacific</p>
+            <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Pacific</p>
               <p className="mt-1 text-2xl font-semibold tabular-nums">
                 {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
               </p>

--- a/components/timezone-selector.tsx
+++ b/components/timezone-selector.tsx
@@ -8,130 +8,131 @@ interface TimezoneSelectorProps {
   utcMinutes: number;
 }
 
+type TimezoneOption = {
+  offset: number;
+  label: string;
+  dst: boolean;
+  region: string | null;
+};
+
+const TIMEZONE_OPTIONS: TimezoneOption[] = [
+  { offset: -12, label: 'Baker Island', dst: false, region: null },
+  { offset: -11, label: 'American Samoa', dst: false, region: null },
+  { offset: -10, label: 'Hawaii', dst: false, region: null },
+  { offset: -9, label: 'Alaska', dst: true, region: 'us' },
+  { offset: -8, label: 'Pacific Time', dst: true, region: 'us' },
+  { offset: -7, label: 'Mountain Time', dst: true, region: 'us' },
+  { offset: -6, label: 'Central Time', dst: true, region: 'us' },
+  { offset: -5, label: 'Eastern Time', dst: true, region: 'us' },
+  { offset: -4, label: 'Atlantic Time', dst: true, region: 'us' },
+  { offset: -3, label: 'Buenos Aires', dst: false, region: null },
+  { offset: -2, label: 'Mid-Atlantic', dst: false, region: null },
+  { offset: -1, label: 'Azores', dst: true, region: 'eu' },
+  { offset: 0, label: 'UTC/London', dst: true, region: 'eu' },
+  { offset: 1, label: 'Central European', dst: true, region: 'eu' },
+  { offset: 2, label: 'Eastern European', dst: true, region: 'eu' },
+  { offset: 3, label: 'Moscow', dst: false, region: null },
+  { offset: 4, label: 'Dubai', dst: false, region: null },
+  { offset: 5, label: 'Pakistan', dst: false, region: null },
+  { offset: 5.5, label: 'India', dst: false, region: null },
+  { offset: 6, label: 'Bangladesh', dst: false, region: null },
+  { offset: 7, label: 'Bangkok', dst: false, region: null },
+  { offset: 8, label: 'Singapore', dst: false, region: null },
+  { offset: 9, label: 'Tokyo', dst: false, region: null },
+  { offset: 10, label: 'Sydney', dst: true, region: 'aus' },
+  { offset: 11, label: 'Solomon Islands', dst: false, region: null },
+  { offset: 12, label: 'New Zealand', dst: true, region: 'nz' },
+];
+
+function getAdjustedOffset(option: TimezoneOption) {
+  if (!option.dst || !option.region) return option.offset;
+  return isDSTActive(option.region) ? option.offset + 1 : option.offset;
+}
+
+function formatTime(hours: number, minutes: number) {
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+function formatOffset(offset: number) {
+  if (offset === 0) return 'UTC';
+  return `UTC${offset >= 0 ? '+' : ''}${offset}`;
+}
+
 export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelectorProps) {
   const [selectedOffset, setSelectedOffset] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState(false);
 
-  // Common UTC offsets with DST information
-  const timezoneOptions = [
-    { offset: -12, label: 'Baker Island', dst: false, region: null },
-    { offset: -11, label: 'American Samoa', dst: false, region: null },
-    { offset: -10, label: 'Hawaii', dst: false, region: null },
-    { offset: -9, label: 'Alaska', dst: true, region: 'us' },
-    { offset: -8, label: 'Pacific Time', dst: true, region: 'us' },
-    { offset: -7, label: 'Mountain Time', dst: true, region: 'us' },
-    { offset: -6, label: 'Central Time', dst: true, region: 'us' },
-    { offset: -5, label: 'Eastern Time', dst: true, region: 'us' },
-    { offset: -4, label: 'Atlantic Time', dst: true, region: 'us' },
-    { offset: -3, label: 'Buenos Aires', dst: false, region: null },
-    { offset: -2, label: 'Mid-Atlantic', dst: false, region: null },
-    { offset: -1, label: 'Azores', dst: true, region: 'eu' },
-    { offset: 0, label: 'UTC/London', dst: true, region: 'eu' },
-    { offset: 1, label: 'Central European', dst: true, region: 'eu' },
-    { offset: 2, label: 'Eastern European', dst: true, region: 'eu' },
-    { offset: 3, label: 'Moscow', dst: false, region: null },
-    { offset: 4, label: 'Dubai', dst: false, region: null },
-    { offset: 5, label: 'Pakistan', dst: false, region: null },
-    { offset: 5.5, label: 'India', dst: false, region: null },
-    { offset: 6, label: 'Bangladesh', dst: false, region: null },
-    { offset: 7, label: 'Bangkok', dst: false, region: null },
-    { offset: 8, label: 'Singapore', dst: false, region: null },
-    { offset: 9, label: 'Tokyo', dst: false, region: null },
-    { offset: 10, label: 'Sydney', dst: true, region: 'aus' },
-    { offset: 11, label: 'Solomon Islands', dst: false, region: null },
-    { offset: 12, label: 'New Zealand', dst: true, region: 'nz' },
-  ];
-
-  // Get adjusted offset accounting for DST
-  const getAdjustedOffset = (option: typeof timezoneOptions[0]) => {
-    if (!option.dst || !option.region) return option.offset;
-    const dstActive = isDSTActive(option.region);
-    return dstActive ? option.offset + 1 : option.offset;
-  };
-
-  const formatTime = (hours: number, minutes: number) => {
-    return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-  };
-
   const calculateOffsetTime = (offset: number) => {
     const totalMinutes = utcHours * 60 + utcMinutes + offset * 60;
     const adjustedMinutes = ((totalMinutes % 1440) + 1440) % 1440;
-    const hours = Math.floor(adjustedMinutes / 60);
-    const minutes = adjustedMinutes % 60;
-    return { hours, minutes };
+    return {
+      hours: Math.floor(adjustedMinutes / 60),
+      minutes: adjustedMinutes % 60,
+    };
   };
 
-  const formatOffset = (offset: number) => {
-    if (offset === 0) return 'UTC';
-    const sign = offset >= 0 ? '+' : '';
-    return `UTC${sign}${offset}`;
-  };
-
-  const handleSelect = (offset: number) => {
-    setSelectedOffset(offset);
-    setIsOpen(false);
-  };
-
-  const selectedOption = selectedOffset !== null 
-    ? timezoneOptions.find(opt => opt.offset === selectedOffset)
-    : null;
-
-  const displayTime = selectedOption
-    ? calculateOffsetTime(getAdjustedOffset(selectedOption))
-    : null;
-
-  const displayOffset = selectedOption
-    ? getAdjustedOffset(selectedOption)
-    : null;
+  const selectedOption =
+    selectedOffset === null
+      ? null
+      : TIMEZONE_OPTIONS.find((option) => option.offset === selectedOffset) ?? null;
+  const displayOffset = selectedOption ? getAdjustedOffset(selectedOption) : null;
+  const displayTime = displayOffset === null ? null : calculateOffsetTime(displayOffset);
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <div className="min-w-[7.7rem]">
-          <button
-            className="w-full text-left hover:bg-muted/50 rounded-md transition-colors p-2 -m-2"
-          >
-            <p className="text-sm text-muted-foreground mb-2">
-              <span className="relative inline-block">
-                {displayOffset !== null ? formatOffset(displayOffset) : 'UTC + ?'}
-                {selectedOption?.dst && (
-                  <span className="absolute left-full ml-1.5 top-1/2 -translate-y-1/2 text-[9px] px-1 py-0.5 bg-amber-500/20 text-amber-700 dark:text-amber-400 rounded font-semibold whitespace-nowrap">
-                    DST
-                  </span>
-                )}
-              </span>
-            </p>
-            <p className="text-4xl font-bold">
-              {displayTime ? formatTime(displayTime.hours, displayTime.minutes) : '--:--'}
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              {selectedOption ? selectedOption.label : 'Select timezone'}
-            </p>
-          </button>
-        </div>
+        <button
+          type="button"
+          className="w-full rounded-xl border border-border/65 bg-background/46 p-3 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.26),0_8px_20px_rgba(20,20,24,0.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <p className="mb-2 text-sm text-muted-foreground">
+            <span className="relative inline-block">
+              {displayOffset === null ? 'UTC + ?' : formatOffset(displayOffset)}
+              {selectedOption?.dst ? (
+                <span className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded bg-amber-500/20 px-1 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
+                  DST
+                </span>
+              ) : null}
+            </span>
+          </p>
+          <p className="font-mono text-4xl font-semibold tabular-nums">
+            {displayTime ? formatTime(displayTime.hours, displayTime.minutes) : '--:--'}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {selectedOption?.label ?? 'Select timezone'}
+          </p>
+        </button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 p-0" align="start" side="top" sideOffset={8}>
+      <PopoverContent
+        className="w-64 border-border/65 bg-popover/88 p-0 text-popover-foreground shadow-[0_22px_58px_rgba(20,20,24,0.2)] backdrop-blur-2xl"
+        align="start"
+        side="top"
+        sideOffset={8}
+      >
         <Command>
           <CommandInput placeholder="Search timezone..." />
           <CommandList className="max-h-40 overflow-y-auto scroll-smooth">
             <CommandEmpty>No timezone found.</CommandEmpty>
             <CommandGroup>
-              {timezoneOptions.map((option) => {
+              {TIMEZONE_OPTIONS.map((option) => {
                 const adjustedOffset = getAdjustedOffset(option);
                 return (
                   <CommandItem
                     key={option.offset}
                     value={`${option.label} ${formatOffset(adjustedOffset)}`}
-                    onSelect={() => handleSelect(option.offset)}
-                    className="flex justify-between items-center"
+                    onSelect={() => {
+                      setSelectedOffset(option.offset);
+                      setIsOpen(false);
+                    }}
+                    className="flex items-center justify-between"
                   >
                     <span className="flex items-center gap-1.5">
                       <span>{option.label}</span>
-                      {option.dst && (
-                        <span className="text-[10px] px-1.5 py-0.5 bg-amber-500/20 text-amber-700 dark:text-amber-400 rounded font-semibold">
+                      {option.dst ? (
+                        <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400">
                           DST
                         </span>
-                      )}
+                      ) : null}
                     </span>
                     <span className="text-xs text-muted-foreground">
                       {formatOffset(adjustedOffset)}
@@ -140,8 +141,8 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
                 );
               })}
             </CommandGroup>
-            <div className="px-3 py-2 text-[11px] text-muted-foreground border-t">
-              <span className="text-amber-700 dark:text-amber-400 font-medium">DST</span> = Observes Daylight Saving Time (offset changes seasonally)
+            <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+              <span className="font-medium text-amber-700 dark:text-amber-400">DST</span> = Observes Daylight Saving Time (offset changes seasonally)
             </div>
           </CommandList>
         </Command>

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -99,9 +99,69 @@ test('homepage counter uses UTC, 7D, and YTD instrument labels', async ({ page }
   await expect(page.locator('[data-activity-digit] > span')).toHaveCount(4);
 });
 
+test('homepage activity tooltip stays anchored through a pointer click', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/');
+  await waitForClientHydration(page);
+
+  const grid = page.locator('[aria-label="Four weeks of GitHub activity"]');
+  const cell = grid.getByRole('button').nth(8);
+  const label = await cell.getAttribute('aria-label');
+  expect(label).toBeTruthy();
+
+  const cellBox = await cell.boundingBox();
+  expect(cellBox).toBeTruthy();
+  const x = cellBox!.x + cellBox!.width / 2;
+  const y = cellBox!.y + cellBox!.height / 2;
+  await page.mouse.move(x, y);
+
+  const tooltip = page.locator('div.fixed').filter({ hasText: label! });
+  await expect(tooltip).toBeVisible();
+  const before = await tooltip.boundingBox();
+  expect(before).toBeTruthy();
+
+  await page.mouse.click(x, y);
+  const after = await tooltip.boundingBox();
+  expect(after).toBeTruthy();
+  expect(Math.abs(after!.x - before!.x)).toBeLessThan(1);
+  expect(Math.abs(after!.y - before!.y)).toBeLessThan(1);
+});
+
+test('homepage shell covers the viewport with the document background', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/');
+
+  const shell = await page.evaluate(() => {
+    const root = document.querySelector('nav')?.parentElement;
+    if (!root) throw new Error('Missing viewport page shell');
+    return {
+      shellBackground: getComputedStyle(root).backgroundColor,
+      bodyBackground: getComputedStyle(document.body).backgroundColor,
+      shellHeight: root.getBoundingClientRect().height,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(shell.shellBackground).toBe(shell.bodyBackground);
+  expect(shell.shellHeight).toBeGreaterThanOrEqual(shell.viewportHeight);
+});
+
+test('desktop clock sits beside the site identity', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto('/');
+  await waitForClientHydration(page);
+
+  const brand = await page.getByRole('link', { name: 'teamleaderleo', exact: true }).boundingBox();
+  const clock = await page.getByRole('link', { name: /Open the time converter/i }).boundingBox();
+  expect(brand).toBeTruthy();
+  expect(clock).toBeTruthy();
+  expect(clock!.x - (brand!.x + brand!.width)).toBeLessThan(36);
+});
+
 test('gallery credits the agents who worked here', async ({ page }) => {
   await page.goto('/gallery');
 
+  await expect(page.getByRole('img', { name: 'Draggable nested-cube gallery orbit' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Codex' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Claude Fable' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Mothbit' })).toBeVisible();


### PR DESCRIPTION
## Summary

Responds to the latest desktop interaction and visual review with a focused repair pass across the homepage, gallery, time page, and shared navigation.

### Homepage activity
- removes pointer-move React renders from the 28-day contribution grid by positioning the hover label through one animation-frame-limited DOM write
- prevents mouse clicks from invoking the keyboard-focus tooltip placement path, so the hover label no longer jumps after clicking a square
- keeps keyboard focus labels available through `:focus-visible`
- enlarges and rebalances the split-flap scoreboard
- moves 7D and YTD into a full-width instrument footer so the stretched card no longer contains a large dead area
- widens the desktop content area and gives the homepage a full-height shared background
- replaces the page-specific outer background colour with the global theme token, eliminating the different right/bottom gutter colour

### Gallery motion and scene
- moves drag rotation targets out of React state, avoiding a component render on every drag event
- pauses the Three.js frame loop while the document is hidden
- clamps resumed frame deltas so returning to the tab cannot produce a large rotation jump
- lowers the idle rotation speed and honours reduced motion
- adds a restrained nested-cube / orbital scene with transparent cube shells, wireframe edges, rings, and slowly orbiting satellite blocks
- lowers the maximum device pixel ratio to reduce unnecessary GPU work

### Navigation and time
- places the clock next to the site identity instead of at the far edge of the desktop link group
- gives navigation, menus, the clock, and the theme switch a restrained translucent material
- applies the shared background, card, text, and border tokens to the time and gallery pages
- gives the time scrubber a translucent, highlighted grab handle
- cleans up the timezone selector data and rendering structure

### Coverage
- verifies that the activity tooltip remains in the same position through a pointer click
- verifies that the homepage shell covers the full viewport and matches the document background
- verifies that the desktop clock sits beside the site identity
- verifies the nested-cube gallery scene is exposed accessibly
- preserves overflow, scrolling, reduced-motion, navigation, and split-flap coverage

The more experimental detachable/bouncing activity squares are deliberately left for a separate physics-lab slice rather than being coupled to these regression fixes.

Tracks the visual-system and tactile-lab work in #368.