### PR TITLE
Define the subdued material vocabulary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
           name: homepage-density-screenshots
           path: test-results/homepage-density
           if-no-files-found: ignore
+      - name: Upload material study screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: material-system-screenshots
+          path: test-results/material-system
+          if-no-files-found: ignore
       - name: Upload browser diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -47,25 +47,44 @@ Pause ambient and simulated motion while hidden. `prefers-reduced-motion` must l
 
 ## Materials have jobs
 
-### Machined metal
+Use material variation to explain the role of an object. Every recipe has light and dark tokens in `app/materials.css`; components consume them through `MaterialSurface` and the small details in `components/material/material-primitives.tsx`.
 
-Counters, hinges, calibrated controls, and status. Tight travel, restrained reflection, weighted settling.
+| Role | Use | Character | Keep plain when |
+| --- | --- | --- | --- |
+| Painted steel | Instrument housings, durable panels, calibrated frames | Low-contrast mottling, shallow bevel, hairline seam, sparse hardware | A normal content card carries no instrument meaning |
+| Phenolic plastic | Digit wells, bezels, compact controls, key-like objects | Warm near-black, tight inset shadow, slight moulded highlight | A large reading surface needs brighter contrast |
+| Smoked or frosted glass | Protected readouts, lenses, scrubber thumbs | Edge reflection and local tint; blur stays modest and optional | Translucency has no useful relationship to the layer behind it |
+| Slate | One small temporary datum, annotation, or status strip | Dry dark face, restrained chalk-like mark, minimal grain | Repeated metrics already have a clearer table or list |
+| Paper | Gallery provenance, field notes, tags, temporary annotations | Warm fibre, quiet ink, imperfect edge used sparingly | Dense application controls need predictable alignment |
+| Tape | Attachment cue for paper, prints, and provenance | Semi-opaque strip, slight skew, tiny lift shadow | The attachment is already obvious or the surface is interactive |
+| Restrained hardware | Screws, rivets, seams, engraved or stamped labels | Small and functional-looking; usually two or four details per object | Decoration would compete with content or imply a false control |
 
-### Rubber and keycaps
+### Reusable details
 
-High-frequency actions, grading controls, and shortcuts. One- or two-pixel compression with a quick release.
+- `InsetSeam` separates a faceplate from its housing without adding layout space.
+- `HardwareScrew` marks a panel corner; it never receives focus or pointer behaviour.
+- `GlassLens` adds a local reflection over a protected readout.
+- `EngravedLabel` belongs on durable housings and calibration marks.
+- `StampedLabel` belongs on temporary or inspected objects.
+- `PaperEdge` and `TapeStrip` support gallery and provenance objects.
 
-### Paper, tape, and card
+### Guardrails
 
-Gallery entrances, annotations, agent notes, provenance, and temporary-looking objects. Slight rotation, imperfect alignment, lifted corners.
+- Preserve WCAG text contrast on the final composited colour, including glass and texture layers.
+- Keep texture beneath reading level: it should appear through highlights or close inspection, then recede.
+- Use one dominant material and at most two supporting roles on an ordinary instrument.
+- Keep screws, seams, labels, and tape outside the reading and touch areas.
+- Let empty areas remain empty. Material depth never earns another metric.
+- Use CSS gradients and compact repeating marks; large texture images stay outside ordinary route bundles.
+- Give glass an opaque fallback. Honour reduced transparency, reduced motion, and forced-colour modes.
+- Avoid continuous pointer lighting. Any moving highlight must be frame-limited, optional, and visually quiet.
+- Preserve the dimensions owned by the component. A material pass may change paint and depth while leaving the tested footprint intact.
 
-### Smoked acrylic
+### Other tactile roles
 
-Depth and enclosure. Prefer tint and edge reflection over broad blur. Give text an opaque local backing whenever translucency lowers clarity.
+Rubber and keycaps serve high-frequency actions, grading controls, and shortcuts. Use one- or two-pixel compression with a quick release.
 
-### Jelly, gel, and slime
-
-Explicit playful surfaces and the tactile lab. Keep primary navigation, text, and predictable controls stable.
+Jelly, gel, and slime belong to explicit playful surfaces and the tactile lab. Keep primary navigation, text, and predictable controls stable.
 
 ## Loading and refreshes
 
@@ -126,4 +145,4 @@ Codenames, stickers, recurring motifs, and running conversations are welcome. Ea
 
 ## Historical memory
 
-Read `docs/interface-memory/2026-07-26-tactile-workshop.md` for the longer reasoning, material presets, physics candidates, implementation phases, and open questions that produced this guide.
+Read `docs/interface-memory/2026-07-26-tactile-workshop.md` for the longer reasoning, material presets, physics candidates, implementation phases, and open questions that produced this guide. The first bounded material vocabulary is recorded in `docs/interface-memory/2026-07-27-subdued-material-system.md`.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,6 @@
 import '@/app/globals.css';
