### PR TITLE
fix: restore compact homepage instrument density

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,13 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium webkit
       - name: Browser regressions
         run: pnpm test:e2e > playwright.log 2>&1
+      - name: Upload homepage density screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: homepage-density-screenshots
+          path: test-results/homepage-density
+          if-no-files-found: ignore
       - name: Upload browser diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,8 +32,8 @@ export default async function Page() {
         }}
       />
 
-      <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-center px-4 py-5 sm:px-6 sm:py-7 lg:px-8">
-        <div className="flex min-w-0 flex-col gap-5 sm:gap-6">
+      <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-start px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
+        <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
           <ActivityDashboard
             initial={{
               today: activity.today,
@@ -45,7 +45,7 @@ export default async function Page() {
             }}
           />
 
-          <section aria-label="Recent systems" className="min-w-0">
+          <section aria-label="Recent systems" className="min-w-0" data-recent-systems>
             <div className="flex items-center justify-between gap-4 px-0.5">
               <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
                 Recent systems
@@ -55,14 +55,14 @@ export default async function Page() {
               </span>
             </div>
 
-            <div className="mt-3 grid min-w-0 grid-cols-1 gap-3 md:grid-cols-3">
+            <div className="mt-2.5 grid min-w-0 grid-cols-1 gap-2.5 md:grid-cols-3">
               {activity.repositories.map((repository) => (
                 <WindLiftCard
                   key={repository.name}
                   href={repository.url}
-                  className="min-h-32"
+                  className="min-h-28 p-3.5"
                 >
-                  <div className="flex min-h-24 flex-col justify-between gap-4">
+                  <div className="flex min-h-20 flex-col justify-between gap-3">
                     <div>
                       <div className="flex items-center justify-between gap-3">
                         <h3 className="truncate font-medium">{repository.name}</h3>
@@ -71,7 +71,7 @@ export default async function Page() {
                           className="shrink-0 text-muted-foreground transition-transform duration-150 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground"
                         />
                       </div>
-                      <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                      <p className="mt-2 text-sm leading-snug text-muted-foreground">
                         {repository.note}
                       </p>
                     </div>

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -111,7 +111,13 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   }, []);
 
   return (
-    <div className="relative grid min-w-0 gap-4 xl:grid-cols-[minmax(22rem,0.72fr)_minmax(32rem,1fr)] xl:items-stretch">
+    <div
+      className="relative grid min-w-0 items-stretch gap-3.5 sm:gap-4"
+      data-home-activity-dashboard
+      style={{
+        gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 24rem), 1fr))',
+      }}
+    >
       <span className="sr-only" aria-live="polite">
         {updating ? 'Updating GitHub activity' : ''}
       </span>

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -127,7 +127,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
       </div>
 
       <div
-        className="mx-auto mt-3 grid w-full max-w-[27rem] min-w-0 grid-cols-7 gap-2 sm:gap-2.5 [@media(max-height:780px)]:max-w-[24rem]"
+        className="mx-auto mt-3 grid w-full max-w-[25rem] min-w-0 grid-cols-7 gap-2 sm:gap-2.5 [@media(max-height:780px)]:max-w-[24rem]"
         aria-label="Four weeks of GitHub activity"
       >
         {days.map((day, index) => {

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -109,7 +109,10 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   };
 
   return (
-    <section className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-4 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-5">
+    <section
+      className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-4"
+      data-home-activity-grid
+    >
       <div className="flex items-center justify-between gap-4">
         <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
           28 days · UTC
@@ -123,7 +126,10 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div className="mt-4 grid min-w-0 grid-cols-7 gap-2.5 sm:gap-3" aria-label="Four weeks of GitHub activity">
+      <div
+        className="mx-auto mt-3 grid w-full max-w-[27rem] min-w-0 grid-cols-7 gap-2 sm:gap-2.5 [@media(max-height:780px)]:max-w-[24rem]"
+        aria-label="Four weeks of GitHub activity"
+      >
         {days.map((day, index) => {
           const label = labelForDay(day, unit);
           const isSelected = day.date === selected?.date;
@@ -158,7 +164,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         })}
       </div>
 
-      <div className="mt-3 flex min-h-9 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-2 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden" aria-live="polite">
+      <div className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden" aria-live="polite">
         {selectedLabel}
       </div>
 

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -187,7 +187,7 @@ function ScoreDigits({ value }: { value: number }) {
 
   return (
     <div
-      className="flex min-w-0 touch-pan-y gap-2 [perspective:780px] sm:gap-2.5"
+      className="flex min-w-0 touch-pan-y gap-1.5 [perspective:780px] sm:gap-2"
       aria-label={`${value} contributions today`}
       data-wind-scoreboard
       onPointerMove={(event) => moveDigits(event.clientX, event.clientY, event.currentTarget)}
@@ -203,7 +203,7 @@ function ScoreDigits({ value }: { value: number }) {
             digitRefs.current[index] = element;
           }}
           data-activity-digit
-          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(2.2rem,6vw,4.9rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_7px_18px_rgba(0,0,0,0.2)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
+          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_7px_18px_rgba(0,0,0,0.2)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
           style={{ transform: IDLE_TRANSFORM }}
         >
           <SplitFlapDigit digit={digit} index={index} />
@@ -216,13 +216,13 @@ function ScoreDigits({ value }: { value: number }) {
 function Metric({ label, value, title }: { label: string; value: string; title?: string }) {
   return (
     <span
-      className="grid min-h-16 content-center gap-1 rounded-xl border border-border/65 bg-background/40 px-3 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)]"
+      className="grid min-h-[3.75rem] content-center gap-1 rounded-xl border border-border/65 bg-background/40 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)]"
       title={title}
     >
       <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
         {label}
       </span>
-      <strong className="font-mono text-xl font-semibold leading-none tabular-nums text-foreground">
+      <strong className="font-mono text-base font-semibold leading-none tabular-nums text-foreground sm:text-lg">
         {value}
       </strong>
     </span>
@@ -248,17 +248,20 @@ export function ActivityScoreboard({
   }, []);
 
   return (
-    <section className="group/score flex h-full min-h-[18rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_22px_44px_rgba(24,24,26,0.16)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_24px_48px_rgba(0,0,0,0.42)]">
-      <div className="border-b border-border/70 bg-muted/70 px-4 py-2.5">
+    <section
+      className="group/score flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_22px_44px_rgba(24,24,26,0.16)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_24px_48px_rgba(0,0,0,0.42)] [@media(max-height:780px)]:min-h-[14.5rem]"
+      data-activity-scoreboard
+    >
+      <div className="border-b border-border/70 bg-muted/70 px-4 py-2.5 [@media(max-height:780px)]:py-2">
         <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
           <span>Today</span>
           <span className="tabular-nums">UTC reset {countdown}</span>
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col justify-center gap-4 p-4 sm:gap-5 sm:p-5">
+      <div className="grid flex-1 grid-cols-[minmax(0,1fr)_minmax(5.5rem,0.34fr)] items-center gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(6.25rem,0.32fr)] sm:gap-4 sm:p-5 [@media(max-height:780px)]:gap-2.5 [@media(max-height:780px)]:p-3.5">
         <ScoreDigits value={today} />
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid content-center gap-2">
           <Metric label="7D" value={weekTotal.toLocaleString('en-GB')} />
           <Metric
             label="YTD"

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -10,8 +10,51 @@ const desktopViewports = [
   { width: 1180, height: 720 },
 ] as const;
 
+async function readHomepageFootprint(page: Page) {
+  return page.evaluate(() => {
+    const dashboard = document.querySelector<HTMLElement>('[data-home-activity-dashboard]');
+    const scoreboard = document.querySelector<HTMLElement>('[data-activity-scoreboard]');
+    const activityGrid = document.querySelector<HTMLElement>('[data-home-activity-grid]');
+    const activityCell = document.querySelector<HTMLElement>(
+      '[aria-label="Four weeks of GitHub activity"] button',
+    );
+    const recentSection = document.querySelector<HTMLElement>('[data-recent-systems]');
+    const recentCard = recentSection?.querySelector<HTMLElement>('a');
+
+    if (!dashboard || !scoreboard || !activityGrid || !activityCell || !recentSection || !recentCard) {
+      throw new Error('Missing homepage density instrument');
+    }
+
+    const rect = (element: HTMLElement) => {
+      const box = element.getBoundingClientRect();
+      return {
+        x: box.x,
+        y: box.y,
+        width: box.width,
+        height: box.height,
+        right: box.right,
+        bottom: box.bottom,
+      };
+    };
+
+    return {
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      document: {
+        width: document.documentElement.scrollWidth,
+        height: document.documentElement.scrollHeight,
+      },
+      dashboard: rect(dashboard),
+      scoreboard: rect(scoreboard),
+      activityGrid: rect(activityGrid),
+      activityCell: rect(activityCell),
+      recentSection: rect(recentSection),
+      recentCard: rect(recentCard),
+    };
+  });
+}
+
 for (const viewport of desktopViewports) {
-  test(`captures homepage density baseline at ${viewport.width}x${viewport.height}`, async ({
+  test(`keeps the homepage instrument compact at ${viewport.width}x${viewport.height}`, async ({
     page,
   }, testInfo) => {
     await page.setViewportSize(viewport);
@@ -20,17 +63,22 @@ for (const viewport of desktopViewports) {
 
     await expect(page.locator('[data-wind-scoreboard]')).toBeVisible();
     await expect(page.locator('[aria-label="Four weeks of GitHub activity"]')).toBeVisible();
+    await expect(page.getByText('Recent systems', { exact: true })).toBeVisible();
 
-    const overflow = await page.evaluate(() => ({
-      clientWidth: document.documentElement.clientWidth,
-      scrollWidth: document.documentElement.scrollWidth,
-    }));
-    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+    const footprint = await readHomepageFootprint(page);
+    expect(footprint.document.width).toBeLessThanOrEqual(footprint.viewport.width);
+    expect(footprint.document.height - footprint.viewport.height).toBeLessThanOrEqual(4);
+    expect(footprint.dashboard.bottom).toBeLessThan(footprint.viewport.height);
+    expect(footprint.recentSection.y).toBeLessThan(footprint.viewport.height - 72);
+    expect(footprint.recentCard.y).toBeLessThan(footprint.viewport.height - 40);
+    expect(footprint.activityCell.width).toBeGreaterThanOrEqual(42);
+    expect(footprint.activityCell.width).toBeLessThanOrEqual(56);
+    expect(Math.abs(footprint.activityCell.width - footprint.activityCell.height)).toBeLessThan(1);
 
     const screenshotPath = path.join(
       'test-results',
       'homepage-density',
-      'before',
+      'after',
       testInfo.project.name,
       `${viewport.width}x${viewport.height}.png`,
     );
@@ -38,3 +86,23 @@ for (const viewport of desktopViewports) {
     await page.screenshot({ path: screenshotPath, animations: 'disabled' });
   });
 }
+
+test('moves through the desktop layout transition without inflating the activity cells', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 820, height: 720 });
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+  await expect(page.locator('[data-home-activity-dashboard]')).toBeVisible();
+
+  const stacked = await readHomepageFootprint(page);
+  expect(Math.abs(stacked.scoreboard.x - stacked.activityGrid.x)).toBeLessThan(2);
+  expect(stacked.activityGrid.y).toBeGreaterThan(stacked.scoreboard.bottom);
+
+  await page.setViewportSize({ width: 860, height: 720 });
+  const sideBySide = await readHomepageFootprint(page);
+  expect(sideBySide.activityGrid.x).toBeGreaterThan(sideBySide.scoreboard.right);
+  expect(Math.abs(sideBySide.scoreboard.y - sideBySide.activityGrid.y)).toBeLessThan(2);
+  expect(Math.abs(stacked.activityCell.width - sideBySide.activityCell.width)).toBeLessThan(6);
+  expect(sideBySide.document.width).toBeLessThanOrEqual(sideBySide.viewport.width);
+});

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const desktopViewports = [
+  { width: 1280, height: 720 },
+  { width: 1366, height: 768 },
+  { width: 1440, height: 900 },
+  { width: 1536, height: 864 },
+  { width: 1180, height: 720 },
+] as const;
+
+for (const viewport of desktopViewports) {
+  test(`captures homepage density baseline at ${viewport.width}x${viewport.height}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize(viewport);
+    const response = await page.goto('/');
+    expect(response?.ok()).toBe(true);
+
+    await expect(page.locator('[data-wind-scoreboard]')).toBeVisible();
+    await expect(page.locator('[aria-label="Four weeks of GitHub activity"]')).toBeVisible();
+
+    const overflow = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+
+    const screenshotPath = path.join(
+      'test-results',
+      'homepage-density',
+      'before',
+      testInfo.project.name,
+      `${viewport.width}x${viewport.height}.png`,
+    );
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, animations: 'disabled' });
+  });
+}

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -53,6 +53,12 @@ async function readHomepageFootprint(page: Page) {
   });
 }
 
+async function removeDevelopmentChrome(page: Page) {
+  await page.evaluate(() => {
+    document.querySelectorAll('nextjs-portal').forEach((portal) => portal.remove());
+  });
+}
+
 for (const viewport of desktopViewports) {
   test(`keeps the homepage instrument compact at ${viewport.width}x${viewport.height}`, async ({
     page,
@@ -75,6 +81,7 @@ for (const viewport of desktopViewports) {
     expect(footprint.activityCell.width).toBeLessThanOrEqual(56);
     expect(Math.abs(footprint.activityCell.width - footprint.activityCell.height)).toBeLessThan(1);
 
+    await removeDevelopmentChrome(page);
     const screenshotPath = path.join(
       'test-results',
       'homepage-density',


### PR DESCRIPTION
## Agent 1 lane

Implements #389 from `fix/issue-389-homepage-density`, based on `main` at `ca54db56b67553393aff5b1eee59d8fc927d179d`.

## What changed

- replace the `xl` snap with an intrinsic two-card threshold: each dashboard instrument keeps a 24rem minimum before stacking;
- move `7D` and `YTD` into a compact side rail so the split-flap display keeps presence without a wide empty lower band;
- add a shorter-height mode at 780px and below for scoreboard height, padding, and contribution-field width;
- cap contribution-cell growth at 25rem normally and 24rem on short desktops;
- tighten the recent-system cards and top-level rhythm so their heading and opening row stay in the first viewport.

## Screenshot evidence

Both archives contain Chromium and WebKit captures at 1180×720, 1280×720, 1366×768, 1440×900, and 1536×864.

- [Before screenshots — CI run #239](https://github.com/teamleaderleo/scrapbook/actions/runs/30211284742/artifacts/8634546517)
- [After screenshots — CI run #259](https://github.com/teamleaderleo/scrapbook/actions/runs/30211792312/artifacts/8634684189)

## Verification

CI run #259 passed lint, typecheck, unit tests, production build, and 72 Playwright checks across Chromium and WebKit. The density suite verifies fold position, zero horizontal overflow, bounded activity-cell size, and the 820×720 stacked → 860×720 side-by-side transition.

## Integration

Merged to `main` as `a34b907e6ba0ea679c3bba79b5a72966ae7253ed` after Agent 4 accepted the footprint contract. #383 and #384 should rebase onto this commit and preserve its dimensions.

Closes #389
Refs #383
Refs #384