### PR TITLE
Rework the mobile time picker around the keyboard

### DIFF
--- a/components/current-time-display.tsx
+++ b/components/current-time-display.tsx
@@ -25,12 +25,10 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
         const offsetMinutes = -now.getTimezoneOffset();
         const offsetHours = Math.floor(Math.abs(offsetMinutes) / 60);
         const offsetMins = Math.abs(offsetMinutes) % 60;
-        const sign = offsetMinutes >= 0 ? '+' : '-';
-        const offsetStr =
-          offsetMins === 0
-            ? `UTC${sign}${offsetHours}`
-            : `UTC${sign}${offsetHours}:${String(offsetMins).padStart(2, '0')}`;
-        setUtcOffset(offsetStr);
+        const sign = offsetMinutes >= 0 ? '+' : '−';
+        setUtcOffset(
+          `UTC${sign}${String(offsetHours).padStart(2, '0')}:${String(offsetMins).padStart(2, '0')}`,
+        );
 
         const dstInfo = detectCurrentTimezoneDST();
         setIsDST(dstInfo.isDSTActive);
@@ -65,21 +63,25 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
         <button
           type="button"
           onClick={() => onJumpToTime(currentTime)}
-          className="cursor-pointer rounded-xl border border-border/65 bg-background/42 px-2.5 py-1 text-3xl font-semibold tabular-nums shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_7px_18px_rgba(20,20,24,0.08)] backdrop-blur-xl transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_10px_22px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="cursor-pointer rounded-xl border border-border/65 bg-background/42 px-2.5 py-1 font-mono text-3xl font-semibold tabular-nums shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_7px_18px_rgba(20,20,24,0.08)] backdrop-blur-xl transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_10px_22px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           title="Jump the scrubber to the current time"
         >
           {formatTime(currentTime)}
         </button>
       </div>
-      <p className="text-sm text-muted-foreground">
-        <span className="relative inline-block">
-          {userTimezone} ({utcOffset})
-          {isDST ? (
-            <span className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded bg-amber-500/20 px-1 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
-              DST
-            </span>
-          ) : null}
-        </span>
+      <p className="flex flex-wrap items-center gap-1.5 font-mono text-xs tabular-nums text-muted-foreground">
+        <span>{userTimezone || 'Local zone'}</span>
+        {utcOffset ? (
+          <>
+            <span aria-hidden="true">·</span>
+            <span>{utcOffset}</span>
+          </>
+        ) : null}
+        {isDST ? (
+          <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-sans text-[9px] font-semibold text-amber-700 dark:text-amber-400">
+            DST
+          </span>
+        ) : null}
       </p>
     </div>
   );

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -8,6 +8,15 @@ import { isDSTActive } from '@/app/lib/dst-utils';
 const DAY_GRADIENT =
   'linear-gradient(90deg, #151720 0%, #252938 9%, #493f55 18%, #715767 28%, #9f6f68 38%, #bd916c 46%, #c9a574 50%, #bd916c 56%, #9f6f68 64%, #715767 73%, #493f55 82%, #252938 91%, #151720 100%)';
 
