### PR TITLE
Make homepage GitHub activity caching stale-safe

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -1,21 +1,27 @@
-import { getGitHubHomeData } from '@/lib/github-home';
+import { createGitHubActivityHeaders } from '@/lib/github-activity-response';
+import { getGitHubHomeResult } from '@/lib/github-home';
 import { connection } from 'next/server';
 import { NextResponse } from 'next/server';
-
-const CLIENT_REFRESH_SECONDS = 60;
-const UPSTREAM_CACHE_SECONDS = 300;
 
 export async function GET() {
   await connection();
   const requestId = crypto.randomUUID();
 
   try {
-    const activity = await getGitHubHomeData();
+    const result = await getGitHubHomeResult();
+    const { activity, diagnostics } = result;
+    const headers = createGitHubActivityHeaders(result, requestId);
 
     if (activity.source === 'unavailable') {
+      headers.set('Cache-Control', 'no-store');
       return NextResponse.json(
-        { ok: false, error: 'GitHub activity is temporarily unavailable', requestId },
-        { status: 503, headers: { 'Cache-Control': 'no-store', 'X-Request-Id': requestId } },
+        {
+          ok: false,
+          error: 'GitHub activity is temporarily unavailable',
+          requestId,
+          diagnostics,
+        },
+        { status: 503, headers },
       );
     }
 
@@ -27,17 +33,9 @@ export async function GET() {
         weekTotal: activity.weekTotal,
         yearTotal: activity.periodLabel === 'this year' ? activity.total : null,
         days: activity.days.slice(-28),
+        diagnostics,
       },
-      {
-        headers: {
-          'Cache-Control': `public, s-maxage=${CLIENT_REFRESH_SECONDS}, stale-while-revalidate=3600`,
-          'X-Activity-Source': activity.source,
-          'X-Activity-Generated-At': activity.generatedAt,
-          'X-Client-Refresh-Seconds': String(CLIENT_REFRESH_SECONDS),
-          'X-Upstream-Cache-Seconds': String(UPSTREAM_CACHE_SECONDS),
-          'X-Request-Id': requestId,
-        },
-      },
+      { headers },
     );
   } catch (error) {
     console.error('Unable to refresh GitHub activity', { requestId, error });

--- a/docs/github-activity-cache.md
+++ b/docs/github-activity-cache.md
@@ -1,0 +1,39 @@
+# GitHub activity cache
+
+The homepage reads public GitHub activity through `getGitHubHomeData()`. Live client refreshes use `getGitHubHomeResult()` through `/api/github-activity`.
+
+## Freshness and failure policy
+
+- The Next.js data cache keeps a successful upstream result fresh for five minutes across server instances and during homepage prerendering.
+- The connected API route adds an in-process coordinator so concurrent refreshes inside one server instance share the same promise.
+- A previous successful API result remains eligible as stale data for one hour.
+- Failed API refreshes use exponential retry backoff from one minute to a fifteen-minute cap.
+- A failure never replaces a previous successful snapshot with zero values.
+- `/api/github-activity` returns `503` only when neither the persistent data cache nor the current instance has a usable successful snapshot.
+- The API response uses `s-maxage=300` and `stale-while-revalidate=3600`, so edge requests normally coalesce before they reach the server coordinator.
+
+The three layers have separate jobs: Next data cache bounds upstream traffic and keeps static generation safe, the instance coordinator provides explicit stale/backoff behaviour, and CDN caching reduces repeated live-refresh requests across instances.
+
+## Diagnostics
+
+Successful JSON responses include a `diagnostics` object. An unavailable `503` response includes the same object so an incident can distinguish an empty cache from a stale fallback.
+
+Important fields:
+
+- `cacheStatus`: `miss`, `hit`, or `stale` for the current server-instance coordinator;
+- `upstreamSource`: `public-profile`, `public-events`, or `unavailable`;
+- `lastUpstreamAttempt` and `lastUpstreamFetch`;
+- `consecutiveFailures` and `nextRetryAt`;
+- `rateLimit`, populated when the REST events fallback returns GitHub rate-limit headers.
+
+The route mirrors the most useful values in `X-Activity-*` headers, including cache status, source, failure count, last attempt, last successful fetch, next retry, and REST rate-limit details. `X-Request-Id` ties a response to server logs.
+
+## Inspection
+
+Use the API directly when investigating the homepage activity panel:
+
+```bash
+curl -i https://<deployment>/api/github-activity
+```
+
+A Vercel preview is useful for changes to this route because CDN and serverless behaviour cannot be fully proven by the local process. Unit tests remain the source of truth for the cache state machine itself.

--- a/lib/github-activity-response.test.ts
+++ b/lib/github-activity-response.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { createGitHubActivityHeaders } from './github-activity-response';
+import type { GitHubHomeResult } from './github-home';
+
+function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResult {
+  return {
+    activity: {
+      username: 'teamleaderleo',
+      source,
+      generatedAt: '2026-07-27T01:00:00.000Z',
+      total: 18,
+      periodLabel: source === 'public-profile' ? 'this year' : 'last 35 days',
+      today: 3,
+      weekTotal: 9,
+      activeDays: 5,
+      currentStreak: 2,
+      days: [],
+      repositories: [],
+    },
+    diagnostics: {
+      cacheStatus: 'stale',
+      upstreamSource: source,
+      lastUpstreamAttempt: '2026-07-27T01:05:00.000Z',
+      lastUpstreamFetch: '2026-07-27T01:00:00.000Z',
+      consecutiveFailures: 2,
+      nextRetryAt: '2026-07-27T01:07:00.000Z',
+      rateLimit: {
+        limit: 60,
+        remaining: 41,
+        used: 19,
+        resetAt: '2026-07-27T02:00:00.000Z',
+        resource: 'core',
+      },
+    },
+  };
+}
+
+describe('createGitHubActivityHeaders', () => {
+  it('exposes freshness, retry, and REST rate-limit diagnostics', () => {
+    const headers = createGitHubActivityHeaders(result('public-events'), 'request-123');
+
+    expect(headers.get('cache-control')).toBe(
+      'public, s-maxage=300, stale-while-revalidate=3600',
+    );
+    expect(headers.get('x-activity-cache')).toBe('stale');
+    expect(headers.get('x-activity-source')).toBe('public-events');
+    expect(headers.get('x-activity-generated-at')).toBe('2026-07-27T01:00:00.000Z');
+    expect(headers.get('x-activity-last-attempt')).toBe('2026-07-27T01:05:00.000Z');
+    expect(headers.get('x-activity-last-upstream-fetch')).toBe('2026-07-27T01:00:00.000Z');
+    expect(headers.get('x-activity-next-retry-at')).toBe('2026-07-27T01:07:00.000Z');
+    expect(headers.get('x-activity-failures')).toBe('2');
+    expect(headers.get('x-activity-ratelimit-limit')).toBe('60');
+    expect(headers.get('x-activity-ratelimit-remaining')).toBe('41');
+    expect(headers.get('x-activity-ratelimit-used')).toBe('19');
+    expect(headers.get('x-activity-ratelimit-reset')).toBe('2026-07-27T02:00:00.000Z');
+    expect(headers.get('x-activity-ratelimit-resource')).toBe('core');
+    expect(headers.get('x-request-id')).toBe('request-123');
+  });
+
+  it('does not label an unavailable placeholder as generated activity', () => {
+    const headers = createGitHubActivityHeaders(result('unavailable'), 'request-456');
+
+    expect(headers.get('x-activity-source')).toBe('unavailable');
+    expect(headers.has('x-activity-generated-at')).toBe(false);
+  });
+});

--- a/lib/github-activity-response.ts
+++ b/lib/github-activity-response.ts
@@ -1,0 +1,53 @@
+import {
+  GITHUB_ACTIVITY_FRESH_SECONDS,
+  GITHUB_ACTIVITY_STALE_SECONDS,
+  type GitHubHomeResult,
+} from './github-home';
+
+export const GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS = 60;
+
+export function createGitHubActivityHeaders(result: GitHubHomeResult, requestId: string) {
+  const { activity, diagnostics } = result;
+  const headers = new Headers({
+    'Cache-Control': `public, s-maxage=${GITHUB_ACTIVITY_FRESH_SECONDS}, stale-while-revalidate=${GITHUB_ACTIVITY_STALE_SECONDS}`,
+    'X-Activity-Cache': diagnostics.cacheStatus,
+    'X-Activity-Source': diagnostics.upstreamSource,
+    'X-Activity-Failures': String(diagnostics.consecutiveFailures),
+    'X-Client-Refresh-Seconds': String(GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS),
+    'X-Upstream-Cache-Seconds': String(GITHUB_ACTIVITY_FRESH_SECONDS),
+    'X-Request-Id': requestId,
+  });
+
+  if (activity.source !== 'unavailable') {
+    headers.set('X-Activity-Generated-At', activity.generatedAt);
+  }
+  if (diagnostics.lastUpstreamAttempt) {
+    headers.set('X-Activity-Last-Attempt', diagnostics.lastUpstreamAttempt);
+  }
+  if (diagnostics.lastUpstreamFetch) {
+    headers.set('X-Activity-Last-Upstream-Fetch', diagnostics.lastUpstreamFetch);
+  }
+  if (diagnostics.nextRetryAt) {
+    headers.set('X-Activity-Next-Retry-At', diagnostics.nextRetryAt);
+  }
+  if (diagnostics.rateLimit?.limit !== null && diagnostics.rateLimit?.limit !== undefined) {
+    headers.set('X-Activity-RateLimit-Limit', String(diagnostics.rateLimit.limit));
+  }
+  if (
+    diagnostics.rateLimit?.remaining !== null &&
+    diagnostics.rateLimit?.remaining !== undefined
+  ) {
+    headers.set('X-Activity-RateLimit-Remaining', String(diagnostics.rateLimit.remaining));
+  }
+  if (diagnostics.rateLimit?.used !== null && diagnostics.rateLimit?.used !== undefined) {
+    headers.set('X-Activity-RateLimit-Used', String(diagnostics.rateLimit.used));
+  }
+  if (diagnostics.rateLimit?.resetAt) {
+    headers.set('X-Activity-RateLimit-Reset', diagnostics.rateLimit.resetAt);
+  }
+  if (diagnostics.rateLimit?.resource) {
+    headers.set('X-Activity-RateLimit-Resource', diagnostics.rateLimit.resource);
+  }
+
+  return headers;
+}

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getRecentDateKeys, parsePublicContributionHtml } from './github-activity-utils';
+import { parseGitHubRateLimit } from './github-home';
 
 describe('parsePublicContributionHtml', () => {
   it('reads direct data-count attributes', () => {
@@ -45,5 +46,29 @@ describe('getRecentDateKeys', () => {
     expect(days).toHaveLength(35);
     expect(days[0]).toBe('2026-06-21');
     expect(days.at(-1)).toBe('2026-07-25');
+  });
+});
+
+describe('parseGitHubRateLimit', () => {
+  it('captures REST fallback limit headers', () => {
+    const headers = new Headers({
+      'x-ratelimit-limit': '60',
+      'x-ratelimit-remaining': '41',
+      'x-ratelimit-used': '19',
+      'x-ratelimit-reset': '1785114000',
+      'x-ratelimit-resource': 'core',
+    });
+
+    expect(parseGitHubRateLimit(headers)).toEqual({
+      limit: 60,
+      remaining: 41,
+      used: 19,
+      resetAt: '2026-07-27T01:00:00.000Z',
+      resource: 'core',
+    });
+  });
+
+  it('returns null when GitHub did not send limit headers', () => {
+    expect(parseGitHubRateLimit(new Headers())).toBeNull();
   });
 });

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -4,6 +4,7 @@ import {
   getRecentDateKeys,
   parsePublicContributionHtml,
 } from './github-activity-utils';
+import { createStaleWhileErrorCache } from './stale-while-error-cache';
 
 const GITHUB_USERNAME = 'teamleaderleo';
 const FEATURED_REPOSITORIES = [
@@ -23,12 +24,24 @@ const FEATURED_REPOSITORIES = [
     note: 'Builds a privacy-minded evidence trail around revisions, failures, recovery, and missing signals.',
   },
 ] as const;
-const CACHE_SECONDS = 300;
+
+export const GITHUB_ACTIVITY_FRESH_SECONDS = 300;
+export const GITHUB_ACTIVITY_STALE_SECONDS = 3_600;
+const RETRY_BASE_MS = 60_000;
+const MAX_FAILURE_BACKOFF_MS = 15 * 60_000;
 const HOME_WINDOW_DAYS = 35;
 
 export type ContributionDay = {
   date: string;
   count: number;
+};
+
+export type GitHubRateLimit = {
+  limit: number | null;
+  remaining: number | null;
+  used: number | null;
+  resetAt: string | null;
+  resource: string | null;
 };
 
 export type GitHubHomeData = {
@@ -49,6 +62,21 @@ export type GitHubHomeData = {
   }>;
 };
 
+export type GitHubActivityDiagnostics = {
+  cacheStatus: 'hit' | 'miss' | 'stale';
+  upstreamSource: GitHubHomeData['source'];
+  lastUpstreamAttempt: string | null;
+  lastUpstreamFetch: string | null;
+  consecutiveFailures: number;
+  nextRetryAt: string | null;
+  rateLimit: GitHubRateLimit | null;
+};
+
+export type GitHubHomeResult = {
+  activity: GitHubHomeData;
+  diagnostics: GitHubActivityDiagnostics;
+};
+
 type RestEvent = {
   type: string;
   created_at: string | null;
@@ -64,6 +92,20 @@ type ActivitySummary = Pick<
   GitHubHomeData,
   'total' | 'periodLabel' | 'today' | 'weekTotal' | 'activeDays' | 'currentStreak' | 'days'
 >;
+type UpstreamActivity = {
+  activity: GitHubHomeData;
+  rateLimit: GitHubRateLimit | null;
+};
+
+class GitHubRestError extends Error {
+  rateLimit: GitHubRateLimit | null;
+
+  constructor(status: number, rateLimit: GitHubRateLimit | null) {
+    super(`GitHub REST returned ${status}`);
+    this.name = 'GitHubRestError';
+    this.rateLimit = rateLimit;
+  }
+}
 
 function daysFromCounts(counts: Map<string, number>, now: Date, length = HOME_WINDOW_DAYS) {
   return getRecentDateKeys(now, length).map((date) => ({ date, count: counts.get(date) ?? 0 }));
@@ -138,7 +180,34 @@ function eventWeight(event: RestEvent): number {
   return 0;
 }
 
-async function githubJson<T>(url: string): Promise<T> {
+function headerInteger(headers: Headers, name: string): number | null {
+  const value = headers.get(name);
+  if (value === null) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parseGitHubRateLimit(headers: Headers): GitHubRateLimit | null {
+  const limit = headerInteger(headers, 'x-ratelimit-limit');
+  const remaining = headerInteger(headers, 'x-ratelimit-remaining');
+  const used = headerInteger(headers, 'x-ratelimit-used');
+  const reset = headerInteger(headers, 'x-ratelimit-reset');
+  const resource = headers.get('x-ratelimit-resource');
+
+  if (limit === null && remaining === null && used === null && reset === null && resource === null) {
+    return null;
+  }
+
+  return {
+    limit,
+    remaining,
+    used,
+    resetAt: reset === null ? null : new Date(reset * 1_000).toISOString(),
+    resource,
+  };
+}
+
+async function githubJson<T>(url: string): Promise<{ data: T; rateLimit: GitHubRateLimit | null }> {
   const response = await fetch(url, {
     cache: 'no-store',
     headers: {
@@ -147,13 +216,17 @@ async function githubJson<T>(url: string): Promise<T> {
       'X-GitHub-Api-Version': '2022-11-28',
     },
   });
+  const rateLimit = parseGitHubRateLimit(response.headers);
 
-  if (!response.ok) throw new Error(`GitHub REST returned ${response.status}`);
-  return (await response.json()) as T;
+  if (!response.ok) throw new GitHubRestError(response.status, rateLimit);
+  return { data: (await response.json()) as T, rateLimit };
 }
 
-async function fetchPublicEventCounts(): Promise<Map<string, number>> {
-  const events = await githubJson<RestEvent[]>(
+async function fetchPublicEventCounts(): Promise<{
+  counts: Map<string, number>;
+  rateLimit: GitHubRateLimit | null;
+}> {
+  const { data: events, rateLimit } = await githubJson<RestEvent[]>(
     `https://api.github.com/users/${GITHUB_USERNAME}/events/public?per_page=100`,
   );
   const counts = new Map<string, number>();
@@ -166,56 +239,103 @@ async function fetchPublicEventCounts(): Promise<Map<string, number>> {
     counts.set(key, (counts.get(key) ?? 0) + weight);
   }
 
-  return counts;
+  return { counts, rateLimit };
 }
 
 function featuredRepositories(): GitHubHomeData['repositories'] {
   return FEATURED_REPOSITORIES.map((repository) => ({ ...repository }));
 }
 
-async function loadGitHubHomeData(): Promise<GitHubHomeData> {
+function unavailableHomeData(now = new Date()): GitHubHomeData {
+  const summary = summarizeCounts(new Map(), 'unavailable', now);
+  return {
+    username: GITHUB_USERNAME,
+    source: 'unavailable',
+    generatedAt: now.toISOString(),
+    ...summary,
+    total: null,
+    repositories: featuredRepositories(),
+  };
+}
+
+async function loadGitHubHomeData(): Promise<UpstreamActivity> {
   try {
     const summary = summarizeCounts(await fetchPublicProfileCounts(), 'public-profile');
     return {
-      username: GITHUB_USERNAME,
-      source: 'public-profile',
-      generatedAt: new Date().toISOString(),
-      ...summary,
-      repositories: featuredRepositories(),
+      activity: {
+        username: GITHUB_USERNAME,
+        source: 'public-profile',
+        generatedAt: new Date().toISOString(),
+        ...summary,
+        repositories: featuredRepositories(),
+      },
+      rateLimit: null,
     };
   } catch (profileError) {
     console.error('GitHub public contribution fetch failed', profileError);
   }
 
   try {
-    const summary = summarizeCounts(await fetchPublicEventCounts(), 'public-events');
+    const { counts, rateLimit } = await fetchPublicEventCounts();
+    const summary = summarizeCounts(counts, 'public-events');
     return {
-      username: GITHUB_USERNAME,
-      source: 'public-events',
-      generatedAt: new Date().toISOString(),
-      ...summary,
-      repositories: featuredRepositories(),
+      activity: {
+        username: GITHUB_USERNAME,
+        source: 'public-events',
+        generatedAt: new Date().toISOString(),
+        ...summary,
+        repositories: featuredRepositories(),
+      },
+      rateLimit,
     };
   } catch (eventError) {
     console.error('GitHub public event fetch failed', eventError);
-    const summary = summarizeCounts(new Map(), 'unavailable');
-    return {
-      username: GITHUB_USERNAME,
-      source: 'unavailable',
-      generatedAt: new Date().toISOString(),
-      ...summary,
-      total: null,
-      repositories: featuredRepositories(),
-    };
+    throw eventError;
   }
 }
 
-const getCachedGitHubHomeData = unstable_cache(
+const getCachedUpstreamActivity = unstable_cache(
   loadGitHubHomeData,
-  ['github-homepage-v5'],
-  { revalidate: CACHE_SECONDS },
+  ['github-homepage-v6'],
+  { revalidate: GITHUB_ACTIVITY_FRESH_SECONDS },
 );
 
+const githubHomeCache = createStaleWhileErrorCache<UpstreamActivity>({
+  load: getCachedUpstreamActivity,
+  freshForMs: GITHUB_ACTIVITY_FRESH_SECONDS * 1_000,
+  staleForMs: GITHUB_ACTIVITY_STALE_SECONDS * 1_000,
+  retryBaseMs: RETRY_BASE_MS,
+  retryMaxMs: MAX_FAILURE_BACKOFF_MS,
+});
+
+function rateLimitFromError(error: unknown): GitHubRateLimit | null {
+  return error instanceof GitHubRestError ? error.rateLimit : null;
+}
+
+export async function getGitHubHomeResult(): Promise<GitHubHomeResult> {
+  const cached = await githubHomeCache.get();
+  const activity = cached.value?.activity ?? unavailableHomeData();
+  const rateLimit = rateLimitFromError(cached.error) ?? cached.value?.rateLimit ?? null;
+
+  return {
+    activity,
+    diagnostics: {
+      cacheStatus: cached.diagnostics.status,
+      upstreamSource: activity.source,
+      lastUpstreamAttempt: cached.diagnostics.lastAttemptAt,
+      lastUpstreamFetch: cached.value?.activity.generatedAt ?? null,
+      consecutiveFailures: cached.diagnostics.consecutiveFailures,
+      nextRetryAt: cached.diagnostics.nextRetryAt,
+      rateLimit,
+    },
+  };
+}
+
 export async function getGitHubHomeData(): Promise<GitHubHomeData> {
-  return getCachedGitHubHomeData();
+  try {
+    return (await getCachedUpstreamActivity()).activity;
+  } catch (error) {
+    console.error('Unable to load cached GitHub homepage activity', error);
+    return unavailableHomeData();
+  }
 }

--- a/lib/stale-while-error-cache.test.ts
+++ b/lib/stale-while-error-cache.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { createStaleWhileErrorCache } from './stale-while-error-cache';
+
+function createClock(initial = Date.parse('2026-07-27T00:00:00.000Z')) {
+  let timestamp = initial;
+  return {
+    now: () => timestamp,
+    advance: (milliseconds: number) => {
+      timestamp += milliseconds;
+    },
+  };
+}
+
+describe('createStaleWhileErrorCache', () => {
+  it('reports an initial miss followed by a fresh hit', async () => {
+    const clock = createClock();
+    let loads = 0;
+    const cache = createStaleWhileErrorCache({
+      load: async () => ++loads,
+      freshForMs: 100,
+      staleForMs: 1_000,
+      retryBaseMs: 20,
+      retryMaxMs: 100,
+      now: clock.now,
+    });
+
+    const miss = await cache.get();
+    const hit = await cache.get();
+
+    expect(miss.value).toBe(1);
+    expect(miss.diagnostics.status).toBe('miss');
+    expect(hit.value).toBe(1);
+    expect(hit.diagnostics.status).toBe('hit');
+    expect(loads).toBe(1);
+  });
+
+  it('coalesces concurrent misses into one load', async () => {
+    const clock = createClock();
+    let loads = 0;
+    let resolveLoad: ((value: number) => void) | undefined;
+    const cache = createStaleWhileErrorCache({
+      load: () => {
+        loads += 1;
+        return new Promise<number>((resolve) => {
+          resolveLoad = resolve;
+        });
+      },
+      freshForMs: 100,
+      staleForMs: 1_000,
+      retryBaseMs: 20,
+      retryMaxMs: 100,
+      now: clock.now,
+    });
+
+    const first = cache.get();
+    const second = cache.get();
+    expect(loads).toBe(1);
+
+    resolveLoad?.(7);
+    await expect(first).resolves.toMatchObject({ value: 7 });
+    await expect(second).resolves.toMatchObject({ value: 7 });
+    expect(loads).toBe(1);
+  });
+
+  it('serves the previous value as stale after a failed refresh', async () => {
+    const clock = createClock();
+    let shouldFail = false;
+    let loads = 0;
+    const cache = createStaleWhileErrorCache({
+      load: async () => {
+        loads += 1;
+        if (shouldFail) throw new Error('upstream unavailable');
+        return 12;
+      },
+      freshForMs: 100,
+      staleForMs: 1_000,
+      retryBaseMs: 20,
+      retryMaxMs: 100,
+      now: clock.now,
+    });
+
+    await cache.get();
+    clock.advance(101);
+    shouldFail = true;
+
+    const stale = await cache.get();
+    expect(stale.value).toBe(12);
+    expect(stale.diagnostics.status).toBe('stale');
+    expect(stale.diagnostics.consecutiveFailures).toBe(1);
+    expect(stale.diagnostics.nextRetryAt).toBe('2026-07-27T00:00:00.121Z');
+
+    clock.advance(10);
+    const backedOff = await cache.get();
+    expect(backedOff.value).toBe(12);
+    expect(backedOff.diagnostics.status).toBe('stale');
+    expect(loads).toBe(2);
+  });
+
+  it('does not serve a value after the stale window expires', async () => {
+    const clock = createClock();
+    let shouldFail = false;
+    const cache = createStaleWhileErrorCache({
+      load: async () => {
+        if (shouldFail) throw new Error('upstream unavailable');
+        return 4;
+      },
+      freshForMs: 100,
+      staleForMs: 200,
+      retryBaseMs: 20,
+      retryMaxMs: 100,
+      now: clock.now,
+    });
+
+    await cache.get();
+    clock.advance(201);
+    shouldFail = true;
+
+    const unavailable = await cache.get();
+    expect(unavailable.value).toBeNull();
+    expect(unavailable.diagnostics.status).toBe('miss');
+    expect(unavailable.error).toBeInstanceOf(Error);
+  });
+
+  it('uses exponential retry backoff capped at the configured maximum', async () => {
+    const clock = createClock();
+    const cache = createStaleWhileErrorCache({
+      load: async () => {
+        throw new Error('upstream unavailable');
+      },
+      freshForMs: 100,
+      staleForMs: 1_000,
+      retryBaseMs: 20,
+      retryMaxMs: 50,
+      now: clock.now,
+    });
+
+    const first = await cache.get();
+    expect(first.diagnostics.nextRetryAt).toBe('2026-07-27T00:00:00.020Z');
+
+    clock.advance(20);
+    const second = await cache.get();
+    expect(second.diagnostics.nextRetryAt).toBe('2026-07-27T00:00:00.060Z');
+
+    clock.advance(40);
+    const third = await cache.get();
+    expect(third.diagnostics.nextRetryAt).toBe('2026-07-27T00:00:00.110Z');
+    expect(third.diagnostics.consecutiveFailures).toBe(3);
+  });
+
+  it('recovers after backoff and clears failure diagnostics', async () => {
+    const clock = createClock();
+    let value = 3;
+    let shouldFail = false;
+    const cache = createStaleWhileErrorCache({
+      load: async () => {
+        if (shouldFail) throw new Error('upstream unavailable');
+        return value;
+      },
+      freshForMs: 100,
+      staleForMs: 1_000,
+      retryBaseMs: 20,
+      retryMaxMs: 100,
+      now: clock.now,
+    });
+
+    await cache.get();
+    clock.advance(101);
+    shouldFail = true;
+    await cache.get();
+
+    clock.advance(20);
+    shouldFail = false;
+    value = 8;
+    const recovered = await cache.get();
+
+    expect(recovered.value).toBe(8);
+    expect(recovered.diagnostics.status).toBe('miss');
+    expect(recovered.diagnostics.consecutiveFailures).toBe(0);
+    expect(recovered.diagnostics.nextRetryAt).toBeNull();
+  });
+});

--- a/lib/stale-while-error-cache.ts
+++ b/lib/stale-while-error-cache.ts
@@ -1,0 +1,110 @@
+export type StaleCacheStatus = 'hit' | 'miss' | 'stale';
+
+export type StaleCacheDiagnostics = {
+  status: StaleCacheStatus;
+  lastAttemptAt: string | null;
+  lastSuccessAt: string | null;
+  consecutiveFailures: number;
+  nextRetryAt: string | null;
+};
+
+export type StaleCacheResult<T> = {
+  value: T | null;
+  diagnostics: StaleCacheDiagnostics;
+  error?: unknown;
+};
+
+type StaleCacheOptions<T> = {
+  load: () => Promise<T>;
+  freshForMs: number;
+  staleForMs: number;
+  retryBaseMs: number;
+  retryMaxMs: number;
+  now?: () => number;
+};
+
+function asIso(timestamp: number | null): string | null {
+  return timestamp === null ? null : new Date(timestamp).toISOString();
+}
+
+export function createStaleWhileErrorCache<T>({
+  load,
+  freshForMs,
+  staleForMs,
+  retryBaseMs,
+  retryMaxMs,
+  now = Date.now,
+}: StaleCacheOptions<T>) {
+  let value: T | null = null;
+  let freshUntil = 0;
+  let staleUntil = 0;
+  let lastAttemptAt: number | null = null;
+  let lastSuccessAt: number | null = null;
+  let consecutiveFailures = 0;
+  let nextRetryAt = 0;
+  let lastError: unknown;
+  let inFlight: Promise<StaleCacheResult<T>> | null = null;
+
+  const usableValue = (timestamp: number) =>
+    value !== null && timestamp < staleUntil ? value : null;
+
+  const result = (
+    status: StaleCacheStatus,
+    timestamp: number,
+    error = lastError,
+  ): StaleCacheResult<T> => ({
+    value: usableValue(timestamp),
+    diagnostics: {
+      status,
+      lastAttemptAt: asIso(lastAttemptAt),
+      lastSuccessAt: asIso(lastSuccessAt),
+      consecutiveFailures,
+      nextRetryAt: nextRetryAt > timestamp ? asIso(nextRetryAt) : null,
+    },
+    ...(error === undefined ? {} : { error }),
+  });
+
+  const refresh = async (): Promise<StaleCacheResult<T>> => {
+    lastAttemptAt = now();
+
+    try {
+      const nextValue = await load();
+      const completedAt = now();
+      value = nextValue;
+      freshUntil = completedAt + freshForMs;
+      staleUntil = completedAt + staleForMs;
+      lastSuccessAt = completedAt;
+      consecutiveFailures = 0;
+      nextRetryAt = 0;
+      lastError = undefined;
+      return result('miss', completedAt, undefined);
+    } catch (error) {
+      const failedAt = now();
+      consecutiveFailures += 1;
+      lastError = error;
+      const backoff = Math.min(
+        retryBaseMs * 2 ** Math.max(0, consecutiveFailures - 1),
+        retryMaxMs,
+      );
+      nextRetryAt = failedAt + backoff;
+      return result(usableValue(failedAt) === null ? 'miss' : 'stale', failedAt, error);
+    }
+  };
+
+  return {
+    async get(): Promise<StaleCacheResult<T>> {
+      const timestamp = now();
+      if (value !== null && timestamp < freshUntil) return result('hit', timestamp, undefined);
+      if (inFlight) return inFlight;
+
+      if (timestamp < nextRetryAt) {
+        return result(usableValue(timestamp) === null ? 'miss' : 'stale', timestamp);
+      }
+
+      inFlight = refresh().finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- retain the five-minute persistent Next.js data cache for homepage prerendering and cross-instance upstream control;
- add an explicit server-instance coordinator for the connected `/api/github-activity` route;
- coalesce concurrent API refreshes;
- retain the last successful API snapshot for one hour when GitHub temporarily fails;
- apply exponential retry backoff capped at fifteen minutes;
- never replace a previous successful API snapshot with empty/unavailable values;
- capture REST fallback rate-limit headers;
- expose cache/source/failure/retry/rate-limit diagnostics in API JSON and `X-Activity-*` headers;
- align CDN caching with the five-minute fresh and one-hour stale windows;
- document the three-layer cache and incident-inspection path.

## Scope fence

Data layer and `/api/github-activity` only. No activity-field geometry, tooltip, scoreboard, material, homepage spacing, or responsive work. #398 remains Agent 5’s UI lane.

## Tests

- initial miss and fresh hit;
- concurrent request deduplication;
- stale fallback after refresh failure;
- stale expiry;
- exponential backoff cap;
- recovery and diagnostic reset;
- GitHub REST rate-limit parsing;
- response freshness, retry, request ID, and rate-limit headers;
- unavailable placeholders never receive a generated-activity header.

## Review notes

`cacheStatus` describes the current server-instance coordinator. `lastUpstreamFetch` comes from the persisted activity generation timestamp. The Next data cache keeps homepage prerendering safe; the API coordinator owns explicit stale/backoff behaviour; `s-maxage=300, stale-while-revalidate=3600` reduces repeated live-refresh requests across instances.

The first CI pass exposed an invalid prerender boundary after the initial implementation moved clock/backoff logic into the homepage path. The final design separates that logic into the connected API path and restores the persistent cache for `app/page.tsx`.

Closes #404
Tracks #368