### PR TITLE
Make Vercel preview deployments explicit and quota-aware

### DIFF
--- a/.github/workflows/vercel-preview-opt-in.yml
+++ b/.github/workflows/vercel-preview-opt-in.yml
@@ -1,0 +1,29 @@
+name: Opt in Vercel preview
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - 'preview/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: vercel-preview-opt-in-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promote:
+    if: ${{ github.event.deleted == false && contains(github.event.head_commit.message, '[preview]') }}
+    runs-on: ubuntu-latest
+    env:
+      PREVIEW_REF: preview/opt-in/${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Promote marked commit to a preview branch
+        run: |
+          echo "Promoting ${GITHUB_SHA} to ${PREVIEW_REF}"
+          git push --force origin "${GITHUB_SHA}:refs/heads/${PREVIEW_REF}"

--- a/docs/deployment-workflow.md
+++ b/docs/deployment-workflow.md
@@ -14,7 +14,7 @@ GitHub CI is the required merge signal. It runs lint, typecheck, unit tests, the
 | Branch prefixed `preview/` | Deploy every push as a persistent preview branch. |
 | Manual or non-Git deployment with no Git ref | Continue the deployment. |
 
-The marker is exact and case-sensitive: use `[preview]`.
+Use `[preview]` as the conventional spelling. Marker matching is case-insensitive.
 
 ## How the repository enforces the policy
 

--- a/docs/deployment-workflow.md
+++ b/docs/deployment-workflow.md
@@ -1,50 +1,93 @@
 # Deployment workflow
 
-Vercel Hobby accounts have two rolling limits relevant to this repository:
+Scrapbook treats GitHub CI and Vercel deployment as separate signals.
 
-- 32 builds per 3,600 seconds;
-- 100 deployments per 86,400 seconds.
+GitHub CI is the required merge signal. It runs lint, typecheck, unit tests, the production build, and Chromium/WebKit regressions. A skipped Vercel preview is an intentional deployment decision, not a code failure.
 
-Using Next.js is classed as a build. The Git integration creates a preview deployment for each push to an ordinary non-production branch and a production deployment for pushes to `main`.
+## Deployment policy
 
-The current failing GitHub checks point to Vercel's `build-rate-limit`, so the immediate lockout is the 32-build hourly limit. The daily deployment limit remains a second ceiling.
+| Source | Vercel behaviour |
+| --- | --- |
+| `main` | Deploy automatically to production. |
+| Ordinary feature, fix, docs, chore, internal, audit, or agent branches | Skip automatic Vercel deployment. |
+| Commit message containing `[preview]` | Promote that commit to `preview/opt-in/<source-branch>` and deploy it. |
+| Branch prefixed `preview/` | Deploy every push as a persistent preview branch. |
+| Manual or non-Git deployment with no Git ref | Continue the deployment. |
 
-The counters begin before a deployment succeeds. A deployment can consume quota when its build is cancelled or later errors.
+The marker is exact and case-sensitive: use `[preview]`.
 
-## Branches that receive previews
+## How the repository enforces the policy
 
-Use a normal feature branch when browser inspection provides useful evidence:
+There are three small controls.
 
-- `feature/*` for visible product work;
-- `fix/*` for behaviour that needs a live reproduction;
-- `preview/*` for an explicit visual review pass.
+### 1. Git branch gate
 
-These branches continue to deploy automatically.
+The root `vercel.json` uses `git.deploymentEnabled` with a deny-by-default rule:
 
-## Branches that use GitHub CI only
+- `main` is enabled;
+- `preview/**` is enabled;
+- every other Git branch is disabled.
 
-The root `vercel.json` disables automatic deployments for:
+This gate runs at the Git integration layer, before Vercel creates a routine feature-branch deployment. It is the quota-saving control.
 
-- `docs/**`;
-- `chore/**`;
-- `internal/**`;
-- `audit/**`.
+### 2. Commit-marker promotion
 
-Use these prefixes for prose, repository maintenance, investigations, and planning that can be judged through diffs and GitHub Actions.
+`.github/workflows/vercel-preview-opt-in.yml` watches non-production pushes. When the latest commit message contains `[preview]`, it force-updates a stable branch named:
+
+```text
+preview/opt-in/<source-branch>
+```
+
+Vercel sees that explicit preview branch and deploys the marked commit. Later ordinary commits on the source branch stay CI-only until another commit carries `[preview]`.
+
+A contributor who wants every push deployed can work directly on a `preview/…` branch instead.
+
+### 3. Vercel ignored-build safeguard
+
+`scripts/vercel-preview-policy.mjs` is the repository-owned final decision for any deployment that reaches Vercel's Ignored Build Step. It continues for:
+
+- `main`;
+- `preview/…` branches;
+- a commit containing `[preview]`;
+- a deployment with no Git ref.
+
+It exits `0` for a routine branch so Vercel ignores the build, and exits `1` when the build should continue. The command prints one concise reason in the deployment log.
+
+The decision function is pure and covered by unit tests. The ignored-build command is defence in depth; the branch gate does the quota-saving work for ordinary Git pushes.
+
+## When a preview is warranted
+
+Request a preview when a shareable deployed URL will change the review decision, especially for:
+
+- visual or responsive inspection;
+- serverless or runtime-environment behaviour;
+- authentication, cookies, headers, redirects, middleware, or edge behaviour;
+- Vercel routing, caching, image optimisation, or deployment configuration;
+- stakeholder review outside the local and CI environments.
+
+Routine prose, tests, repository maintenance, and changes already covered by deterministic browser CI should stay on ordinary branches without a marker.
 
 ## Practical cadence
 
 1. Run local checks before pushing when local access is available.
-2. Accumulate related changes on one branch.
-3. Let GitHub CI answer lint, type, unit, and build questions.
-4. Push a visual branch when a live browser review will change the decision.
-5. Merge accepted work to `main` for the production deployment.
+2. Accumulate related changes instead of pushing tiny deployment probes.
+3. Let GitHub CI answer lint, type, unit, build, and browser questions.
+4. Add `[preview]` to one commit when a deployed review URL adds useful evidence, or use a `preview/…` branch for a longer preview session.
+5. Merge accepted work to `main` for the automatic production deployment.
+
+## Quota accounting
+
+Vercel Hobby accounts have rolling build and deployment limits. Vercel's Ignored Build Step executes after a deployment has already been created, and Vercel documents ignored or cancelled builds as counting toward deployment quotas and concurrent build slots.
+
+For that reason, this repository does not rely on the ignored-build command alone. `git.deploymentEnabled` blocks routine branches before deployment creation. The ignored-build script remains a readable safeguard for manual deployments and any deployment that reaches the build stage through another route.
 
 ## Retrying a blocked production deployment
 
-When a `main` deployment hits the rolling build limit, wait until enough earlier builds leave the 3,600-second window, then trigger one deliberate retry. Avoid repeated rapid retries because every created deployment consumes quota even when Vercel cancels it before building.
+When a `main` deployment hits a rolling limit, wait until enough earlier activity leaves the quota window, then trigger one deliberate retry. Repeated rapid retries create more deployment attempts and extend the problem.
 
-Vercel's Ignored Build Step runs after a deployment has already been created. Cancelled builds from that mechanism still count toward deployment quotas and concurrent build slots, so branch-level `git.deploymentEnabled` rules are the useful control for this repository.
+## Project boundary
+
+This policy applies to the existing Vercel project `setzen`. It changes repository-controlled Git deployment behaviour only. Production domains, project environment variables, and runtime settings stay unchanged.
 
 ## Sources
 
@@ -52,3 +95,4 @@ Vercel's Ignored Build Step runs after a deployment has already been created. Ca
 - [Deploying Git repositories with Vercel](https://vercel.com/docs/git)
 - [Git configuration](https://vercel.com/docs/project-configuration/git-configuration)
 - [Project settings and Ignored Build Step accounting](https://vercel.com/docs/project-configuration/project-settings)
+- [System environment variables](https://vercel.com/docs/environment-variables/system-environment-variables)

--- a/scripts/vercel-preview-policy.mjs
+++ b/scripts/vercel-preview-policy.mjs
@@ -66,7 +66,7 @@ export function ignoredBuildExitCode(decision) {
 }
 
 /**
- * @param {NodeJS.ProcessEnv} env
+ * @param {Partial<NodeJS.ProcessEnv>} env
  * @param {(message: string) => void} log
  */
 export function runVercelPreviewPolicy(env = process.env, log = console.log) {

--- a/scripts/vercel-preview-policy.mjs
+++ b/scripts/vercel-preview-policy.mjs
@@ -1,0 +1,84 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const VERCEL_IGNORE_BUILD_EXIT_CODE = 0;
+export const VERCEL_CONTINUE_BUILD_EXIT_CODE = 1;
+
+/**
+ * @typedef {object} VercelDeploymentInput
+ * @property {string | undefined} gitRef
+ * @property {string | undefined} commitMessage
+ */
+
+/**
+ * Decide whether a deployment that reaches Vercel's ignored-build step should continue.
+ * Git branch gating in vercel.json prevents routine branches from creating deployments;
+ * this function is the final repository-owned policy for main, previews, and manual runs.
+ *
+ * @param {VercelDeploymentInput} input
+ */
+export function decideVercelDeployment({ gitRef, commitMessage }) {
+  const ref = typeof gitRef === 'string' ? gitRef.trim() : '';
+  const message = typeof commitMessage === 'string' ? commitMessage : '';
+
+  if (!ref) {
+    return {
+      deploy: true,
+      reason: 'manual or non-Git deployment has no Git ref',
+    };
+  }
+
+  if (ref === 'main') {
+    return {
+      deploy: true,
+      reason: 'main is the production branch',
+    };
+  }
+
+  if (ref.startsWith('preview/')) {
+    return {
+      deploy: true,
+      reason: `${ref} is an explicit preview branch`,
+    };
+  }
+
+  if (message.includes('[preview]')) {
+    return {
+      deploy: true,
+      reason: 'commit message contains [preview]',
+    };
+  }
+
+  return {
+    deploy: false,
+    reason: `${ref} is a routine branch; add [preview] or push under preview/ to opt in`,
+  };
+}
+
+/**
+ * Vercel continues a build on exit 1 and ignores it on exit 0.
+ *
+ * @param {{ deploy: boolean }} decision
+ */
+export function ignoredBuildExitCode(decision) {
+  return decision.deploy ? VERCEL_CONTINUE_BUILD_EXIT_CODE : VERCEL_IGNORE_BUILD_EXIT_CODE;
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @param {(message: string) => void} log
+ */
+export function runVercelPreviewPolicy(env = process.env, log = console.log) {
+  const decision = decideVercelDeployment({
+    gitRef: env.VERCEL_GIT_COMMIT_REF,
+    commitMessage: env.VERCEL_GIT_COMMIT_MESSAGE,
+  });
+  const action = decision.deploy ? 'build' : 'skip';
+  log(`[vercel-preview-policy] ${action}: ${decision.reason}`);
+  return ignoredBuildExitCode(decision);
+}
+
+const invokedUrl = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedUrl === import.meta.url) {
+  process.exitCode = runVercelPreviewPolicy();
+}

--- a/scripts/vercel-preview-policy.mjs
+++ b/scripts/vercel-preview-policy.mjs
@@ -20,6 +20,7 @@ export const VERCEL_CONTINUE_BUILD_EXIT_CODE = 1;
 export function decideVercelDeployment({ gitRef, commitMessage }) {
   const ref = typeof gitRef === 'string' ? gitRef.trim() : '';
   const message = typeof commitMessage === 'string' ? commitMessage : '';
+  const hasPreviewMarker = message.toLowerCase().includes('[preview]');
 
   if (!ref) {
     return {
@@ -42,7 +43,7 @@ export function decideVercelDeployment({ gitRef, commitMessage }) {
     };
   }
 
-  if (message.includes('[preview]')) {
+  if (hasPreviewMarker) {
     return {
       deploy: true,
       reason: 'commit message contains [preview]',

--- a/tests/vercel-preview-policy.test.ts
+++ b/tests/vercel-preview-policy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  VERCEL_CONTINUE_BUILD_EXIT_CODE,
+  VERCEL_IGNORE_BUILD_EXIT_CODE,
+  decideVercelDeployment,
+  ignoredBuildExitCode,
+  runVercelPreviewPolicy,
+} from '../scripts/vercel-preview-policy.mjs';
+
+describe('Vercel preview deployment policy', () => {
+  it('continues production deployment from main', () => {
+    const decision = decideVercelDeployment({
+      gitRef: 'main',
+      commitMessage: 'Merge pull request #401',
+    });
+
+    expect(decision).toEqual({
+      deploy: true,
+      reason: 'main is the production branch',
+    });
+    expect(ignoredBuildExitCode(decision)).toBe(VERCEL_CONTINUE_BUILD_EXIT_CODE);
+  });
+
+  it('skips an ordinary feature branch', () => {
+    const decision = decideVercelDeployment({
+      gitRef: 'feature/navigation-copy',
+      commitMessage: 'Tighten navigation copy',
+    });
+
+    expect(decision.deploy).toBe(false);
+    expect(decision.reason).toContain('add [preview] or push under preview/');
+    expect(ignoredBuildExitCode(decision)).toBe(VERCEL_IGNORE_BUILD_EXIT_CODE);
+  });
+
+  it('continues when the commit message contains the preview marker', () => {
+    const decision = decideVercelDeployment({
+      gitRef: 'feature/navigation-copy',
+      commitMessage: 'Tighten navigation copy [preview]',
+    });
+
+    expect(decision).toEqual({
+      deploy: true,
+      reason: 'commit message contains [preview]',
+    });
+  });
+
+  it('continues for a persistent preview branch', () => {
+    const decision = decideVercelDeployment({
+      gitRef: 'preview/navigation-copy',
+      commitMessage: 'Tighten navigation copy',
+    });
+
+    expect(decision.deploy).toBe(true);
+    expect(decision.reason).toContain('explicit preview branch');
+  });
+
+  it('continues manual or non-Git deployments when the Git ref is missing', () => {
+    const decision = decideVercelDeployment({
+      gitRef: undefined,
+      commitMessage: undefined,
+    });
+
+    expect(decision).toEqual({
+      deploy: true,
+      reason: 'manual or non-Git deployment has no Git ref',
+    });
+  });
+
+  it('prints a concise skip explanation for Vercel logs', () => {
+    const log = vi.fn();
+    const exitCode = runVercelPreviewPolicy(
+      {
+        VERCEL_GIT_COMMIT_REF: 'fix/copy',
+        VERCEL_GIT_COMMIT_MESSAGE: 'Fix copy',
+      },
+      log,
+    );
+
+    expect(exitCode).toBe(VERCEL_IGNORE_BUILD_EXIT_CODE);
+    expect(log).toHaveBeenCalledWith(
+      '[vercel-preview-policy] skip: fix/copy is a routine branch; add [preview] or push under preview/ to opt in',
+    );
+  });
+});

--- a/tests/vercel-preview-policy.test.ts
+++ b/tests/vercel-preview-policy.test.ts
@@ -38,11 +38,16 @@ describe('Vercel preview deployment policy', () => {
       gitRef: 'feature/navigation-copy',
       commitMessage: 'Tighten navigation copy [preview]',
     });
+    const upperCaseDecision = decideVercelDeployment({
+      gitRef: 'feature/navigation-copy',
+      commitMessage: 'Tighten navigation copy [PREVIEW]',
+    });
 
     expect(decision).toEqual({
       deploy: true,
       reason: 'commit message contains [preview]',
     });
+    expect(upperCaseDecision).toEqual(decision);
   });
 
   it('continues for a persistent preview branch', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,10 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "docs/**": false,
-      "chore/**": false,
-      "internal/**": false,
-      "audit/**": false
+      "**": false,
+      "main": true,
+      "preview/**": true
     }
-  }
+  },
+  "ignoreCommand": "node scripts/vercel-preview-policy.mjs"
 }


### PR DESCRIPTION
Closes #401

## Policy

- `main` keeps automatic production deployment
- routine Git branches are denied at Vercel's Git integration layer
- `[preview]` in the latest commit promotes that commit to `preview/opt-in/<source-branch>`
- direct `preview/…` branches deploy persistently
- manual or non-Git deployments continue when no Git ref is present
- GitHub CI remains the required merge signal

## Implementation

- replace prefix-by-prefix exclusions with deny-by-default `git.deploymentEnabled` rules
- add a small GitHub workflow that promotes preview-marked commits without Vercel credentials
- add a repository-owned ignored-build policy with a pure decision function and concise logs
- cover main, ordinary branch, commit marker, preview branch, missing Git ref, and skip logging with Vitest
- document preview-worthy changes, routine CI-only work, manual deployment, and quota accounting

## Quota note

Vercel documents the Ignored Build Step as running after deployment creation, so ignored/cancelled deployments can still count against deployment quotas. The branch gate is the quota-saving control; the ignored-build command is defence in depth.

## Project verification

Checked the connected `setzen` project (`prj_6xVAKEVJ3LQUCpSfRzxXFkKjGlsx`): Next.js, Node 22.x, and the existing production domains. This PR changes repository Git-deployment policy only and does not alter domains or environment variables.

The ordinary `ops/issue-401-selective-vercel-previews` branch created zero Vercel deployments after the deny-by-default gate landed.

## Validation

GitHub CI passed lint, typecheck, unit tests, production build, Chromium, and WebKit.

Ready for review. Do not merge automatically.