+function formatOffset(offsetMinutes: number) {
+  if (offsetMinutes === 0) return 'UTC±00:00';
+
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  const hours = Math.floor(absoluteMinutes / 60);
+  const minutes = absoluteMinutes % 60;
+  return `UTC${offsetMinutes >= 0 ? '+' : '−'}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
 export default function UTCTimeVisualizer() {
   const [localTime, setLocalTime] = useState(0);
   const [localOffsetMinutes, setLocalOffsetMinutes] = useState(0);
@@ -49,11 +58,15 @@ export default function UTCTimeVisualizer() {
             : 'Night';
 
   return (
-    <div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-6xl items-center px-4 py-6 sm:px-6 sm:py-8 lg:px-8">
-      <div className="w-full rounded-[1.5rem] border border-border/70 bg-card/92 p-5 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] backdrop-blur-xl dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
+    <div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-6xl items-start px-4 py-4 sm:px-6 sm:py-8 lg:px-8">
+      <div className="w-full rounded-[1.5rem] border border-border/70 bg-card/92 p-4 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] backdrop-blur-xl dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
         <CurrentTimeDisplay onJumpToTime={setLocalTime} />
 
-        <div className="mt-7">
+        <div className="mt-5 sm:mt-7">
+          <TimezoneSelector utcHours={utcHours} utcMinutes={utcMinutes} />
+        </div>
+
+        <div className="mt-6 sm:mt-7">
           <div className="mb-3 flex items-center justify-between gap-3">
             <label
               htmlFor="time-of-day"
@@ -78,7 +91,7 @@ export default function UTCTimeVisualizer() {
             className="time-day-slider h-14 w-full cursor-pointer rounded-full"
             style={{ background: DAY_GRADIENT }}
           />
-          <div className="mt-2 flex justify-between font-mono text-[10px] text-muted-foreground">
+          <div className="mt-2 flex justify-between font-mono text-[10px] tabular-nums text-muted-foreground">
             <span>00:00</span>
             <span>06:00</span>
             <span>12:00</span>
@@ -87,41 +100,56 @@ export default function UTCTimeVisualizer() {
           </div>
         </div>
 
-        <div className="mt-7 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)]">
-          <div className="rounded-xl border border-border/65 bg-background/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md">
-            <div className="flex items-end gap-3">
-              <p className="font-mono text-5xl font-semibold tabular-nums tracking-[-0.05em] sm:text-6xl">
-                {formatTime(localHours, localMinutes)}
-              </p>
-              <p className="pb-1 text-xl text-muted-foreground">
-                {formatTime12Hour(localHours, localMinutes)} {period}
-              </p>
-            </div>
-            <p className="mt-2 text-sm text-muted-foreground">Selected local time</p>
+        <section
+          aria-label="Time comparisons"
+          className="mt-6 grid grid-cols-2 gap-3 sm:mt-7 sm:grid-cols-4"
+        >
+          <div className="col-span-2 rounded-xl border border-border/65 bg-background/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md sm:col-span-1">
+            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
+              Local
+            </p>
+            <p className="mt-1 font-mono text-3xl font-semibold tabular-nums tracking-[-0.03em]">
+              {formatTime(localHours, localMinutes)}
+            </p>
+            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
+              {formatTime12Hour(localHours, localMinutes)} {period} ·{' '}
+              {formatOffset(localOffsetMinutes)}
+            </p>
           </div>
-
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">UTC</p>
-              <p className="mt-1 text-2xl font-semibold tabular-nums">{formatTime(utcHours, utcMinutes)}</p>
-            </div>
-            <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Eastern</p>
-              <p className="mt-1 text-2xl font-semibold tabular-nums">
-                {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
-              </p>
-            </div>
-            <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-              <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Pacific</p>
-              <p className="mt-1 text-2xl font-semibold tabular-nums">
-                {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
-              </p>
-            </div>
-            <div className="col-span-2 sm:col-span-3">
-              <TimezoneSelector utcHours={utcHours} utcMinutes={utcMinutes} />
-            </div>
+          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
+            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
+              UTC
+            </p>
+            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
+              {formatTime(utcHours, utcMinutes)}
+            </p>
+            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
+              UTC±00:00
+            </p>
           </div>
-        </div>
+          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
+            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
+              Eastern
+            </p>
+            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
+              {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
+            </p>
+            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
+              {formatOffset(easternOffset * 60)}
+            </p>
+          </div>
+          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
+            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
+              Pacific
+            </p>
+            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
+              {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
+            </p>
+            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
+              {formatOffset(pacificOffset * 60)}
+            </p>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/components/timezone-selector.tsx
+++ b/components/timezone-selector.tsx
@@ -1,6 +1,15 @@
-import { useState } from 'react';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Search } from 'lucide-react';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
 import { isDSTActive } from '@/app/lib/dst-utils';
 
 interface TimezoneSelectorProps {
@@ -9,43 +18,239 @@ interface TimezoneSelectorProps {
 }
 
 type TimezoneOption = {
+  id: string;
   offset: number;
   label: string;
+  abbreviation: string;
   dst: boolean;
   region: string | null;
 };
 
+const UTC_OPTION: TimezoneOption = {
+  id: 'utc',
+  offset: 0,
+  label: 'Coordinated Universal Time',
+  abbreviation: 'UTC',
+  dst: false,
+  region: null,
+};
+
 const TIMEZONE_OPTIONS: TimezoneOption[] = [
-  { offset: -12, label: 'Baker Island', dst: false, region: null },
-  { offset: -11, label: 'American Samoa', dst: false, region: null },
-  { offset: -10, label: 'Hawaii', dst: false, region: null },
-  { offset: -9, label: 'Alaska', dst: true, region: 'us' },
-  { offset: -8, label: 'Pacific Time', dst: true, region: 'us' },
-  { offset: -7, label: 'Mountain Time', dst: true, region: 'us' },
-  { offset: -6, label: 'Central Time', dst: true, region: 'us' },
-  { offset: -5, label: 'Eastern Time', dst: true, region: 'us' },
-  { offset: -4, label: 'Atlantic Time', dst: true, region: 'us' },
-  { offset: -3, label: 'Buenos Aires', dst: false, region: null },
-  { offset: -2, label: 'Mid-Atlantic', dst: false, region: null },
-  { offset: -1, label: 'Azores', dst: true, region: 'eu' },
-  { offset: 0, label: 'UTC/London', dst: true, region: 'eu' },
-  { offset: 1, label: 'Central European', dst: true, region: 'eu' },
-  { offset: 2, label: 'Eastern European', dst: true, region: 'eu' },
-  { offset: 3, label: 'Moscow', dst: false, region: null },
-  { offset: 4, label: 'Dubai', dst: false, region: null },
-  { offset: 5, label: 'Pakistan', dst: false, region: null },
-  { offset: 5.5, label: 'India', dst: false, region: null },
-  { offset: 6, label: 'Bangladesh', dst: false, region: null },
-  { offset: 7, label: 'Bangkok', dst: false, region: null },
-  { offset: 8, label: 'Singapore', dst: false, region: null },
-  { offset: 9, label: 'Tokyo', dst: false, region: null },
-  { offset: 10, label: 'Sydney', dst: true, region: 'aus' },
-  { offset: 11, label: 'Solomon Islands', dst: false, region: null },
-  { offset: 12, label: 'New Zealand', dst: true, region: 'nz' },
+  {
+    id: 'baker',
+    offset: -12,
+    label: 'Baker Island',
+    abbreviation: 'BIT',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'samoa',
+    offset: -11,
+    label: 'American Samoa',
+    abbreviation: 'SST',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'hawaii',
+    offset: -10,
+    label: 'Hawaii',
+    abbreviation: 'HST',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'alaska',
+    offset: -9,
+    label: 'Alaska',
+    abbreviation: 'AKT',
+    dst: true,
+    region: 'us',
+  },
+  {
+    id: 'pacific',
+    offset: -8,
+    label: 'Pacific Time',
+    abbreviation: 'PT',
+    dst: true,
+    region: 'us',
+  },
+  {
+    id: 'mountain',
+    offset: -7,
+    label: 'Mountain Time',
+    abbreviation: 'MT',
+    dst: true,
+    region: 'us',
+  },
+  {
+    id: 'central',
+    offset: -6,
+    label: 'Central Time',
+    abbreviation: 'CT',
+    dst: true,
+    region: 'us',
+  },
+  {
+    id: 'eastern',
+    offset: -5,
+    label: 'Eastern Time',
+    abbreviation: 'ET',
+    dst: true,
+    region: 'us',
+  },
+  {
+    id: 'atlantic',
+    offset: -4,
+    label: 'Atlantic Time',
+    abbreviation: 'AT',
+    dst: true,
+    region: 'us',
+  },
+  {
+    id: 'buenos-aires',
+    offset: -3,
+    label: 'Buenos Aires',
+    abbreviation: 'ART',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'mid-atlantic',
+    offset: -2,
+    label: 'Mid-Atlantic',
+    abbreviation: 'UTC−2',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'azores',
+    offset: -1,
+    label: 'Azores',
+    abbreviation: 'AZOT',
+    dst: true,
+    region: 'eu',
+  },
+  UTC_OPTION,
+  {
+    id: 'london',
+    offset: 0,
+    label: 'London',
+    abbreviation: 'UK',
+    dst: true,
+    region: 'eu',
+  },
+  {
+    id: 'central-europe',
+    offset: 1,
+    label: 'Central European',
+    abbreviation: 'CET',
+    dst: true,
+    region: 'eu',
+  },
+  {
+    id: 'eastern-europe',
+    offset: 2,
+    label: 'Eastern European',
+    abbreviation: 'EET',
+    dst: true,
+    region: 'eu',
+  },
+  {
+    id: 'moscow',
+    offset: 3,
+    label: 'Moscow',
+    abbreviation: 'MSK',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'dubai',
+    offset: 4,
+    label: 'Dubai',
+    abbreviation: 'GST',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'pakistan',
+    offset: 5,
+    label: 'Pakistan',
+    abbreviation: 'PKT',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'india',
+    offset: 5.5,
+    label: 'India',
+    abbreviation: 'IST',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'bangladesh',
+    offset: 6,
+    label: 'Bangladesh',
+    abbreviation: 'BST',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'bangkok',
+    offset: 7,
+    label: 'Bangkok',
+    abbreviation: 'ICT',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'singapore',
+    offset: 8,
+    label: 'Singapore',
+    abbreviation: 'SGT',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'tokyo',
+    offset: 9,
+    label: 'Tokyo',
+    abbreviation: 'JST',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'sydney',
+    offset: 10,
+    label: 'Sydney',
+    abbreviation: 'AET',
+    dst: true,
+    region: 'aus',
+  },
+  {
+    id: 'solomon',
+    offset: 11,
+    label: 'Solomon Islands',
+    abbreviation: 'SBT',
+    dst: false,
+    region: null,
+  },
+  {
+    id: 'new-zealand',
+    offset: 12,
+    label: 'New Zealand',
+    abbreviation: 'NZT',
+    dst: true,
+    region: 'nz',
+  },
 ];
 
-function getAdjustedOffset(option: TimezoneOption) {
-  if (!option.dst || !option.region) return option.offset;
+const DEFAULT_RECENT_ZONE_IDS = ['utc', 'eastern', 'pacific'];
+
+function getAdjustedOffset(option: TimezoneOption, canApplyDST: boolean) {
+  if (!canApplyDST || !option.dst || !option.region) return option.offset;
   return isDSTActive(option.region) ? option.offset + 1 : option.offset;
 }
 
@@ -54,99 +259,309 @@ function formatTime(hours: number, minutes: number) {
 }
 
 function formatOffset(offset: number) {
-  if (offset === 0) return 'UTC';
-  return `UTC${offset >= 0 ? '+' : ''}${offset}`;
+  if (offset === 0) return 'UTC±00:00';
+
+  const totalMinutes = Math.round(Math.abs(offset) * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `UTC${offset >= 0 ? '+' : '−'}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+function formatSearchOffset(offset: number) {
+  if (offset === 0) return 'UTC 0 UTC+0 UTC-0';
+  return `UTC${offset >= 0 ? '+' : ''}${offset} UTC ${offset}`;
 }
 
 export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelectorProps) {
-  const [selectedOffset, setSelectedOffset] = useState<number | null>(null);
+  const [selectedZoneId, setSelectedZoneId] = useState(UTC_OPTION.id);
+  const [previewZoneId, setPreviewZoneId] = useState<string | null>(null);
+  const [recentZoneIds, setRecentZoneIds] = useState(DEFAULT_RECENT_ZONE_IDS);
   const [isOpen, setIsOpen] = useState(false);
-
-  const calculateOffsetTime = (offset: number) => {
-    const totalMinutes = utcHours * 60 + utcMinutes + offset * 60;
-    const adjustedMinutes = ((totalMinutes % 1440) + 1440) % 1440;
-    return {
-      hours: Math.floor(adjustedMinutes / 60),
-      minutes: adjustedMinutes % 60,
-    };
-  };
+  const [query, setQuery] = useState('');
+  const [canApplyDST, setCanApplyDST] = useState(false);
+  const [resultMaxHeight, setResultMaxHeight] = useState(320);
+  const rootRef = useRef<HTMLElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const restorePositionRef = useRef({ left: 0, top: 0 });
 
   const selectedOption =
-    selectedOffset === null
-      ? null
-      : TIMEZONE_OPTIONS.find((option) => option.offset === selectedOffset) ?? null;
-  const displayOffset = selectedOption ? getAdjustedOffset(selectedOption) : null;
-  const displayTime = displayOffset === null ? null : calculateOffsetTime(displayOffset);
+    TIMEZONE_OPTIONS.find((option) => option.id === selectedZoneId) ?? UTC_OPTION;
+  const previewOption =
+    isOpen && previewZoneId
+      ? TIMEZONE_OPTIONS.find((option) => option.id === previewZoneId) ?? null
+      : null;
+  const displayOption = previewOption ?? selectedOption;
+  const displayOffset = getAdjustedOffset(displayOption, canApplyDST);
+  const totalMinutes = utcHours * 60 + utcMinutes + displayOffset * 60;
+  const adjustedMinutes = ((totalMinutes % 1440) + 1440) % 1440;
+  const displayHours = Math.floor(adjustedMinutes / 60);
+  const displayMinutes = adjustedMinutes % 60;
+  const isPreviewing = Boolean(previewOption && previewOption.id !== selectedOption.id);
+
+  const measureAvailableResults = useCallback(() => {
+    if (!isOpen || !listRef.current) return;
+
+    const viewport = window.visualViewport;
+    const viewportBottom = viewport
+      ? viewport.offsetTop + viewport.height
+      : window.innerHeight;
+    const listTop = listRef.current.getBoundingClientRect().top;
+    const availableHeight = Math.floor(viewportBottom - listTop - 12);
+    setResultMaxHeight(Math.max(0, Math.min(360, availableHeight)));
+  }, [isOpen]);
+
+  const keepActiveOptionVisible = useCallback(() => {
+    const list = listRef.current;
+    const activeOption = list?.querySelector<HTMLElement>('[cmdk-item][data-selected="true"]');
+    if (!list || !activeOption) return;
+
+    const listBox = list.getBoundingClientRect();
+    const optionBox = activeOption.getBoundingClientRect();
+    if (optionBox.top < listBox.top) {
+      list.scrollTop -= listBox.top - optionBox.top;
+    } else if (optionBox.bottom > listBox.bottom) {
+      list.scrollTop += optionBox.bottom - listBox.bottom;
+    }
+  }, []);
+
+  const closePicker = useCallback(() => {
+    setIsOpen(false);
+    setPreviewZoneId(null);
+    setQuery('');
+
+    window.requestAnimationFrame(() => {
+      triggerRef.current?.focus({ preventScroll: true });
+      window.scrollTo({
+        left: restorePositionRef.current.left,
+        top: restorePositionRef.current.top,
+        behavior: 'auto',
+      });
+    });
+  }, []);
+
+  const openPicker = useCallback(() => {
+    restorePositionRef.current = { left: window.scrollX, top: window.scrollY };
+    setPreviewZoneId(selectedZoneId);
+    setIsOpen(true);
+
+    window.requestAnimationFrame(() => {
+      if (window.matchMedia('(max-width: 767px)').matches) {
+        rootRef.current?.scrollIntoView({ block: 'start', behavior: 'auto' });
+      }
+      window.requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }));
+    });
+  }, [selectedZoneId]);
+
+  const rememberZone = useCallback((option: TimezoneOption) => {
+    setSelectedZoneId(option.id);
+    setRecentZoneIds((current) =>
+      [option.id, ...current.filter((id) => id !== option.id)].slice(0, 3),
+    );
+  }, []);
+
+  const selectZone = useCallback(
+    (option: TimezoneOption) => {
+      rememberZone(option);
+      closePicker();
+    },
+    [closePicker, rememberZone],
+  );
+
+  useEffect(() => setCanApplyDST(true), []);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    measureAvailableResults();
+    const frame = window.requestAnimationFrame(measureAvailableResults);
+    const viewport = window.visualViewport;
+    const observer = new ResizeObserver(measureAvailableResults);
+    if (rootRef.current) observer.observe(rootRef.current);
+
+    viewport?.addEventListener('resize', measureAvailableResults);
+    viewport?.addEventListener('scroll', measureAvailableResults);
+    window.addEventListener('resize', measureAvailableResults);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
+      viewport?.removeEventListener('resize', measureAvailableResults);
+      viewport?.removeEventListener('scroll', measureAvailableResults);
+      window.removeEventListener('resize', measureAvailableResults);
+    };
+  }, [isOpen, measureAvailableResults]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const dismissOnPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) closePicker();
+    };
+
+    document.addEventListener('pointerdown', dismissOnPointerDown);
+    return () => document.removeEventListener('pointerdown', dismissOnPointerDown);
+  }, [closePicker, isOpen]);
 
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="w-full rounded-xl border border-border/65 bg-background/46 p-3 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.26),0_8px_20px_rgba(20,20,24,0.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <p className="mb-2 text-sm text-muted-foreground">
-            <span className="relative inline-block">
-              {displayOffset === null ? 'UTC + ?' : formatOffset(displayOffset)}
-              {selectedOption?.dst ? (
-                <span className="absolute left-full top-1/2 ml-1.5 -translate-y-1/2 whitespace-nowrap rounded bg-amber-500/20 px-1 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
-                  DST
-                </span>
-              ) : null}
-            </span>
-          </p>
-          <p className="font-mono text-4xl font-semibold tabular-nums">
-            {displayTime ? formatTime(displayTime.hours, displayTime.minutes) : '--:--'}
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {selectedOption?.label ?? 'Select timezone'}
-          </p>
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        className="w-64 border-border/65 bg-popover/88 p-0 text-popover-foreground shadow-[0_22px_58px_rgba(20,20,24,0.2)] backdrop-blur-2xl"
-        align="start"
-        side="top"
-        sideOffset={8}
+    <section
+      ref={rootRef}
+      data-timezone-instrument
+      data-material-role="instrument-housing"
+      aria-label="Selected time zone"
+      className="scroll-mt-3 rounded-2xl border border-border/65 bg-background/36 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md sm:p-4 lg:grid lg:grid-cols-[minmax(0,0.9fr)_minmax(18rem,1.1fr)] lg:gap-4"
+    >
+      <div
+        data-selected-time-readout
+        data-material-role="instrument-readout"
+        aria-live={isOpen ? 'off' : 'polite'}
+        className="rounded-xl border border-border/70 bg-background/58 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_12px_30px_rgba(20,20,24,0.08)]"
       >
