### PR TITLE
Apply materials to time and navigation instruments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,13 @@ jobs:
           name: material-system-screenshots
           path: test-results/material-system
           if-no-files-found: ignore
+      - name: Upload time and navigation material evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: material-instrument-screenshots
+          path: test-results/material-instruments
+          if-no-files-found: ignore
       - name: Upload browser diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import '@/app/globals.css';
 import '@/app/materials.css';
 import '@/app/materials-accessibility.css';
 import '@/app/navigation-feedback.css';
+import '@/app/material-instruments.css';
 import { inter } from '@/components/ui/assets/fonts';
 import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';

--- a/app/material-instruments.css
+++ b/app/material-instruments.css
@@ -1,0 +1,271 @@
+/* Paint-only application of the shared #384 material vocabulary.
+   Geometry, interaction, and lifecycle behaviour remain owned by #397 and #396. */
+
+[data-material-role='instrument-housing'] {
+  position: relative;
+  isolation: isolate;
+  border-color: hsl(var(--material-steel-edge) / 0.44);
+  background-color: hsl(var(--material-steel-face));
+  background-image:
+    linear-gradient(
+      145deg,
+      hsl(var(--material-steel-highlight) / 0.2),
+      transparent 27%,
+      hsl(var(--material-steel-shadow) / 0.065) 72%,
+      hsl(var(--material-steel-shadow) / 0.12)
+    ),
+    radial-gradient(
+      circle at 30% 20%,
+      hsl(var(--material-steel-highlight) / var(--material-grain-opacity)) 0 0.55px,
+      transparent 0.8px
+    );
+  background-size: auto, 5px 5px;
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.28),
+    inset 0 -1px 0 hsl(var(--material-steel-shadow) / 0.16),
+    0 12px 28px hsl(var(--material-steel-shadow) / 0.12);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+[data-material-role='instrument-housing']::before {
+  content: '';
+  position: absolute;
+  inset: 0.45rem;
+  z-index: 0;
+  border: 1px solid hsl(var(--material-steel-shadow) / 0.17);
+  border-radius: calc(1rem - 0.2rem);
+  box-shadow: 0 1px 0 hsl(var(--material-steel-highlight) / 0.16);
+  pointer-events: none;
+}
+
+[data-material-role='instrument-housing'] > * {
+  position: relative;
+  z-index: 1;
+}
+
+[data-material-role='instrument-readout'] {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-color: hsl(var(--material-phenolic-edge) / 0.84);
+  background-color: hsl(var(--material-phenolic-face));
+  background-image:
+    radial-gradient(
+      circle at 32% 18%,
+      hsl(var(--material-phenolic-highlight) / 0.26),
+      transparent 38%
+    ),
+    linear-gradient(
+      160deg,
+      hsl(var(--material-phenolic-highlight) / 0.12),
+      transparent 32%,
+      hsl(var(--material-phenolic-face-low) / 0.76)
+    );
+  color: hsl(var(--material-slate-mark));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-phenolic-highlight) / 0.26),
+    inset 0 -10px 18px hsl(var(--material-phenolic-edge) / 0.34),
+    0 7px 16px hsl(var(--material-steel-shadow) / 0.18);
+}
+
+[data-material-role='instrument-readout']::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border: 1px solid hsl(var(--material-glass-edge) / 0.24);
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      118deg,
+      hsl(var(--material-glass-highlight) / 0.2),
+      transparent 21% 72%,
+      hsl(var(--material-glass-edge) / 0.08)
+    ),
+    linear-gradient(180deg, transparent, hsl(var(--material-glass-tint) / 0.08));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-glass-highlight) / 0.34),
+    inset 0 -1px 0 hsl(var(--material-glass-edge) / 0.16);
+  pointer-events: none;
+}
+
+[data-material-role='instrument-readout'] > * {
+  position: relative;
+  z-index: 1;
+}
+
+[data-material-role='instrument-readout'] .text-foreground {
+  color: hsl(var(--material-slate-mark));
+}
+
+[data-material-role='instrument-readout'] .text-muted-foreground {
+  color: hsl(var(--material-slate-mark) / 0.72);
+}
+
+[data-material-role='instrument-readout'] > p:first-child {
+  text-shadow:
+    0 1px 0 hsl(var(--material-phenolic-highlight) / 0.26),
+    0 -1px 0 hsl(var(--material-phenolic-edge) / 0.44);
+}
+
+[data-timezone-instrument] button[aria-pressed] {
+  border-color: hsl(var(--material-steel-edge) / 0.34);
+  background: hsl(var(--material-steel-highlight) / 0.14);
+  box-shadow: inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.2);
+}
+
+[data-timezone-instrument] button[aria-pressed]:hover {
+  background: hsl(var(--material-steel-highlight) / 0.23);
+}
+
+[data-timezone-instrument] button[aria-pressed='true'] {
+  border-color: hsl(var(--material-phenolic-edge) / 0.76);
+  background: hsl(var(--material-phenolic-face));
+  color: hsl(var(--material-slate-mark));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-phenolic-highlight) / 0.24),
+    inset 0 -3px 7px hsl(var(--material-phenolic-edge) / 0.24);
+}
+
+[data-timezone-trigger] {
+  border-color: hsl(var(--material-steel-edge) / 0.38);
+  background: hsl(var(--material-steel-highlight) / 0.15);
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.24),
+    0 2px 5px hsl(var(--material-steel-shadow) / 0.08);
+}
+
+[data-timezone-trigger]:hover {
+  background: hsl(var(--material-steel-highlight) / 0.24);
+}
+
+[data-timezone-picker] {
+  border-color: hsl(var(--material-steel-edge) / 0.46);
+  background-color: hsl(var(--background) / 0.98);
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.2),
+    0 18px 42px hsl(var(--material-steel-shadow) / 0.18);
+}
+
+[data-timezone-picker] [cmdk-root] {
+  background: transparent;
+}
+
+[data-timezone-picker] [cmdk-input-wrapper] {
+  border-color: hsl(var(--material-steel-edge) / 0.28);
+}
+
+.navigation-rail {
+  background-color: hsl(var(--material-steel-face-low));
+  background-image: linear-gradient(
+    180deg,
+    hsl(var(--material-steel-highlight) / 0.28),
+    hsl(var(--material-steel-face-low) / 0.76) 48%,
+    hsl(var(--material-steel-edge) / 0.6)
+  );
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.22),
+    0 1px 0 hsl(var(--material-steel-shadow) / 0.16);
+}
+
+.dark .navigation-rail {
+  background-color: hsl(var(--material-steel-face-low));
+  background-image: linear-gradient(
+    180deg,
+    hsl(var(--material-steel-highlight) / 0.24),
+    hsl(var(--material-steel-face-low) / 0.8) 48%,
+    hsl(var(--material-steel-edge) / 0.72)
+  );
+}
+
+.navigation-progress {
+  background-color: hsl(var(--material-hardware-face));
+  background-image: linear-gradient(
+    90deg,
+    hsl(var(--material-hardware-edge) / 0.92),
+    hsl(var(--material-hardware-face)) 58%,
+    hsl(var(--material-steel-highlight) / 0.88)
+  );
+  box-shadow:
+    0 0 7px hsl(var(--material-glass-edge) / 0.32),
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.46);
+}
+
+.dark .navigation-progress {
+  background-color: hsl(var(--material-hardware-face));
+  background-image: linear-gradient(
+    90deg,
+    hsl(var(--material-hardware-edge) / 0.96),
+    hsl(var(--material-hardware-face)) 58%,
+    hsl(var(--material-steel-highlight) / 0.94)
+  );
+  box-shadow:
+    0 0 8px hsl(var(--material-glass-edge) / 0.28),
+    inset 0 1px 0 hsl(var(--material-steel-highlight) / 0.42);
+}
+
+.navigation-status {
+  border-color: hsl(var(--material-slate-face-low) / 0.72);
+  background-color: hsl(var(--material-slate-face));
+  background-image:
+    linear-gradient(168deg, hsl(var(--material-slate-mark) / 0.055), transparent 34%),
+    radial-gradient(circle, hsl(var(--material-slate-mark) / 0.07) 0 0.5px, transparent 0.8px);
+  background-size: auto, 7px 7px;
+  color: hsl(var(--material-slate-mark));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-slate-mark) / 0.12),
+    inset 0 -5px 12px hsl(var(--material-slate-face-low) / 0.32),
+    0 8px 24px hsl(var(--material-steel-shadow) / 0.16);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+.dark .navigation-status {
+  border-color: hsl(var(--material-slate-face-low) / 0.8);
+  background-color: hsl(var(--material-slate-face));
+  color: hsl(var(--material-slate-mark));
+  box-shadow:
+    inset 0 1px 0 hsl(var(--material-slate-mark) / 0.1),
+    inset 0 -5px 12px hsl(var(--material-slate-face-low) / 0.38),
+    0 8px 24px hsl(var(--material-steel-shadow) / 0.24);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  [data-material-role='instrument-readout']::before {
+    background: none;
+  }
+
+  [data-timezone-picker] {
+    background-color: hsl(var(--background));
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+@media (forced-colors: active) {
+  [data-material-role='instrument-housing'],
+  [data-material-role='instrument-readout'],
+  [data-timezone-instrument] button[aria-pressed],
+  [data-timezone-trigger],
+  [data-timezone-picker],
+  .navigation-rail,
+  .navigation-status {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+    color: CanvasText;
+  }
+
+  [data-material-role='instrument-housing']::before,
+  [data-material-role='instrument-readout']::before {
+    border-color: CanvasText;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .navigation-progress {
+    background: Highlight;
+    box-shadow: none;
+  }
+}

--- a/tests/e2e/material-instruments.spec.ts
+++ b/tests/e2e/material-instruments.spec.ts
@@ -1,0 +1,279 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const EVIDENCE_PHASE = 'after';
+
+const timeStudies = [
+  { theme: 'light', width: 390, height: 844 },
+  { theme: 'dark', width: 390, height: 844 },
+  { theme: 'light', width: 1366, height: 768 },
+  { theme: 'dark', width: 1440, height: 900 },
+] as const;
+
+async function setTheme(page: Page, theme: 'light' | 'dark') {
+  await page.addInitScript((nextTheme) => {
+    window.localStorage.setItem('theme', nextTheme);
+  }, theme);
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+}
+
+async function waitForClientHydration(page: Page) {
+  const timeLink = page.getByRole('link', { name: /Open the time converter/i });
+  await expect
+    .poll(() => timeLink.getAttribute('aria-label'))
+    .not.toContain('Local time --:--');
+}
+
+async function evidencePath(
+  testInfo: TestInfo,
+  group: string,
+  name: string,
+) {
+  const target = path.join(
+    'test-results',
+    'material-instruments',
+    EVIDENCE_PHASE,
+    group,
+    testInfo.project.name,
+    `${name}.png`,
+  );
+  await mkdir(path.dirname(target), { recursive: true });
+  return target;
+}
+
+for (const study of timeStudies) {
+  test(`captures ${study.theme} time instrument at ${study.width}x${study.height}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: study.width, height: study.height });
+    await setTheme(page, study.theme);
+    const response = await page.goto('/time');
+    expect(response?.ok()).toBe(true);
+
+    const root = page.locator('html');
+    await expect(root).toHaveClass(new RegExp(study.theme));
+
+    const housing = page.locator('[data-material-role="instrument-housing"]');
+    const readout = page.locator('[data-material-role="instrument-readout"]');
+    const trigger = page.locator('[data-timezone-trigger]');
+    await expect(housing).toBeVisible();
+    await expect(readout).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+
+    const materialStyles = await page.evaluate(() => {
+      const housingElement = document.querySelector<HTMLElement>(
+        '[data-material-role="instrument-housing"]',
+      );
+      const readoutElement = document.querySelector<HTMLElement>(
+        '[data-material-role="instrument-readout"]',
+      );
+      if (!housingElement || !readoutElement) throw new Error('Missing time instrument');
+      return {
+        housingBackgroundImage: getComputedStyle(housingElement).backgroundImage,
+        readoutBackgroundImage: getComputedStyle(readoutElement).backgroundImage,
+        lensContent: getComputedStyle(readoutElement, '::before').content,
+      };
+    });
+    expect(materialStyles.housingBackgroundImage).not.toBe('none');
+    expect(materialStyles.readoutBackgroundImage).not.toBe('none');
+    expect(materialStyles.lensContent).not.toBe('none');
+
+    await housing.screenshot({
+      path: await evidencePath(
+        testInfo,
+        'time',
+        `closed-${study.theme}-${study.width}x${study.height}`,
+      ),
+      animations: 'disabled',
+    });
+
+    await trigger.click();
+    const picker = page.locator('[data-timezone-picker]');
+    const input = page.getByRole('combobox', { name: 'Search time zones' });
+    await expect(picker).toBeVisible();
+    await expect(input).toBeFocused();
+    await expectNoHorizontalOverflow(page);
+
+    await housing.screenshot({
+      path: await evidencePath(
+        testInfo,
+        'time',
+        `open-${study.theme}-${study.width}x${study.height}`,
+      ),
+      animations: 'disabled',
+    });
+  });
+}
+
+async function prepareNavigationEvidence(
+  page: Page,
+  theme: 'light' | 'dark',
+  width: number,
+  height: number,
+) {
+  await page.setViewportSize({ width, height });
+  await setTheme(page, theme);
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+  await expect(page.locator('nav')).toBeVisible();
+  await waitForClientHydration(page);
+  await expect(page.locator('html')).toHaveClass(new RegExp(theme));
+}
+
+async function startNavigationState(page: Page) {
+  const feedback = page.locator('[data-navigation-feedback]');
+  await expect
+    .poll(async () => {
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent('scrapbook:navigation-start', {
+            detail: { href: '/time', label: 'time' },
+          }),
+        );
+      });
+      return feedback.isVisible();
+    })
+    .toBe(true);
+  return feedback;
+}
+
+async function captureNavigationTop(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+  width: number,
+) {
+  await page.screenshot({
+    path: await evidencePath(testInfo, 'navigation', name),
+    animations: 'disabled',
+    clip: { x: 0, y: 0, width, height: 104 },
+  });
+}
+
+test('captures the ordinary progress rail', async ({ page }, testInfo) => {
+  const width = 1366;
+  await prepareNavigationEvidence(page, 'light', width, 768);
+  const feedback = await startNavigationState(page);
+  await expect(feedback).toHaveAttribute('data-navigation-state', 'running');
+  await expectNoHorizontalOverflow(page);
+  await captureNavigationTop(page, testInfo, 'ordinary-light-1366x768', width);
+});
+
+test('captures the progress rail on mobile', async ({ page }, testInfo) => {
+  const width = 390;
+  await prepareNavigationEvidence(page, 'dark', width, 844);
+  const feedback = await startNavigationState(page);
+  await expect(feedback).toHaveAttribute('data-navigation-state', 'running');
+  await expectNoHorizontalOverflow(page);
+  await captureNavigationTop(page, testInfo, 'ordinary-dark-390x844', width);
+});
+
+test('captures delayed slow navigation feedback', async ({ page }, testInfo) => {
+  const width = 1366;
+  await prepareNavigationEvidence(page, 'dark', width, 768);
+  const feedback = await startNavigationState(page);
+  await expect
+    .poll(() => feedback.getAttribute('data-navigation-state'), { timeout: 5_500 })
+    .toBe('slow');
+  await expect(page.getByText('Still opening time…')).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+  await captureNavigationTop(page, testInfo, 'slow-dark-1366x768', width);
+});
+
+test('captures actionable failure feedback', async ({ page }, testInfo) => {
+  const width = 1366;
+  await prepareNavigationEvidence(page, 'light', width, 768);
+  const feedback = await startNavigationState(page);
+  await page.evaluate(() => {
+    window.dispatchEvent(
+      new CustomEvent('scrapbook:navigation-error', {
+        detail: { message: 'Navigation could not finish. Try the link again or reload this page.' },
+      }),
+    );
+  });
+  await expect(feedback).toHaveAttribute('data-navigation-state', 'failed');
+  await expect(page.getByText(/Navigation could not finish/)).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+  await captureNavigationTop(page, testInfo, 'failure-light-1366x768', width);
+});
+
+test('removes the glass tint and picker blur for reduced transparency', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Chromium media emulation covers this fallback.');
+
+  const session = await page.context().newCDPSession(page);
+  await session.send('Emulation.setEmulatedMedia', {
+    features: [{ name: 'prefers-reduced-transparency', value: 'reduce' }],
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/time');
+
+  expect(
+    await page.evaluate(() => window.matchMedia('(prefers-reduced-transparency: reduce)').matches),
+  ).toBe(true);
+
+  const readout = page.locator('[data-material-role="instrument-readout"]');
+  const lensBackground = await readout.evaluate(
+    (element) => getComputedStyle(element, '::before').backgroundImage,
+  );
+  expect(lensBackground).toBe('none');
+
+  await page.locator('[data-timezone-trigger]').click();
+  const picker = page.locator('[data-timezone-picker]');
+  await expect(picker).toBeVisible();
+  await expect(picker).toHaveCSS('backdrop-filter', 'none');
+});
+
+test('keeps time and navigation instruments legible in forced colours', async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Forced-colour emulation is checked in Chromium.');
+
+  await page.emulateMedia({ forcedColors: 'active' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/time');
+
+  const forcedTimeStyles = await page.evaluate(() => {
+    const housing = document.querySelector<HTMLElement>(
+      '[data-material-role="instrument-housing"]',
+    );
+    const readout = document.querySelector<HTMLElement>(
+      '[data-material-role="instrument-readout"]',
+    );
+    if (!housing || !readout) throw new Error('Missing time instrument');
+    return {
+      housingBackgroundImage: getComputedStyle(housing).backgroundImage,
+      readoutBackgroundImage: getComputedStyle(readout).backgroundImage,
+      lensBackgroundImage: getComputedStyle(readout, '::before').backgroundImage,
+    };
+  });
+  expect(forcedTimeStyles.housingBackgroundImage).toBe('none');
+  expect(forcedTimeStyles.readoutBackgroundImage).toBe('none');
+  expect(forcedTimeStyles.lensBackgroundImage).toBe('none');
+
+  await page.goto('/');
+  await waitForClientHydration(page);
+  await startNavigationState(page);
+  const forcedNavigationStyles = await page.evaluate(() => {
+    const rail = document.querySelector<HTMLElement>('.navigation-rail');
+    const progress = document.querySelector<HTMLElement>('.navigation-progress');
+    if (!rail || !progress) throw new Error('Missing navigation rail');
+    return {
+      railBackgroundImage: getComputedStyle(rail).backgroundImage,
+      progressBackgroundImage: getComputedStyle(progress).backgroundImage,
+      railHeight: rail.getBoundingClientRect().height,
+    };
+  });
+  expect(forcedNavigationStyles.railBackgroundImage).toBe('none');
+  expect(forcedNavigationStyles.progressBackgroundImage).toBe('none');
+  expect(forcedNavigationStyles.railHeight).toBe(2);
+  await expectNoHorizontalOverflow(page);
+});

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -82,8 +82,11 @@ test('keeps the material exemplar calm with reduced motion', async ({ page }) =>
   await digit.hover();
   const after = await digit.evaluate((element) => element.style.transform);
   const transitionDurationMs = await scoreboard.evaluate((element) => {
-    const value = window.getComputedStyle(element).transitionDuration.split(',')[0] ?? '0s';
-    return value.endsWith('ms') ? Number.parseFloat(value) : Number.parseFloat(value) * 1_000;
+    const value = window.getComputedStyle(element).transitionDuration.split(',')[0]?.trim() ?? '';
+    if (!value) return 0;
+    const duration = Number.parseFloat(value);
+    if (!Number.isFinite(duration)) return 0;
+    return value.endsWith('ms') ? duration : duration * 1_000;
   });
 
   expect(after).toBe(before);


### PR DESCRIPTION
Closes #403

## Result

Applies the shared #384 material vocabulary to the settled time and navigation instruments through one paint-only CSS layer.

The branch is rebased onto current `main` at `ef600924867f5fdb4fb58a17f8809fc934ee9863` and is zero commits behind.

## Time instrument

- uses the existing `instrument-housing` hook as a quiet painted-steel enclosure;
- uses the existing `instrument-readout` hook as a phenolic well with a local glass lens;
- keeps recent-zone controls and the open search list visually subordinate and utilitarian;
- preserves information order, type scale, control dimensions, result sizing, visual-viewport handling, focus restoration, scroll restoration, touch behaviour, and keyboard selection.

## Navigation instrument

- treats the existing 2px rail as a stable steel channel with a restrained hardware/enamel progress face;
- uses the shared slate vocabulary only for delayed slow/failure text;
- preserves fixed positioning, dimensions, monotonic progress, thresholds, timing model, lifecycle events, failure copy, and reduced-motion transition timing.

## Exact behaviour fence

The production implementation changes only:

- `app/material-instruments.css` — token-based paint and accessibility fallbacks;
- `app/layout.tsx` — one CSS import.

These owned files remain unchanged from `main`:

- `components/timezone-selector.tsx`;
- `tests/e2e/time-picker.spec.ts`;
- `components/navigation-feedback.tsx`;
- `lib/navigation-progress.ts`;
- `lib/navigation-progress.test.ts`;
- `tests/e2e/smoke.spec.ts`.

The remaining diff is evidence plumbing:

- `.github/workflows/ci.yml` retains the focused screenshot set;
- `tests/e2e/material-instruments.spec.ts` captures closed/open time states plus ordinary/slow/failure navigation states and checks reduced transparency, forced colours, and overflow;
- `tests/e2e/material-system.spec.ts` now treats an empty computed transition duration as zero, removing an inherited evidence-only retry.

## Accessibility and restraint

- reduced transparency removes the glass tint and picker blur;
- forced colours collapse the housing, readout, controls, rail, progress, and status surfaces to system colours;
- no continuous texture animation, pointer tracking, layout-affecting depth, package change, raster asset, or new palette;
- homepage honeycomb work remains outside this branch.

## Evidence

True before set from the evidence-only branch state:

- artifact `material-instrument-screenshots`;
- digest `sha256:151ecc6da80f6d7519a8fd34bd8db6ab0c2b373982653d8458ce1e6349a2defe`.

Final after set on current main:

- [CI run 327](https://github.com/teamleaderleo/scrapbook/actions/runs/30219583239);
- lint, typecheck, unit tests, production build, Chromium, and WebKit passed;
- **118 passed, four intentional skips, zero retries or flakes**;
- material-instrument screenshots: `sha256:c6f6e1715d949203cb237660a3839e53927896f96fe07c6940434ca2a85b477f`;
- Playwright log: `sha256:5ec883b0f6a530218be2f113ced6b6287edd39998be539947fa582153effdd84`.

Visual review covers light/dark mobile and desktop time states, the open picker, ordinary desktop/mobile rails, delayed slow feedback, and actionable failure feedback across Chromium and WebKit.

## Reviews

- Agent 2: progress-rail behaviour fence;
- Agent 3: time-picker behaviour fence;
- Agent 1: shared visual consistency.

Keep unmerged until the focused reviews land.