+import '@/app/materials.css';
+import '@/app/materials-accessibility.css';
 import '@/app/navigation-feedback.css';
 import { inter } from '@/components/ui/assets/fonts';
 import type { Metadata, Viewport } from 'next';

--- a/app/materials-accessibility.css
+++ b/app/materials-accessibility.css
@@ -1,0 +1,6 @@
+@media (forced-colors: active) {
+  .material-glass-lens,
+  .material-inset-seam {
+    background: transparent;
+  }
+}

--- a/app/materials.css
+++ b/app/materials.css
@@ -1,0 +1,326 @@
+:root {
+  --material-steel-face: 38 7% 72%;
+  --material-steel-face-low: 40 7% 64%;
+  --material-steel-edge: 240 4% 30%;
+  --material-steel-highlight: 48 30% 97%;
+  --material-steel-shadow: 240 8% 14%;
+  --material-phenolic-face: 24 11% 17%;
+  --material-phenolic-face-low: 24 13% 11%;
+  --material-phenolic-edge: 28 9% 5%;
+  --material-phenolic-highlight: 34 14% 40%;
+  --material-glass-tint: 206 18% 82%;
+  --material-glass-edge: 206 15% 40%;
+  --material-glass-highlight: 0 0% 100%;
+  --material-slate-face: 156 7% 24%;
+  --material-slate-face-low: 158 8% 18%;
+  --material-slate-mark: 48 16% 91%;
+  --material-paper-face: 44 31% 91%;
+  --material-paper-edge: 36 18% 68%;
+  --material-paper-ink: 232 7% 18%;
+  --material-tape-face: 44 44% 79%;
+  --material-tape-edge: 34 22% 57%;
+  --material-hardware-face: 42 7% 58%;
+  --material-hardware-edge: 240 5% 24%;
+  --material-grain-opacity: 0.055;
+}
+
+.dark {
+  --material-steel-face: 230 5% 23%;
+  --material-steel-face-low: 230 6% 16%;
+  --material-steel-edge: 220 5% 7%;
+  --material-steel-highlight: 40 8% 72%;
+  --material-steel-shadow: 240 12% 2%;
+  --material-phenolic-face: 24 9% 13%;
+  --material-phenolic-face-low: 24 12% 7%;
+  --material-phenolic-edge: 24 8% 3%;
+  --material-phenolic-highlight: 30 10% 30%;
+  --material-glass-tint: 210 13% 22%;
+  --material-glass-edge: 210 11% 48%;
+  --material-glass-highlight: 40 8% 94%;
+  --material-slate-face: 160 7% 19%;
+  --material-slate-face-low: 160 8% 12%;
+  --material-slate-mark: 44 12% 86%;
+  --material-paper-face: 42 18% 78%;
+  --material-paper-edge: 34 14% 48%;
+  --material-paper-ink: 232 8% 14%;
+  --material-tape-face: 42 28% 62%;
+  --material-tape-edge: 34 18% 38%;
+  --material-hardware-face: 42 5% 42%;
+  --material-hardware-edge: 220 6% 8%;
+  --material-grain-opacity: 0.075;
+}
+
+.material-surface {
+  position: relative;
+  isolation: isolate;
+}
+
+.material-steel {
+  border-color: hsl(var(--material-steel-edge) / 0.44);
+  background-color: hsl(var(--material-steel-face));
+  background-image:
+    linear-gradient(
+      145deg,
+      hsl(var(--material-steel-highlight) / 0.2),
+      transparent 26%,
+      hsl(var(--material-steel-shadow) / 0.07) 72%,
+      hsl(var(--material-steel-shadow) / 0.13)
+    ),
+    radial-gradient(
+      circle at 30% 20%,
+      hsl(var(--material-steel-highlight) / var(--material-grain-opacity)) 0 0.55px,
+      transparent 0.8px
+    );
+  background-size: auto, 5px 5px;
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.28),
+    inset 0 -1px 0 hsl(var(--material-steel-shadow) / 0.16),
+    0 12px 28px hsl(var(--material-steel-shadow) / 0.14);
+}
+
+.material-phenolic {
+  border-color: hsl(var(--material-phenolic-edge) / 0.84);
+  background-color: hsl(var(--material-phenolic-face));
+  background-image:
+    radial-gradient(circle at 32% 18%, hsl(var(--material-phenolic-highlight) / 0.28), transparent 38%),
+    linear-gradient(
+      160deg,
+      hsl(var(--material-phenolic-highlight) / 0.13),
+      transparent 32%,
+      hsl(var(--material-phenolic-face-low) / 0.74)
+    );
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-phenolic-highlight) / 0.26),
+    inset 0 -10px 18px hsl(var(--material-phenolic-edge) / 0.34),
+    0 6px 15px hsl(var(--material-steel-shadow) / 0.18);
+}
+
+.material-glass {
+  border-color: hsl(var(--material-glass-edge) / 0.36);
+  background-color: hsl(var(--material-glass-tint) / 0.3);
+  background-image: linear-gradient(
+    132deg,
+    hsl(var(--material-glass-highlight) / 0.34),
+    transparent 24%,
+    transparent 68%,
+    hsl(var(--material-glass-edge) / 0.12)
+  );
+  -webkit-backdrop-filter: blur(8px) saturate(112%);
+  backdrop-filter: blur(8px) saturate(112%);
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-glass-highlight) / 0.44),
+    inset 0 -1px 0 hsl(var(--material-glass-edge) / 0.18);
+}
+
+.material-slate {
+  border-color: hsl(var(--material-slate-face-low) / 0.72);
+  background-color: hsl(var(--material-slate-face));
+  background-image:
+    linear-gradient(168deg, hsl(var(--material-slate-mark) / 0.055), transparent 34%),
+    radial-gradient(circle, hsl(var(--material-slate-mark) / 0.07) 0 0.5px, transparent 0.8px);
+  background-size: auto, 7px 7px;
+  color: hsl(var(--material-slate-mark));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-slate-mark) / 0.12),
+    inset 0 -5px 12px hsl(var(--material-slate-face-low) / 0.32);
+}
+
+.material-paper {
+  border-color: hsl(var(--material-paper-edge) / 0.6);
+  background-color: hsl(var(--material-paper-face));
+  background-image:
+    linear-gradient(90deg, hsl(var(--material-paper-edge) / 0.07) 1px, transparent 1px),
+    radial-gradient(circle, hsl(var(--material-paper-ink) / 0.045) 0 0.45px, transparent 0.75px);
+  background-size: 1.35rem 100%, 5px 5px;
+  color: hsl(var(--material-paper-ink));
+  box-shadow:
+    inset 0 1px 0 hsl(0 0% 100% / 0.46),
+    0 8px 18px hsl(var(--material-steel-shadow) / 0.12);
+}
+
+.material-tape {
+  border-color: hsl(var(--material-tape-edge) / 0.48);
+  background-color: hsl(var(--material-tape-face) / 0.88);
+  background-image:
+    linear-gradient(96deg, transparent, hsl(0 0% 100% / 0.16) 48%, transparent 54%),
+    repeating-linear-gradient(90deg, transparent 0 6px, hsl(var(--material-tape-edge) / 0.06) 6px 7px);
+  box-shadow:
+    inset 0 1px 0 hsl(0 0% 100% / 0.32),
+    0 2px 4px hsl(var(--material-steel-shadow) / 0.12);
+}
+
+.material-inset-seam {
+  position: absolute;
+  inset: 0.45rem;
+  z-index: 1;
+  border: 1px solid hsl(var(--material-steel-shadow) / 0.18);
+  border-radius: inherit;
+  box-shadow: 0 1px 0 hsl(var(--material-steel-highlight) / 0.17);
+  pointer-events: none;
+}
+
+.material-screw {
+  position: absolute;
+  z-index: 3;
+  width: 0.55rem;
+  height: 0.55rem;
+  border: 1px solid hsl(var(--material-hardware-edge) / 0.56);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 34% 28%, hsl(var(--material-steel-highlight) / 0.52), transparent 27%),
+    hsl(var(--material-hardware-face));
+  box-shadow:
+    inset 0 -1px 1px hsl(var(--material-hardware-edge) / 0.36),
+    0 1px 2px hsl(var(--material-steel-shadow) / 0.28);
+  pointer-events: none;
+}
+
+.material-screw::after {
+  content: '';
+  position: absolute;
+  inset: 50% 15% auto;
+  height: 1px;
+  background: hsl(var(--material-hardware-edge) / 0.72);
+  transform: translateY(-50%) rotate(-18deg);
+}
+
+.material-glass-lens {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  border: 1px solid hsl(var(--material-glass-edge) / 0.24);
+  border-radius: inherit;
+  background:
+    linear-gradient(118deg, hsl(var(--material-glass-highlight) / 0.2), transparent 21% 72%, hsl(var(--material-glass-edge) / 0.08)),
+    linear-gradient(180deg, transparent, hsl(var(--material-glass-tint) / 0.08));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-glass-highlight) / 0.34),
+    inset 0 -1px 0 hsl(var(--material-glass-edge) / 0.16);
+  pointer-events: none;
+}
+
+.material-label-engraved {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-shadow:
+    0 1px 0 hsl(var(--material-steel-highlight) / 0.26),
+    0 -1px 0 hsl(var(--material-steel-shadow) / 0.28);
+}
+
+.material-label-stamped {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid currentColor;
+  border-radius: 0.18rem;
+  padding: 0.12rem 0.3rem 0.08rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.68em;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  line-height: 1;
+  text-transform: uppercase;
+  transform: rotate(-0.45deg);
+}
+
+.material-paper-edge {
+  position: absolute;
+  inset: auto 0 -1px;
+  height: 0.35rem;
+  background: linear-gradient(
+    135deg,
+    transparent 0 20%,
+    hsl(var(--material-paper-edge) / 0.32) 21% 42%,
+    transparent 43% 64%,
+    hsl(var(--material-paper-edge) / 0.24) 65% 82%,
+    transparent 83%
+  );
+  background-size: 1.1rem 100%;
+  opacity: 0.64;
+  pointer-events: none;
+}
+
+.material-tape-strip {
+  position: absolute;
+  z-index: 4;
+  width: 3.25rem;
+  height: 0.95rem;
+  border: 1px solid hsl(var(--material-tape-edge) / 0.34);
+  background:
+    linear-gradient(96deg, transparent, hsl(0 0% 100% / 0.18) 48%, transparent 54%),
+    hsl(var(--material-tape-face) / 0.86);
+  box-shadow: 0 2px 4px hsl(var(--material-steel-shadow) / 0.1);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.material-tape-strip[data-side='top'] {
+  top: -0.45rem;
+  left: 50%;
+  transform: translateX(-50%) rotate(-1deg);
+}
+
+.material-tape-strip[data-side='right'] {
+  top: 50%;
+  right: -1.15rem;
+  transform: translateY(-50%) rotate(91deg);
+}
+
+.material-tape-strip[data-side='bottom'] {
+  bottom: -0.45rem;
+  left: 50%;
+  transform: translateX(-50%) rotate(0.75deg);
+}
+
+.material-tape-strip[data-side='left'] {
+  top: 50%;
+  left: -1.15rem;
+  transform: translateY(-50%) rotate(89deg);
+}
+
+@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .material-glass {
+    background-color: hsl(var(--material-glass-tint) / 0.82);
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .material-glass {
+    background-color: hsl(var(--material-glass-tint) / 0.94);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .material-surface,
+  .material-tape-strip,
+  .material-label-stamped {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}
+
+@media (forced-colors: active) {
+  .material-surface,
+  .material-steel,
+  .material-phenolic,
+  .material-glass,
+  .material-slate,
+  .material-paper,
+  .material-tape {
+    border: 1px solid CanvasText;
+    background: Canvas;
+    box-shadow: none;
+    color: CanvasText;
+  }
+
+  .material-screw,
+  .material-glass-lens,
+  .material-inset-seam,
+  .material-tape-strip {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+  }
+}

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,5 +1,12 @@
 'use client';
 
+import {
+  EngravedLabel,
+  GlassLens,
+  HardwareScrew,
+  InsetSeam,
+  MaterialSurface,
+} from '@/components/material/material-primitives';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -57,7 +64,7 @@ function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
           <motion.span
             key={`depart-${sequence}`}
             aria-hidden="true"
-            className="absolute inset-x-0 top-0 z-20 h-1/2 origin-bottom overflow-hidden bg-[#1b1c20] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-8px_12px_rgba(0,0,0,0.2)] [backface-visibility:hidden] [transform-style:preserve-3d]"
+            className="absolute inset-x-0 top-0 z-20 h-1/2 origin-bottom overflow-hidden bg-[hsl(var(--material-phenolic-face))] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-8px_12px_rgba(0,0,0,0.2)] [backface-visibility:hidden] [transform-style:preserve-3d]"
             initial={{ rotateX: 0 }}
             animate={{ rotateX: -90 }}
             transition={{ duration: 0.22, delay: stagger, ease: [0.55, 0.06, 0.68, 0.19] }}
@@ -69,7 +76,7 @@ function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
           <motion.span
             key={`arrive-${sequence}`}
             aria-hidden="true"
-            className="absolute inset-x-0 bottom-0 z-30 h-1/2 origin-top overflow-hidden bg-[#15161a] shadow-[inset_0_8px_12px_rgba(0,0,0,0.34)] [backface-visibility:hidden] [transform-style:preserve-3d]"
+            className="absolute inset-x-0 bottom-0 z-30 h-1/2 origin-top overflow-hidden bg-[hsl(var(--material-phenolic-face-low))] shadow-[inset_0_8px_12px_rgba(0,0,0,0.34)] [backface-visibility:hidden] [transform-style:preserve-3d]"
             initial={{ rotateX: 90 }}
             animate={{ rotateX: 0 }}
             transition={{ duration: 0.28, delay: stagger + 0.19, ease: [0.22, 1, 0.36, 1] }}
@@ -83,9 +90,18 @@ function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
       ) : null}
 
       <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px bg-black/80" />
-      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px -translate-y-px bg-white/[0.05]" />
-      <span aria-hidden="true" className="absolute left-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]" />
-      <span aria-hidden="true" className="absolute right-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]" />
+      <span
+        aria-hidden="true"
+        className="absolute inset-x-0 top-1/2 z-40 h-px -translate-y-px bg-white/[0.05]"
+      />
+      <span
+        aria-hidden="true"
+        className="absolute left-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]"
+      />
+      <span
+        aria-hidden="true"
+        className="absolute right-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]"
+      />
     </span>
   );
 }