-        <Command>
-          <CommandInput placeholder="Search timezone..." />
-          <CommandList className="max-h-40 overflow-y-auto scroll-smooth">
-            <CommandEmpty>No timezone found.</CommandEmpty>
-            <CommandGroup>
-              {TIMEZONE_OPTIONS.map((option) => {
-                const adjustedOffset = getAdjustedOffset(option);
-                return (
-                  <CommandItem
-                    key={option.offset}
-                    value={`${option.label} ${formatOffset(adjustedOffset)}`}
-                    onSelect={() => {
-                      setSelectedOffset(option.offset);
-                      setIsOpen(false);
-                    }}
-                    className="flex items-center justify-between"
-                  >
-                    <span className="flex items-center gap-1.5">
-                      <span>{option.label}</span>
-                      {option.dst ? (
-                        <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-400">
-                          DST
+        <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {isPreviewing ? 'Preview time' : 'Selected time'}
+        </p>
+        <div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
+          <p className="font-mono text-5xl font-semibold tabular-nums tracking-[-0.05em] sm:text-6xl">
+            {formatTime(displayHours, displayMinutes)}
+          </p>
+          <p className="pb-1 font-mono text-sm font-medium tabular-nums text-muted-foreground">
+            {displayOption.abbreviation}
+          </p>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tabular-nums text-muted-foreground">
+          <span className="font-semibold text-foreground">{displayOption.label}</span>
+          <span aria-hidden="true">·</span>
+          <span>{formatOffset(displayOffset)}</span>
+          {displayOption.dst ? (
+            <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-sans text-[9px] font-semibold text-amber-700 dark:text-amber-400">
+              DST
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-4 min-w-0 lg:mt-0">
+        <div>
+          <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Recent zones
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {recentZoneIds.map((zoneId) => {
+              const option = TIMEZONE_OPTIONS.find((candidate) => candidate.id === zoneId);
+              if (!option) return null;
+              const isSelected = option.id === selectedOption.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => {
+                    rememberZone(option);
+                    if (isOpen) closePicker();
+                  }}
+                  aria-pressed={isSelected}
+                  className="min-h-10 rounded-full border border-border/65 bg-background/52 px-3 font-mono text-xs tabular-nums text-muted-foreground transition-colors hover:bg-background/72 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-pressed:border-foreground/25 aria-pressed:bg-accent aria-pressed:text-accent-foreground"
+                >
+                  {option.abbreviation}{' '}
+                  {formatOffset(getAdjustedOffset(option, canApplyDST))}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <button
+          ref={triggerRef}
+          data-timezone-trigger
+          type="button"
+          aria-expanded={isOpen}
+          aria-controls="timezone-picker-results"
+          onClick={() => (isOpen ? closePicker() : openPicker())}
+          className="mt-3 flex min-h-11 w-full items-center gap-2 rounded-xl border border-border/70 bg-background/58 px-3 text-left text-sm font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.22)] transition-colors hover:bg-background/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <span>{isOpen ? 'Hide zone search' : 'Search time zones'}</span>
+          <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+            {isOpen ? 'Esc' : 'Open'}
+          </span>
+        </button>
+
+        {isOpen ? (
+          <div
+            id="timezone-picker-results"
+            data-timezone-picker
+            className="mt-2 overflow-hidden rounded-xl border border-border/65 bg-popover/92 text-popover-foreground shadow-[0_18px_42px_rgba(20,20,24,0.16)] backdrop-blur-xl"
+          >
+            <Command
+              loop
+              value={previewZoneId ?? undefined}
+              onValueChange={setPreviewZoneId}
+              className="rounded-xl"
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  closePicker();
+                  return;
+                }
+                if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                  window.requestAnimationFrame(keepActiveOptionVisible);
+                }
+              }}
+            >
+              <CommandInput
+                ref={inputRef}
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Type a city, zone, or UTC offset"
+                aria-label="Search time zones"
+                className="font-mono tabular-nums"
+              />
+              <CommandList
+                ref={listRef}
+                data-timezone-results
+                className="max-h-none overscroll-contain scroll-auto"
+                style={{ maxHeight: resultMaxHeight }}
+              >
+                <CommandEmpty>No time zone found.</CommandEmpty>
+                <CommandGroup>
+                  {TIMEZONE_OPTIONS.map((option) => {
+                    const adjustedOffset = getAdjustedOffset(option, canApplyDST);
+                    return (
+                      <CommandItem
+                        key={option.id}
+                        value={option.id}
+                        keywords={[
+                          option.label,
+                          option.abbreviation,
+                          formatOffset(adjustedOffset),
+                          formatSearchOffset(adjustedOffset),
+                        ]}
+                        onSelect={() => selectZone(option)}
+                        className="min-h-11 items-center justify-between gap-3 px-3 py-2"
+                      >
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm">{option.label}</span>
+                          <span className="mt-0.5 block font-mono text-[10px] tabular-nums text-muted-foreground">
+                            {option.abbreviation}
+                            {option.dst ? ' · observes DST' : ''}
+                          </span>
                         </span>
-                      ) : null}
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      {formatOffset(adjustedOffset)}
-                    </span>
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-            <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
-              <span className="font-medium text-amber-700 dark:text-amber-400">DST</span> = Observes Daylight Saving Time (offset changes seasonally)
-            </div>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+                        <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                          {formatOffset(adjustedOffset)}
+                        </span>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+                <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+                  Offsets reflect the current daylight-saving period.
+                </div>
+              </CommandList>
+            </Command>
+          </div>
+        ) : null}
+      </div>
+    </section>
   );
 }

--- a/tests/e2e/time-picker.spec.ts
+++ b/tests/e2e/time-picker.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+}
+
+async function prepareDocumentScroll(page: Page, selector: string) {
+  await page.locator(selector).scrollIntoViewIfNeeded();
+  return page.evaluate(() => {
+    const element = document.scrollingElement;
+    if (!element) throw new Error('Missing document scrolling element');
+    const max = element.scrollHeight - element.clientHeight;
+    if (element.scrollTop >= max - 8) element.scrollTop = Math.max(0, max - 160);
+    return { top: element.scrollTop, max };
+  });
+}
+
+test.describe('mobile time picker', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/time');
+  });
+
+  test('uses the visual viewport and restores focus and scroll on dismissal', async ({ page }) => {
+    const trigger = page.locator('[data-timezone-trigger]');
+    await trigger.scrollIntoViewIfNeeded();
+    const scrollBeforeOpen = await page.evaluate(() => window.scrollY);
+
+    await trigger.click();
+    const input = page.getByRole('combobox', { name: 'Search time zones' });
+    const picker = page.locator('[data-timezone-picker]');
+
+    await expect(input).toBeFocused();
+    await expect(picker).toBeVisible();
+
+    await page.setViewportSize({ width: 390, height: 520 });
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const list = document.querySelector<HTMLElement>('[data-timezone-results]');
+          const viewport = window.visualViewport;
+          if (!list) return Number.POSITIVE_INFINITY;
+          const viewportBottom = viewport
+            ? viewport.offsetTop + viewport.height
+            : window.innerHeight;
+          return Math.ceil(list.getBoundingClientRect().bottom - viewportBottom);
+        }),
+      )
+      .toBeLessThanOrEqual(1);
+
+    const geometry = await page.evaluate(() => {
+      const selected = document.querySelector<HTMLElement>('[data-selected-time-readout]');
+      const viewport = window.visualViewport;
+      if (!selected) throw new Error('Missing selected-time readout');
+      return {
+        readoutTop: selected.getBoundingClientRect().top,
+        viewportTop: viewport?.offsetTop ?? 0,
+      };
+    });
+    expect(geometry.readoutTop).toBeGreaterThanOrEqual(geometry.viewportTop - 1);
+
+    await input.press('Escape');
+    await expect(picker).toBeHidden();
+    await expect(trigger).toBeFocused();
+    await expect
+      .poll(() =>
+        page.evaluate((expected) => Math.abs(window.scrollY - expected), scrollBeforeOpen),
+      )
+      .toBeLessThanOrEqual(1);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('supports keyboard preview and selection without moving the page', async ({ page }) => {
+    const trigger = page.locator('[data-timezone-trigger]');
+    await trigger.scrollIntoViewIfNeeded();
+    const scrollBeforeOpen = await page.evaluate(() => window.scrollY);
+    await trigger.click();
+    const input = page.getByRole('combobox', { name: 'Search time zones' });
+    const readout = page.locator('[data-selected-time-readout]');
+
+    await input.fill('Singapore');
+    await input.press('ArrowDown');
+    await expect(readout).toContainText('Preview time');
+    await expect(readout).toContainText('Singapore');
+    await input.press('Enter');
+
+    await expect(readout).toContainText('Selected time');
+    await expect(readout).toContainText('Singapore');
+    await expect(readout).toContainText('SGT');
+    await expect(trigger).toBeFocused();
+    await expect(page.locator('[data-timezone-picker]')).toBeHidden();
+    await expect
+      .poll(() =>
+        page.evaluate((expected) => Math.abs(window.scrollY - expected), scrollBeforeOpen),
+      )
+      .toBeLessThanOrEqual(1);
+  });
+
+  test('supports touch selection and keeps natural page scrolling', async ({ page }) => {
+    const trigger = page.locator('[data-timezone-trigger]');
+    await trigger.click();
+    const input = page.getByRole('combobox', { name: 'Search time zones' });
+    await input.fill('Tokyo');
+
+    await page.locator('[cmdk-item]').filter({ hasText: 'Tokyo' }).click();
+    await expect(page.locator('[data-selected-time-readout]')).toContainText('Tokyo');
+    await expect(trigger).toBeFocused();
+
+    const slider = page.locator('input[type="range"]');
+    const scrollState = await prepareDocumentScroll(page, 'input[type="range"]');
+    expect(scrollState.max).toBeGreaterThan(0);
+    const box = await slider.boundingBox();
+    expect(box).toBeTruthy();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.wheel(0, 260);
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(scrollState.top);
+    await expectNoHorizontalOverflow(page);
+  });
+});


### PR DESCRIPTION
## Summary

- move the selected-zone readout and selector above the scrubber and comparison details;
- replace the upward fixed popover with one inline picker that opens downward;
- size the result list from the current visual viewport so reduced mobile height remains usable;
- preserve the original page position and restore focus to the trigger after selection or dismissal;
- keep keyboard preview inside the result list without shifting the document;
- use one monospaced, tabular-numeral treatment for time, abbreviation, and UTC-offset readouts;
- retain the deployed translucent scrubber thumb and existing visual tokens.

## Mobile interaction

The picker records the current scroll position, brings the selected-time instrument near the top on narrow screens, focuses the search field with `preventScroll`, and derives the result-list height from `visualViewport.offsetTop + visualViewport.height`. Escape, touch selection, trigger dismissal, and outside dismissal return focus and scroll to the saved position.

Recent-zone controls sit between the selected readout and search trigger. Search results remain inline below the field. Desktop uses the same state and selection model with responsive two-column placement.

## Material boundary

This branch reuses the current background, card, border, ring, shadow, and blur tokens. `data-material-role="instrument-housing"` and `data-material-role="instrument-readout"` leave narrow integration points for the material-system lane without defining that system here.

## Playwright coverage

- reduced available mobile height and visual-viewport result bounds;
- selected readout visibility while search is open;
- Escape dismissal with restored focus and scroll;
- keyboard preview and selection;
- touch selection;
- natural document scrolling over the scrubber;
- zero horizontal overflow.

## Validation

- CI verify: lint, typecheck, unit tests, and production build passed;
- CI browser regressions: Chromium and WebKit Playwright suite passed;
- Vercel preview: blocked by the account's daily deployment quota (`api-deployments-free-per-day`), independent of this branch.

## Coordination

The branch was claimed from `main` at `ca54db56b67553393aff5b1eee59d8fc927d179d`. Current `main` is one later documentation-only commit ahead, touching `docs/agent-art-creation-and-research.md` and `docs/gallery-artwork.md`; there is no file overlap with this PR.

Refs #385
Coordinates with #384 and #386.
