### PR TITLE
Harden mobile keyboard dismissal against delayed viewport changes

### DIFF
--- a/components/timezone-selector.tsx
+++ b/components/timezone-selector.tsx
@@ -10,266 +10,24 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import { isDSTActive } from '@/app/lib/dst-utils';
+import {
+  DEFAULT_RECENT_ZONE_IDS,
+  TIMEZONE_OPTIONS,
+  UTC_OPTION,
+  formatOffset,
+  formatSearchOffset,
+  formatTime,
+  getAdjustedOffset,
+  type TimezoneOption,
+} from '@/lib/timezone-options';
+import {
+  createBrowserViewportRestorationScheduler,
+  type ViewportRestorationScheduler,
+} from '@/lib/visual-viewport-restoration';
 
 interface TimezoneSelectorProps {
   utcHours: number;
   utcMinutes: number;
-}
-
-type TimezoneOption = {
-  id: string;
-  offset: number;
-  label: string;
-  abbreviation: string;
-  dst: boolean;
-  region: string | null;
-};
-
-const UTC_OPTION: TimezoneOption = {
-  id: 'utc',
-  offset: 0,
-  label: 'Coordinated Universal Time',
-  abbreviation: 'UTC',
-  dst: false,
-  region: null,
-};
-
-const TIMEZONE_OPTIONS: TimezoneOption[] = [
-  {
-    id: 'baker',
-    offset: -12,
-    label: 'Baker Island',
-    abbreviation: 'BIT',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'samoa',
-    offset: -11,
-    label: 'American Samoa',
-    abbreviation: 'SST',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'hawaii',
-    offset: -10,
-    label: 'Hawaii',
-    abbreviation: 'HST',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'alaska',
-    offset: -9,
-    label: 'Alaska',
-    abbreviation: 'AKT',
-    dst: true,
-    region: 'us',
-  },
-  {
-    id: 'pacific',
-    offset: -8,
-    label: 'Pacific Time',
-    abbreviation: 'PT',
-    dst: true,
-    region: 'us',
-  },
-  {
-    id: 'mountain',
-    offset: -7,
-    label: 'Mountain Time',
-    abbreviation: 'MT',
-    dst: true,
-    region: 'us',
-  },
-  {
-    id: 'central',
-    offset: -6,
-    label: 'Central Time',
-    abbreviation: 'CT',
-    dst: true,
-    region: 'us',
-  },
-  {
-    id: 'eastern',
-    offset: -5,
-    label: 'Eastern Time',
-    abbreviation: 'ET',
-    dst: true,
-    region: 'us',
-  },
-  {
-    id: 'atlantic',
-    offset: -4,
-    label: 'Atlantic Time',
-    abbreviation: 'AT',
-    dst: true,
-    region: 'us',
-  },
-  {
-    id: 'buenos-aires',
-    offset: -3,
-    label: 'Buenos Aires',
-    abbreviation: 'ART',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'mid-atlantic',
-    offset: -2,
-    label: 'Mid-Atlantic',
-    abbreviation: 'UTC−2',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'azores',
-    offset: -1,
-    label: 'Azores',
-    abbreviation: 'AZOT',
-    dst: true,
-    region: 'eu',
-  },
-  UTC_OPTION,
-  {
-    id: 'london',
-    offset: 0,
-    label: 'London',
-    abbreviation: 'UK',
-    dst: true,
-    region: 'eu',
-  },
-  {
-    id: 'central-europe',
-    offset: 1,
-    label: 'Central European',
-    abbreviation: 'CET',
-    dst: true,
-    region: 'eu',
-  },
-  {
-    id: 'eastern-europe',
-    offset: 2,
-    label: 'Eastern European',
-    abbreviation: 'EET',
-    dst: true,
-    region: 'eu',
-  },
-  {
-    id: 'moscow',
-    offset: 3,
-    label: 'Moscow',
-    abbreviation: 'MSK',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'dubai',
-    offset: 4,
-    label: 'Dubai',
-    abbreviation: 'GST',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'pakistan',
-    offset: 5,
-    label: 'Pakistan',
-    abbreviation: 'PKT',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'india',
-    offset: 5.5,
-    label: 'India',
-    abbreviation: 'IST',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'bangladesh',
-    offset: 6,
-    label: 'Bangladesh',
-    abbreviation: 'BST',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'bangkok',
-    offset: 7,
-    label: 'Bangkok',
-    abbreviation: 'ICT',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'singapore',
-    offset: 8,
-    label: 'Singapore',
-    abbreviation: 'SGT',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'tokyo',
-    offset: 9,
-    label: 'Tokyo',
-    abbreviation: 'JST',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'sydney',
-    offset: 10,
-    label: 'Sydney',
-    abbreviation: 'AET',
-    dst: true,
-    region: 'aus',
-  },
-  {
-    id: 'solomon',
-    offset: 11,
-    label: 'Solomon Islands',
-    abbreviation: 'SBT',
-    dst: false,
-    region: null,
-  },
-  {
-    id: 'new-zealand',
-    offset: 12,
-    label: 'New Zealand',
-    abbreviation: 'NZT',
-    dst: true,
-    region: 'nz',
-  },
-];
-
-const DEFAULT_RECENT_ZONE_IDS = ['utc', 'eastern', 'pacific'];
-
-function getAdjustedOffset(option: TimezoneOption, canApplyDST: boolean) {
-  if (!canApplyDST || !option.dst || !option.region) return option.offset;
-  return isDSTActive(option.region) ? option.offset + 1 : option.offset;
-}
-
-function formatTime(hours: number, minutes: number) {
-  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-}
-
-function formatOffset(offset: number) {
-  if (offset === 0) return 'UTC±00:00';
-
-  const totalMinutes = Math.round(Math.abs(offset) * 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return `UTC${offset >= 0 ? '+' : '−'}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-}
-
-function formatSearchOffset(offset: number) {
-  if (offset === 0) return 'UTC 0 UTC+0 UTC-0';
-  return `UTC${offset >= 0 ? '+' : ''}${offset} UTC ${offset}`;
 }
 
 export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelectorProps) {
@@ -285,6 +43,7 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const restorePositionRef = useRef({ left: 0, top: 0 });
+  const restorationSchedulerRef = useRef<ViewportRestorationScheduler | null>(null);
 
   const selectedOption =
     TIMEZONE_OPTIONS.find((option) => option.id === selectedZoneId) ?? UTC_OPTION;
@@ -331,17 +90,24 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
     setPreviewZoneId(null);
     setQuery('');
 
+    const trigger = triggerRef.current;
+    const position = restorePositionRef.current;
+    const focusTrigger = () => trigger?.focus({ preventScroll: true });
+    const scheduler = restorationSchedulerRef.current;
+
+    if (scheduler) {
+      scheduler.schedule({ focus: focusTrigger, position });
+      return;
+    }
+
+    focusTrigger();
     window.requestAnimationFrame(() => {
-      triggerRef.current?.focus({ preventScroll: true });
-      window.scrollTo({
-        left: restorePositionRef.current.left,
-        top: restorePositionRef.current.top,
-        behavior: 'auto',
-      });
+      window.scrollTo({ ...position, behavior: 'auto' });
     });
   }, []);
 
   const openPicker = useCallback(() => {
+    restorationSchedulerRef.current?.cancel();
     restorePositionRef.current = { left: window.scrollX, top: window.scrollY };
     setPreviewZoneId(selectedZoneId);
     setIsOpen(true);
@@ -369,7 +135,18 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
     [closePicker, rememberZone],
   );
 
-  useEffect(() => setCanApplyDST(true), []);
+  useEffect(() => {
+    setCanApplyDST(true);
+    const scheduler = createBrowserViewportRestorationScheduler();
+    restorationSchedulerRef.current = scheduler;
+
+    return () => {
+      scheduler.cancel();
+      if (restorationSchedulerRef.current === scheduler) {
+        restorationSchedulerRef.current = null;
+      }
+    };
+  }, []);
 
   useLayoutEffect(() => {
     if (!isOpen) return;

--- a/docs/mobile-time-picker-ios-checklist.md
+++ b/docs/mobile-time-picker-ios-checklist.md
@@ -1,0 +1,11 @@
+# Mobile time picker: iOS Safari checklist
+
+Use this checklist on a physical iPhone or an iOS simulator when one is available. This branch records the procedure only; it does not claim a physical-device run.
+
+1. Open `/time` in portrait, scroll until the zone-search trigger is visible, open it, and type enough text to show the software keyboard.
+2. Press Escape from a hardware keyboard or dismiss through the trigger. Confirm the keyboard closes, focus returns to the trigger, and the page returns to its saved position without a late jump.
+3. Open the picker again, search for Tokyo, and tap the result. Confirm the selected readout updates, remains visible, and the saved page position returns after the keyboard finishes closing.
+4. Repeat while Safari’s bottom toolbar is expanded and collapsed.
+5. Rotate to landscape and repeat Escape and tap selection with the reduced vertical area.
+6. Reopen the picker immediately while the keyboard is closing. Confirm the new picker stays open and no stale restoration moves the page.
+7. Scroll naturally through the page and drag the time scrubber. Confirm the picker work has not changed ordinary page scrolling or scrubber interaction.

--- a/lib/timezone-options.ts
+++ b/lib/timezone-options.ts
@@ -1,0 +1,86 @@
+import { isDSTActive } from '@/app/lib/dst-utils';
+
+export type TimezoneOption = {
+  id: string;
+  offset: number;
+  label: string;
+  abbreviation: string;
+  dst: boolean;
+  region: string | null;
+};
+
+type TimezoneDefinition = readonly [
+  id: string,
+  offset: number,
+  label: string,
+  abbreviation: string,
+  dst: boolean,
+  region: string | null,
+];
+
+const TIMEZONE_DEFINITIONS: readonly TimezoneDefinition[] = [
+  ['baker', -12, 'Baker Island', 'BIT', false, null],
+  ['samoa', -11, 'American Samoa', 'SST', false, null],
+  ['hawaii', -10, 'Hawaii', 'HST', false, null],
+  ['alaska', -9, 'Alaska', 'AKT', true, 'us'],
+  ['pacific', -8, 'Pacific Time', 'PT', true, 'us'],
+  ['mountain', -7, 'Mountain Time', 'MT', true, 'us'],
+  ['central', -6, 'Central Time', 'CT', true, 'us'],
+  ['eastern', -5, 'Eastern Time', 'ET', true, 'us'],
+  ['atlantic', -4, 'Atlantic Time', 'AT', true, 'us'],
+  ['buenos-aires', -3, 'Buenos Aires', 'ART', false, null],
+  ['mid-atlantic', -2, 'Mid-Atlantic', 'UTC−2', false, null],
+  ['azores', -1, 'Azores', 'AZOT', true, 'eu'],
+  ['utc', 0, 'Coordinated Universal Time', 'UTC', false, null],
+  ['london', 0, 'London', 'UK', true, 'eu'],
+  ['central-europe', 1, 'Central European', 'CET', true, 'eu'],
+  ['eastern-europe', 2, 'Eastern European', 'EET', true, 'eu'],
+  ['moscow', 3, 'Moscow', 'MSK', false, null],
+  ['dubai', 4, 'Dubai', 'GST', false, null],
+  ['pakistan', 5, 'Pakistan', 'PKT', false, null],
+  ['india', 5.5, 'India', 'IST', false, null],
+  ['bangladesh', 6, 'Bangladesh', 'BST', false, null],
+  ['bangkok', 7, 'Bangkok', 'ICT', false, null],
+  ['singapore', 8, 'Singapore', 'SGT', false, null],
+  ['tokyo', 9, 'Tokyo', 'JST', false, null],
+  ['sydney', 10, 'Sydney', 'AET', true, 'aus'],
+  ['solomon', 11, 'Solomon Islands', 'SBT', false, null],
+  ['new-zealand', 12, 'New Zealand', 'NZT', true, 'nz'],
+];
+
+export const TIMEZONE_OPTIONS: TimezoneOption[] = TIMEZONE_DEFINITIONS.map(
+  ([id, offset, label, abbreviation, dst, region]) => ({
+    id,
+    offset,
+    label,
+    abbreviation,
+    dst,
+    region,
+  }),
+);
+
+export const UTC_OPTION = TIMEZONE_OPTIONS.find((option) => option.id === 'utc')!;
+export const DEFAULT_RECENT_ZONE_IDS = ['utc', 'eastern', 'pacific'];
+
+export function getAdjustedOffset(option: TimezoneOption, canApplyDST: boolean) {
+  if (!canApplyDST || !option.dst || !option.region) return option.offset;
+  return isDSTActive(option.region) ? option.offset + 1 : option.offset;
+}
+
+export function formatTime(hours: number, minutes: number) {
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+export function formatOffset(offset: number) {
+  if (offset === 0) return 'UTC±00:00';
+
+  const totalMinutes = Math.round(Math.abs(offset) * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `UTC${offset >= 0 ? '+' : '−'}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+export function formatSearchOffset(offset: number) {
+  if (offset === 0) return 'UTC 0 UTC+0 UTC-0';
+  return `UTC${offset >= 0 ? '+' : ''}${offset} UTC ${offset}`;
+}

--- a/lib/visual-viewport-restoration.test.ts
+++ b/lib/visual-viewport-restoration.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createViewportRestorationScheduler,
+  type ScrollPosition,
+  type ViewportRestorationRuntime,
+  type VisualViewportLike,
+} from './visual-viewport-restoration';
+
+class FakeVisualViewport implements VisualViewportLike {
+  height: number;
+  offsetTop = 0;
+  private listeners = new Map<'resize' | 'scroll', Set<() => void>>();
+
+  constructor(height: number) {
+    this.height = height;
+  }
+
+  addEventListener(type: 'resize' | 'scroll', listener: () => void) {
+    const listeners = this.listeners.get(type) ?? new Set<() => void>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: 'resize' | 'scroll', listener: () => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: 'resize' | 'scroll') {
+    for (const listener of this.listeners.get(type) ?? []) listener();
+  }
+
+  listenerCount() {
+    return [...this.listeners.values()].reduce((total, listeners) => total + listeners.size, 0);
+  }
+}
+
+type PendingCallback = {
+  id: number;
+  callback: () => void;
+  dueAt: number;
+};
+
+class FakeRuntime implements ViewportRestorationRuntime {
+  viewport: FakeVisualViewport | null;
+  layoutHeight = 844;
+  now = 0;
+  focusCount = 0;
+  scrolls: ScrollPosition[] = [];
+  private nextId = 1;
+  private frames = new Map<number, () => void>();
+  private timers = new Map<number, PendingCallback>();
+
+  constructor(viewportHeight: number | null) {
+    this.viewport = viewportHeight === null ? null : new FakeVisualViewport(viewportHeight);
+  }
+
+  getVisualViewport = () => this.viewport;
+  getLayoutViewportHeight = () => this.layoutHeight;
+
+  requestAnimationFrame = (callback: () => void) => {
+    const id = this.nextId++;
+    this.frames.set(id, callback);
+    return id;
+  };
+
+  cancelAnimationFrame = (id: number) => {
+    this.frames.delete(id);
+  };
+
+  setTimeout = (callback: () => void, delayMs: number) => {
+    const id = this.nextId++;
+    this.timers.set(id, { id, callback, dueAt: this.now + delayMs });
+    return id;
+  };
+
+  clearTimeout = (id: number) => {
+    this.timers.delete(id);
+  };
+
+  scrollTo = (position: ScrollPosition) => {
+    this.scrolls.push(position);
+  };
+
+  focus = () => {
+    this.focusCount += 1;
+  };
+
+  flushFrames() {
+    const callbacks = [...this.frames.values()];
+    this.frames.clear();
+    for (const callback of callbacks) callback();
+  }
+
+  advanceBy(delayMs: number) {
+    const target = this.now + delayMs;
+    while (true) {
+      const next = [...this.timers.values()]
+        .filter((timer) => timer.dueAt <= target)
+        .sort((left, right) => left.dueAt - right.dueAt || left.id - right.id)[0];
+      if (!next) break;
+      this.now = next.dueAt;
+      this.timers.delete(next.id);
+      next.callback();
+    }
+    this.now = target;
+  }
+
+  pendingTimerCount() {
+    return this.timers.size;
+  }
+
+  pendingFrameCount() {
+    return this.frames.size;
+  }
+}
+
+const position = { left: 0, top: 312 };
+
+function schedule(runtime: FakeRuntime) {
+  const scheduler = createViewportRestorationScheduler(runtime, {
+    quietMs: 80,
+    maxWaitMs: 420,
+  });
+  scheduler.schedule({ focus: runtime.focus, position });
+  return scheduler;
+}
+
+describe('visual viewport restoration scheduler', () => {
+  it('restores on the next frame when the viewport is already stable', () => {
+    const runtime = new FakeRuntime(844);
+    schedule(runtime);
+
+    expect(runtime.focusCount).toBe(1);
+    expect(runtime.scrolls).toEqual([]);
+    runtime.flushFrames();
+    expect(runtime.scrolls).toEqual([position]);
+  });
+
+  it('waits for one delayed keyboard-close resize', () => {
+    const runtime = new FakeRuntime(520);
+    schedule(runtime);
+
+    runtime.advanceBy(120);
+    expect(runtime.scrolls).toEqual([]);
+    runtime.viewport!.height = 844;
+    runtime.viewport!.emit('resize');
+    runtime.advanceBy(79);
+    expect(runtime.scrolls).toEqual([]);
+    runtime.advanceBy(1);
+    expect(runtime.scrolls).toEqual([position]);
+  });
+
+  it('restarts the quiet window across repeated viewport changes', () => {
+    const runtime = new FakeRuntime(520);
+    schedule(runtime);
+
+    runtime.viewport!.height = 830;
+    runtime.viewport!.emit('resize');
+    runtime.advanceBy(50);
+    runtime.viewport!.height = 844;
+    runtime.viewport!.emit('resize');
+    runtime.advanceBy(79);
+    expect(runtime.scrolls).toEqual([]);
+    runtime.advanceBy(1);
+    expect(runtime.scrolls).toEqual([position]);
+  });
+
+  it('uses the bounded timeout when the viewport never expands', () => {
+    const runtime = new FakeRuntime(520);
+    schedule(runtime);
+
+    runtime.advanceBy(419);
+    expect(runtime.scrolls).toEqual([]);
+    runtime.advanceBy(1);
+    expect(runtime.scrolls).toEqual([position]);
+  });
+
+  it('cancels stale restoration when the picker reopens', () => {
+    const runtime = new FakeRuntime(520);
+    const scheduler = schedule(runtime);
+
+    scheduler.cancel();
+    runtime.viewport!.height = 844;
+    runtime.viewport!.emit('resize');
+    runtime.advanceBy(500);
+    runtime.flushFrames();
+    expect(runtime.scrolls).toEqual([]);
+  });
+
+  it('cleans listeners, timers, and frames during unmount cleanup', () => {
+    const runtime = new FakeRuntime(520);
+    const scheduler = schedule(runtime);
+
+    expect(runtime.viewport!.listenerCount()).toBe(2);
+    expect(runtime.pendingTimerCount()).toBe(1);
+    scheduler.cancel();
+
+    expect(runtime.viewport!.listenerCount()).toBe(0);
+    expect(runtime.pendingTimerCount()).toBe(0);
+    expect(runtime.pendingFrameCount()).toBe(0);
+  });
+});

--- a/lib/visual-viewport-restoration.ts
+++ b/lib/visual-viewport-restoration.ts
@@ -1,0 +1,138 @@
+export type ScrollPosition = {
+  left: number;
+  top: number;
+};
+
+type ViewportEvent = 'resize' | 'scroll';
+
+export type VisualViewportLike = {
+  height: number;
+  offsetTop: number;
+  addEventListener: (type: ViewportEvent, listener: () => void) => void;
+  removeEventListener: (type: ViewportEvent, listener: () => void) => void;
+};
+
+export type ViewportRestorationRuntime = {
+  getVisualViewport: () => VisualViewportLike | null;
+  getLayoutViewportHeight: () => number;
+  requestAnimationFrame: (callback: () => void) => number;
+  cancelAnimationFrame: (id: number) => void;
+  setTimeout: (callback: () => void, delayMs: number) => number;
+  clearTimeout: (id: number) => void;
+  scrollTo: (position: ScrollPosition) => void;
+};
+
+export type ViewportRestorationOptions = {
+  keyboardGapPx?: number;
+  quietMs?: number;
+  maxWaitMs?: number;
+};
+
+export type ViewportRestorationRequest = {
+  focus: () => void;
+  position: ScrollPosition;
+};
+
+export type ViewportRestorationScheduler = {
+  schedule: (request: ViewportRestorationRequest) => void;
+  cancel: () => void;
+};
+
+const DEFAULT_KEYBOARD_GAP_PX = 48;
+const DEFAULT_QUIET_MS = 80;
+const DEFAULT_MAX_WAIT_MS = 420;
+
+export function createViewportRestorationScheduler(
+  runtime: ViewportRestorationRuntime,
+  options: ViewportRestorationOptions = {},
+): ViewportRestorationScheduler {
+  const keyboardGapPx = options.keyboardGapPx ?? DEFAULT_KEYBOARD_GAP_PX;
+  const quietMs = options.quietMs ?? DEFAULT_QUIET_MS;
+  const maxWaitMs = options.maxWaitMs ?? DEFAULT_MAX_WAIT_MS;
+
+  let generation = 0;
+  let frameId: number | null = null;
+  let quietTimerId: number | null = null;
+  let fallbackTimerId: number | null = null;
+  let viewport: VisualViewportLike | null = null;
+  let viewportListener: (() => void) | null = null;
+
+  const clearPendingWork = () => {
+    if (frameId !== null) runtime.cancelAnimationFrame(frameId);
+    if (quietTimerId !== null) runtime.clearTimeout(quietTimerId);
+    if (fallbackTimerId !== null) runtime.clearTimeout(fallbackTimerId);
+    if (viewport && viewportListener) {
+      viewport.removeEventListener('resize', viewportListener);
+      viewport.removeEventListener('scroll', viewportListener);
+    }
+
+    frameId = null;
+    quietTimerId = null;
+    fallbackTimerId = null;
+    viewport = null;
+    viewportListener = null;
+  };
+
+  const cancel = () => {
+    generation += 1;
+    clearPendingWork();
+  };
+
+  const schedule = ({ focus, position }: ViewportRestorationRequest) => {
+    cancel();
+    const activeGeneration = generation;
+
+    focus();
+
+    const finish = () => {
+      if (activeGeneration !== generation) return;
+      clearPendingWork();
+      runtime.scrollTo(position);
+    };
+
+    const isKeyboardConstrained = () => {
+      if (!viewport) return false;
+      const visibleBottom = viewport.offsetTop + viewport.height;
+      return runtime.getLayoutViewportHeight() - visibleBottom > keyboardGapPx;
+    };
+
+    viewport = runtime.getVisualViewport();
+    if (!viewport || !isKeyboardConstrained()) {
+      frameId = runtime.requestAnimationFrame(finish);
+      return;
+    }
+
+    viewportListener = () => {
+      if (activeGeneration !== generation) return;
+      if (quietTimerId !== null) runtime.clearTimeout(quietTimerId);
+      quietTimerId = null;
+
+      if (isKeyboardConstrained()) return;
+      quietTimerId = runtime.setTimeout(finish, quietMs);
+    };
+
+    viewport.addEventListener('resize', viewportListener);
+    viewport.addEventListener('scroll', viewportListener);
+    fallbackTimerId = runtime.setTimeout(finish, maxWaitMs);
+    viewportListener();
+  };
+
+  return { schedule, cancel };
+}
+
+export function createBrowserViewportRestorationScheduler(
+  options?: ViewportRestorationOptions,
+): ViewportRestorationScheduler {
+  return createViewportRestorationScheduler(
+    {
+      getVisualViewport: () => window.visualViewport,
+      getLayoutViewportHeight: () => window.innerHeight,
+      requestAnimationFrame: (callback) => window.requestAnimationFrame(callback),
+      cancelAnimationFrame: (id) => window.cancelAnimationFrame(id),
+      setTimeout: (callback, delayMs) => window.setTimeout(callback, delayMs),
+      clearTimeout: (id) => window.clearTimeout(id),
+      scrollTo: ({ left, top }) => window.scrollTo({ left, top, behavior: 'auto' }),
+    },
+    options,
+  );
+}

--- a/tests/e2e/time-picker.spec.ts
+++ b/tests/e2e/time-picker.spec.ts
@@ -1,5 +1,26 @@
 import { expect, test, type Page } from '@playwright/test';
 
+type MobileViewportScenario = {
+  name: string;
+  width: number;
+  height: number;
+  keyboardHeight: number;
+};
+
+const portrait: MobileViewportScenario = {
+  name: 'mobile portrait',
+  width: 390,
+  height: 844,
+  keyboardHeight: 520,
+};
+
+const landscape: MobileViewportScenario = {
+  name: 'reduced-height landscape',
+  width: 740,
+  height: 390,
+  keyboardHeight: 246,
+};
+
 async function expectNoHorizontalOverflow(page: Page) {
   const overflow = await page.evaluate(
     () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
@@ -18,7 +39,72 @@ async function prepareDocumentScroll(page: Page, selector: string) {
   });
 }
 
+async function installSyntheticVisualViewport(page: Page, height: number) {
+  await page.addInitScript((initialHeight) => {
+    class TestVisualViewport extends EventTarget {
+      height = initialHeight;
+      width = window.innerWidth;
+      offsetTop = 0;
+      offsetLeft = 0;
+      pageTop = 0;
+      pageLeft = 0;
+      scale = 1;
+
+      setHeight(nextHeight: number) {
+        this.height = nextHeight;
+        this.dispatchEvent(new Event('resize'));
+      }
+    }
+
+    const viewport = new TestVisualViewport();
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: viewport,
+    });
+    (
+      window as Window & {
+        __setTestVisualViewportHeight?: (nextHeight: number) => void;
+      }
+    ).__setTestVisualViewportHeight = (nextHeight) => viewport.setHeight(nextHeight);
+  }, height);
+}
+
+async function setSyntheticVisualViewportHeight(page: Page, height: number) {
+  await page.evaluate((nextHeight) => {
+    const setter = (
+      window as Window & {
+        __setTestVisualViewportHeight?: (value: number) => void;
+      }
+    ).__setTestVisualViewportHeight;
+    if (!setter) throw new Error('Missing synthetic visual viewport');
+    setter(nextHeight);
+  }, height);
+}
+
+async function gotoWithSyntheticViewport(page: Page, scenario: MobileViewportScenario) {
+  await page.setViewportSize({ width: scenario.width, height: scenario.height });
+  await installSyntheticVisualViewport(page, scenario.height);
+  await page.goto('/time');
+}
+
+async function savedScrollBeforeOpen(page: Page) {
+  const trigger = page.locator('[data-timezone-trigger]');
+  await trigger.scrollIntoViewIfNeeded();
+  const savedScroll = await page.evaluate(() => window.scrollY);
+  await trigger.click();
+  await expect(page.getByRole('combobox', { name: 'Search time zones' })).toBeFocused();
+  return { trigger, savedScroll };
+}
+
+async function expectSavedScroll(page: Page, savedScroll: number) {
+  await expect
+    .poll(() => page.evaluate((expected) => Math.abs(window.scrollY - expected), savedScroll))
+    .toBeLessThanOrEqual(2);
+}
+
 test.describe('mobile time picker', () => {
+  test.use({ hasTouch: true });
+
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto('/time');
@@ -66,11 +152,7 @@ test.describe('mobile time picker', () => {
     await input.press('Escape');
     await expect(picker).toBeHidden();
     await expect(trigger).toBeFocused();
-    await expect
-      .poll(() =>
-        page.evaluate((expected) => Math.abs(window.scrollY - expected), scrollBeforeOpen),
-      )
-      .toBeLessThanOrEqual(1);
+    await expectSavedScroll(page, scrollBeforeOpen);
     await expectNoHorizontalOverflow(page);
   });
 
@@ -93,20 +175,16 @@ test.describe('mobile time picker', () => {
     await expect(readout).toContainText('SGT');
     await expect(trigger).toBeFocused();
     await expect(page.locator('[data-timezone-picker]')).toBeHidden();
-    await expect
-      .poll(() =>
-        page.evaluate((expected) => Math.abs(window.scrollY - expected), scrollBeforeOpen),
-      )
-      .toBeLessThanOrEqual(1);
+    await expectSavedScroll(page, scrollBeforeOpen);
   });
 
   test('supports touch selection and keeps natural page scrolling', async ({ page }) => {
     const trigger = page.locator('[data-timezone-trigger]');
-    await trigger.click();
+    await trigger.tap();
     const input = page.getByRole('combobox', { name: 'Search time zones' });
     await input.fill('Tokyo');
 
-    await page.locator('[cmdk-item]').filter({ hasText: 'Tokyo' }).click();
+    await page.locator('[cmdk-item]').filter({ hasText: 'Tokyo' }).tap();
     await expect(page.locator('[data-selected-time-readout]')).toContainText('Tokyo');
     await expect(trigger).toBeFocused();
 
@@ -119,6 +197,56 @@ test.describe('mobile time picker', () => {
     await page.mouse.wheel(0, 260);
 
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(scrollState.top);
+    await expectNoHorizontalOverflow(page);
+  });
+});
+
+test.describe('delayed mobile keyboard dismissal', () => {
+  test.use({ hasTouch: true });
+
+  test(`${portrait.name} waits for delayed viewport expansion after Escape`, async ({ page }) => {
+    await gotoWithSyntheticViewport(page, portrait);
+    const { trigger, savedScroll } = await savedScrollBeforeOpen(page);
+    const input = page.getByRole('combobox', { name: 'Search time zones' });
+    const readout = page.locator('[data-selected-time-readout]');
+
+    await setSyntheticVisualViewportHeight(page, portrait.keyboardHeight);
+    await input.press('Escape');
+
+    await expect(page.locator('[data-timezone-picker]')).toBeHidden();
+    await expect(trigger).toBeFocused();
+    await expect(readout).toBeVisible();
+
+    await setSyntheticVisualViewportHeight(page, portrait.height);
+    await expectSavedScroll(page, savedScroll);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test(`${landscape.name} waits for delayed viewport expansion after touch selection`, async ({
+    page,
+  }) => {
+    await gotoWithSyntheticViewport(page, landscape);
+    const { trigger, savedScroll } = await savedScrollBeforeOpen(page);
+    const input = page.getByRole('combobox', { name: 'Search time zones' });
+    const readout = page.locator('[data-selected-time-readout]');
+
+    await setSyntheticVisualViewportHeight(page, landscape.keyboardHeight);
+    await input.fill('Tokyo');
+    const tokyoOption = page.locator('[cmdk-item]').filter({ hasText: 'Tokyo' });
+    await expect(tokyoOption).toBeVisible();
+    // The synthetic visual viewport changes scheduler geometry without changing native
+    // hit testing, so send the touch pointer sequence directly to the selected option.
+    await tokyoOption.dispatchEvent('pointerdown', { pointerType: 'touch', isPrimary: true });
+    await tokyoOption.dispatchEvent('pointerup', { pointerType: 'touch', isPrimary: true });
+    await tokyoOption.dispatchEvent('click', { detail: 1 });
+
+    await expect(page.locator('[data-timezone-picker]')).toBeHidden();
+    await expect(trigger).toBeFocused();
+    await expect(readout).toContainText('Tokyo');
+    await expect(readout).toBeVisible();
+
+    await setSyntheticVisualViewportHeight(page, landscape.height);
+    await expectSavedScroll(page, savedScroll);
     await expectNoHorizontalOverflow(page);
   });
 });


### PR DESCRIPTION
## Summary

- extract saved-scroll restoration into a deterministic visual-viewport scheduler;
- return focus to the zone-search trigger immediately with `preventScroll`;
- defer document scroll while the visual viewport still indicates a keyboard-constrained area;
- settle after an 80 ms quiet resize window, with a bounded 420 ms fallback;
- cancel pending restoration when the picker reopens or the selector unmounts;
- preserve the existing picker hierarchy, time readouts, material hooks, and natural scrolling.

## Lifecycle review

Agent 2 completed the bounded lifecycle review and recorded an approve verdict with no blocking findings. The shared repository account cannot formally approve its own PR, so the independent review is recorded as a commented approval verdict.

The review confirmed generation invalidation, reopen cancellation, unmount cleanup, synchronous `preventScroll` focus, quiet-window restart, bounded fallback completion, and next-frame desktop behaviour. No branch changes were requested.

## Rebase

Rebased onto current `main` at `ef600924867f5fdb4fb58a17f8809fc934ee9863`. The reviewed six-file patch was replayed as a clean commit on that parent.

## Deterministic coverage

Unit coverage exercises:

- already-stable viewport;
- one delayed viewport resize;
- repeated resize events and quiet-window restart;
- bounded timeout fallback;
- reopen cancellation;
- unmount cleanup of listeners, timers, and frames.

Playwright installs a synthetic `visualViewport` and expands it after dismissal. The scenarios cover Escape in mobile portrait and touch selection in reduced-height landscape. The ordinary portrait touch test retains an unforced native `.tap()`; the synthetic landscape case sends a direct touch pointer sequence because changing the mocked visual viewport does not change Playwright's native hit-test viewport.

The full file also covers keyboard selection, readout visibility, focus restoration, saved-scroll tolerance, horizontal overflow, and natural scrubber/page scrolling.

## Manual iOS Safari checklist

`docs/mobile-time-picker-ios-checklist.md` records portrait, landscape, toolbar, immediate-reopen, touch-selection, and scrubber checks. This PR records the procedure and makes no physical-device claim.

## Validation

Head: `3c0ab21c9b6cb68e305937f96241dc635cb21b87`

CI run 325 passed on the rebased head:

- lint;
- TypeScript typecheck;
- unit tests;
- production build;
- full Chromium suite;
- full WebKit suite.

## Scope

No homepage, navigation-progress, or material-system styling changes. Existing time-picker `data-material-role` hooks remain intact.

Closes #402