@@ -203,10 +219,12 @@ function ScoreDigits({ value }: { value: number }) {
             digitRefs.current[index] = element;
           }}
           data-activity-digit
-          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_7px_18px_rgba(0,0,0,0.2)] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
+          data-material="phenolic"
+          className="material-surface material-phenolic relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border px-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none text-[#f3f0e9] transition-[filter,box-shadow] duration-150 [transform-style:preserve-3d] will-change-transform motion-reduce:transform-none"
           style={{ transform: IDLE_TRANSFORM }}
         >
           <SplitFlapDigit digit={digit} index={index} />
+          <GlassLens />
         </div>
       ))}
     </div>
@@ -215,17 +233,19 @@ function ScoreDigits({ value }: { value: number }) {
 
 function Metric({ label, value, title }: { label: string; value: string; title?: string }) {
   return (
-    <span
-      className="grid min-h-[3.75rem] content-center gap-1 rounded-xl border border-border/65 bg-background/40 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)]"
+    <MaterialSurface
+      as="span"
+      material="slate"
+      className="grid min-h-[3.75rem] content-center gap-1 rounded-xl border px-2.5 py-2"
       title={title}
     >
-      <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+      <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-[hsl(var(--material-slate-mark)/0.7)]">
         {label}
       </span>
-      <strong className="font-mono text-base font-semibold leading-none tabular-nums text-foreground sm:text-lg">
+      <strong className="font-mono text-base font-semibold leading-none tabular-nums sm:text-lg">
         {value}
       </strong>
-    </span>
+    </MaterialSurface>
   );
 }
 
@@ -248,18 +268,27 @@ export function ActivityScoreboard({
   }, []);
 
   return (
-    <section
-      className="group/score flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[transform,box-shadow] duration-300 hover:-translate-y-0.5 hover:shadow-[0_22px_44px_rgba(24,24,26,0.16)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_24px_48px_rgba(0,0,0,0.42)] [@media(max-height:780px)]:min-h-[14.5rem]"
+    <MaterialSurface
+      as="section"
+      material="steel"
+      className="group/score flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border text-card-foreground transition-transform duration-300 hover:-translate-y-0.5 motion-reduce:transition-none motion-reduce:hover:translate-y-0 [@media(max-height:780px)]:min-h-[14.5rem]"
       data-activity-scoreboard
+      data-material-exemplar="scoreboard"
     >
-      <div className="border-b border-border/70 bg-muted/70 px-4 py-2.5 [@media(max-height:780px)]:py-2">
-        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          <span>Today</span>
-          <span className="tabular-nums">UTC reset {countdown}</span>
+      <InsetSeam />
+      <HardwareScrew className="left-1 top-1" />
+      <HardwareScrew className="right-1 top-1" />
+      <HardwareScrew className="bottom-1 left-1" />
+      <HardwareScrew className="bottom-1 right-1" />
+
+      <div className="relative z-[2] border-b border-[hsl(var(--material-steel-edge)/0.28)] bg-black/[0.045] px-4 py-2.5 dark:bg-black/10 [@media(max-height:780px)]:py-2">
+        <div className="flex items-center justify-between gap-3 text-[9px] font-semibold text-foreground/70">
+          <EngravedLabel>Today</EngravedLabel>
+          <EngravedLabel className="tabular-nums">UTC reset {countdown}</EngravedLabel>
         </div>
       </div>
 
-      <div className="grid flex-1 grid-cols-[minmax(0,1fr)_minmax(5.5rem,0.34fr)] items-center gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(6.25rem,0.32fr)] sm:gap-4 sm:p-5 [@media(max-height:780px)]:gap-2.5 [@media(max-height:780px)]:p-3.5">
+      <div className="relative z-[2] grid flex-1 grid-cols-[minmax(0,1fr)_minmax(5.5rem,0.34fr)] items-center gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(6.25rem,0.32fr)] sm:gap-4 sm:p-5 [@media(max-height:780px)]:gap-2.5 [@media(max-height:780px)]:p-3.5">
         <ScoreDigits value={today} />
         <div className="grid content-center gap-2">
           <Metric label="7D" value={weekTotal.toLocaleString('en-GB')} />
@@ -270,6 +299,6 @@ export function ActivityScoreboard({
           />
         </div>
       </div>
-    </section>
+    </MaterialSurface>
   );
 }

--- a/components/material/material-primitives.tsx
+++ b/components/material/material-primitives.tsx
@@ -1,0 +1,89 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type MaterialRole =
+  | 'steel'
+  | 'phenolic'
+  | 'glass'
+  | 'slate'
+  | 'paper'
+  | 'tape';
+
+type MaterialElement = 'div' | 'section' | 'aside' | 'header' | 'span';
+
+type MaterialSurfaceProps = HTMLAttributes<HTMLElement> & {
+  as?: MaterialElement;
+  material: MaterialRole;
+  children?: ReactNode;
+};
+
+export function MaterialSurface({
+  as: Component = 'div',
+  material,
+  className,
+  children,
+  ...props
+}: MaterialSurfaceProps) {
+  return (
+    <Component
+      data-material={material}
+      className={cn('material-surface', `material-${material}`, className)}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}
+
+export function InsetSeam({ className }: { className?: string }) {
+  return <span aria-hidden="true" className={cn('material-inset-seam', className)} />;
+}
+
+export function HardwareScrew({ className }: { className?: string }) {
+  return <span aria-hidden="true" className={cn('material-screw', className)} />;
+}
+
+export function GlassLens({ className }: { className?: string }) {
+  return <i aria-hidden="true" className={cn('material-glass-lens', className)} />;
+}
+
+export function EngravedLabel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <span className={cn('material-label-engraved', className)}>{children}</span>;
+}
+
+export function StampedLabel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return <span className={cn('material-label-stamped', className)}>{children}</span>;
+}
+
+export function PaperEdge({ className }: { className?: string }) {
+  return <span aria-hidden="true" className={cn('material-paper-edge', className)} />;
+}
+
+export function TapeStrip({
+  className,
+  side = 'top',
+}: {
+  className?: string;
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      data-side={side}
+      className={cn('material-tape-strip', className)}
+    />
+  );
+}

--- a/docs/interface-memory/2026-07-27-subdued-material-system.md
+++ b/docs/interface-memory/2026-07-27-subdued-material-system.md
@@ -1,0 +1,131 @@
+# Subdued material vocabulary — 2026-07-27
+
+Issue: #384  
+Lane: Agent 4 — material vocabulary and scoreboard study  
+Base: `main` at `ca54db56b67553393aff5b1eee59d8fc927d179d`
+
+## Intent
+
+Scrapbook should read as a cabinet of distinct working objects. Material cues carry role and atmosphere while typography, spacing, interaction, and responsive behaviour remain familiar.
+
+The target is a quiet form of skeuomorphism:
+
+- recognisable materials without photoreal imitation;
+- depth concentrated around edges, seams, and protected readouts;
+- texture visible through close inspection and highlight, then absent from ordinary reading;
+- decorative hardware used as punctuation;
+- CSS-only recipes on ordinary routes.
+
+## Material map
+
+### Painted steel
+
+Use for durable housings and instrument faceplates. The recipe combines a low-contrast diagonal value shift, tiny repeating grain, an upper highlight, a lower inset shadow, and a modest cast shadow.
+
+Light mode uses warm grey steel. Dark mode uses charcoal steel. Neither expression becomes chrome.
+
+### Phenolic plastic
+
+Use for digit wells, bezels, compact controls, and key-like objects. The surface stays warm near-black with a slight moulded highlight and deep inset edge.
+
+The role carries density and grip. It should remain local rather than becoming a page background.
+
+### Smoked or frosted glass
+
+Use for lenses, protected readouts, and translucent handles. The cue comes from edge reflection and local tint. Backdrop blur remains modest and has an opaque fallback.
+
+Glass belongs where the layer beneath it contributes meaning. It should never become the default card treatment.
+
+### Slate
+
+Use for one temporary datum, annotation, or status strip. Grain stays dry and quiet. The text uses a warm chalk-like colour with ordinary contrast requirements.
+
+Slate should be rare enough that it reads as an annotation surface.
+
+### Paper
+
+Use for provenance, gallery notes, field records, and temporary objects. Warm fibre, a tiny repeating speckle, and an optional imperfect edge provide the cue.
+
+Paper may rotate or overlap in the gallery. Application controls remain aligned and predictable.
+
+### Tape
+
+Use to explain attachment. A tape strip is semi-opaque, slightly skewed, and visually passive. It never covers controls, focus rings, or critical text.
+
+### Restrained hardware
+
+Use a sparse vocabulary of screws, inset seams, engraved labels, stamped labels, paper edges, and tape strips. These details support object identity. They carry no pointer behaviour and consume no layout space.
+
+## Token strategy
+
+`app/materials.css` owns the light and dark variables for face, low face, edge, highlight, shadow, ink, mark, hardware, and grain opacity. Recipes use HSL channels so theme expressions can change without rewriting every gradient.
+
+`components/material/material-primitives.tsx` exposes:
+
+- `MaterialSurface`;
+- `InsetSeam`;
+- `HardwareScrew`;
+- `GlassLens`;
+- `EngravedLabel`;
+- `StampedLabel`;
+- `PaperEdge`;
+- `TapeStrip`.
+
+The primitive layer stays visually thin. Component authors choose semantic elements and retain ownership of dimensions, layout, and interaction.
+
+## Accessibility and fallback rules
+
+- Text contrast is judged after all tint and texture layers are composited.
+- Glass becomes locally opaque when backdrop filtering is unavailable.
+- `prefers-reduced-transparency` removes blur and raises local opacity.
+- `prefers-reduced-motion` removes decorative transition duration.
+- Forced-colour mode collapses recipes to `Canvas` and `CanvasText` with explicit borders.
+- Hardware and texture remain pointer-transparent.
+- The material layer introduces no continuous animation or pointer-tracking loop.
+
+## Scoreboard exemplar plan
+
+The homepage scoreboard is the first complete application after #389 fixes its tested footprint.
+
+Paint-only mapping:
+
+- outer housing: painted steel;
+- corner details: four small screws, positioned inside the existing border box;
+- header labels: engraved treatment;
+- digit wells: phenolic plastic;
+- protected digit faces: local glass lenses;
+- secondary values: one slate annotation area or restrained inset readouts;
+- seams: one inset faceplate seam;
+- motion: existing split-flap motion retained, with no new continuous lighting effect.
+
+The material pass must preserve the settled min-height, padding, grid, digit clamp, breakpoint, and touch target contract from #389.
+
+## Restraint decisions
+
+Several surfaces stay plain by design:
+
+- page background and ordinary content cards;
+- the contribution field until its later geometry lane settles;
+- navigation and routine buttons;
+- long scrolling lists;
+- body copy and metadata rows;
+- empty areas inside the scoreboard.
+
+The exemplar receives one dominant steel role, phenolic and glass readouts, and a small slate secondary role. Paper and tape remain available to the gallery rather than appearing on the scoreboard.
+
+## Evidence matrix
+
+The exemplar review should capture these four cases at 100% browser zoom:
+
+| Theme | Viewport | Required checks |
+| --- | --- | --- |
+| Light | Mobile, 390×844 | Contrast, touch behaviour, zero horizontal overflow |
+| Dark | Mobile, 390×844 | Digit legibility, glass fallback, compact footprint |
+| Light | Desktop, 1366×768 | Above-the-fold relationship with contribution field and recent systems |
+| Dark | Desktop, 1440×900 | Depth hierarchy, restrained grain, focus visibility |
+
+Also exercise reduced motion, reduced transparency, and forced-colour fallbacks. Compare route bundle output before and after; this slice adds CSS and TypeScript only, with zero raster texture assets.
+
+## Open coordination
+
+Agent 1 / #389 owns dimensions and short-viewport behaviour. Agent 4 reviews that density work before transplanting the paint-only exemplar. Agent 1 performs the final homepage reconciliation. The material PR remains draft and unmerged throughout that exchange.

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const studies = [
+  { theme: 'light', width: 390, height: 844 },
+  { theme: 'dark', width: 390, height: 844 },
+  { theme: 'light', width: 1366, height: 768 },
+  { theme: 'dark', width: 1440, height: 900 },
+] as const;
+
+for (const study of studies) {
+  test(`captures ${study.theme} scoreboard material study at ${study.width}x${study.height}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: study.width, height: study.height });
+    await page.addInitScript((theme) => {
+      window.localStorage.setItem('theme', theme);
+    }, study.theme);
+
+    const response = await page.goto('/');
+    expect(response?.ok()).toBe(true);
+
+    const root = page.locator('html');
+    if (study.theme === 'dark') {
+      await expect(root).toHaveClass(/dark/);
+    } else {
+      await expect(root).toHaveClass(/light/);
+    }
+
+    const scoreboard = page.locator('[data-material-exemplar="scoreboard"]');
+    await expect(scoreboard).toBeVisible();
+    await expect(scoreboard).toHaveAttribute('data-material', 'steel');
+    await expect(scoreboard.locator('[data-material="phenolic"]')).toHaveCount(4);
+    await expect(scoreboard.locator('[data-material="slate"]')).toHaveCount(2);
+
+    const digits = scoreboard.locator('[data-activity-digit]');
+    const lens = digits.first().locator('.material-glass-lens');
+    await expect(digits.first()).toBeVisible();
+    await expect(lens).toHaveCSS('pointer-events', 'none');
+
+    const overflow = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+
+    const readWidth = () =>
+      scoreboard.evaluate((element) => element.getBoundingClientRect().width);
+    const readHeight = () =>
+      scoreboard.evaluate((element) => element.getBoundingClientRect().height);
+    await expect.poll(readWidth).toBeGreaterThan(0);
+    await expect.poll(readWidth).toBeLessThanOrEqual(study.width);
+    await expect
+      .poll(readHeight)
+      .toBeGreaterThanOrEqual(study.height <= 780 ? 232 : 248);
+
+    const screenshotPath = path.join(
+      'test-results',
+      'material-system',
+      study.theme,
+      testInfo.project.name,
+      `${study.width}x${study.height}.png`,
+    );
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, animations: 'disabled' });
+  });
+}
+
+test('keeps the material exemplar calm with reduced motion', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    window.localStorage.setItem('theme', 'system');
+  });
+  await page.goto('/');
+
+  const scoreboard = page.locator('[data-material-exemplar="scoreboard"]');
+  const digit = scoreboard.locator('[data-activity-digit]').first();
+  await expect(digit).toBeVisible();
+  const before = await digit.evaluate((element) => element.style.transform);
+  await digit.hover();
+  const after = await digit.evaluate((element) => element.style.transform);
+  const transitionDurationMs = await scoreboard.evaluate((element) => {
+    const value = window.getComputedStyle(element).transitionDuration.split(',')[0] ?? '0s';
+    return value.endsWith('ms') ? Number.parseFloat(value) : Number.parseFloat(value) * 1_000;
+  });
+
+  expect(after).toBe(before);
+  expect(transitionDurationMs).toBeLessThanOrEqual(0.02);
+});
+
+test('keeps split-flap digits readable in forced colours', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Forced-colour emulation is checked in Chromium.');
+
+  await page.emulateMedia({ forcedColors: 'active' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const digit = page.locator('[data-activity-digit]').first();
+  const lens = digit.locator('.material-glass-lens');
+  await expect(digit).toBeVisible();
+  const lensAlpha = await lens.evaluate((element) => {
+    const background = window.getComputedStyle(element).backgroundColor;
+    const match = background.match(/rgba\([^,]+,[^,]+,[^,]+,\s*([\d.]+)\)/);
+    return match ? Number.parseFloat(match[1]) : 1;
+  });
+  expect(lensAlpha).toBe(0);
+  await expect(lens).toHaveCSS('pointer-events', 'none');
+});


### PR DESCRIPTION
Closes #384

## Result

Defines the shared restrained material vocabulary and applies it to the homepage scoreboard as the first complete exemplar.

The branch is rebased onto current `main` at `7522c96dbaa8a16dc18c4bea905508ff495f7659`, including the merged compact homepage from #392 and corrected time picker from #397.

## Included

- light/dark CSS tokens and compact recipes for painted steel, phenolic plastic, smoked/frosted glass, slate, paper, tape, and restrained hardware;
- reusable `MaterialSurface`, inset seam, screw, glass lens, engraved label, stamped label, paper edge, and tape strip primitives;
- concise material map and restraint guardrails in `DESIGN.md`;
- dated study at `docs/interface-memory/2026-07-27-subdued-material-system.md`;
- steel scoreboard housing with inset seam and restrained screws;
- phenolic split-flap wells behind local glass lenses;
- engraved header labels and compact slate metric readouts;
- zero raster texture assets, package changes, or runtime dependencies.

## Preserved homepage contract

The rebased scoreboard retains every #392 footprint and test hook:

- `min-h-[15.5rem]`;
- `14.5rem` at viewport heights up to 780px;
- `clamp(2rem, 5vw, 4.25rem)` digits;
- the compact side metric rail;
- existing grid proportions, gaps, padding, pointer behaviour, and data attributes;
- the five named short-desktop fold checks and 820→860 px responsive transition.

`app/page.tsx`, `components/home/activity-dashboard.tsx`, and the contribution field remain outside the material lane.

## Accessibility and fallbacks

- reduced motion removes decorative transition duration and pointer lift;
- reduced transparency raises glass opacity and removes blur;
- missing backdrop-filter support receives an opaque glass fallback;
- forced-colour mode uses system colours while glass and seam overlays remain transparent;
- decorative details remain pointer-transparent;
- focus and touch behaviour remain owned by the existing controls.

## Rebased validation

Head: `672613fafe76674a667e286b0dc61a3d3e8ad649`

[CI run 290](https://github.com/teamleaderleo/scrapbook/actions/runs/30215025301) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- **98 passed, two intentional skips, zero retries or flakes**.

Retained evidence:

- homepage density screenshots: `sha256:fe8c8bf938147c873c9a00b0b66d15817ce2865766f267439ae95a2eb8f1ce4d`;
- material screenshots: `sha256:2930d05045c320b1b0ab8204b56c8ee1c9db2c4c68b47093c51d9590245775e5`;
- Playwright log: `sha256:c911cd96e54860f65f867e667cc9a3fe698a67c01de590e1d336935a3db6e07a`.

The material set includes light/dark mobile and desktop captures across both engines. Visual review confirms the compact fold and leaves ordinary cards, navigation, page backgrounds, contribution geometry, and empty space plain.

## Reviews

- Agent 4 self-reviewed material restraint, accessibility fallbacks, DOM compatibility, route cost, and evidence reliability;
- Agent 1 reviewed the homepage footprint and requested the current-main rebase plus combined density/material run;
- the rebased head satisfies that integration fence.