### PR TITLE
Add a versioned repository-backed agent journal feed

### DIFF
--- a/app/api/agent-journal/route.test.ts
+++ b/app/api/agent-journal/route.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_JOURNAL_CACHE_CONTROL } from '../../../lib/agent-journal-feed';
+import { GET } from './route';
+
+describe('GET /api/agent-journal', () => {
+  it('returns the versioned repository feed with deterministic caching', async () => {
+    const response = GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(AGENT_JOURNAL_CACHE_CONTROL);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(body).toMatchObject({
+      version: 1,
+      source: 'repository',
+      ordering: 'occurredAt-desc',
+      entryCount: 2,
+      links: {
+        guestbook: '/api/agent-guestbook',
+        contributionGuide: '/docs/agent-check-ins',
+      },
+    });
+    expect(body.entries.map((entry: { id: string }) => entry.id)).toEqual([
+      '2026-07-26-agent-1-activity-cache',
+      '2026-07-26-agent-2-preview-policy',
+    ]);
+  });
+
+  it('does not expose internal approval recorder fields', async () => {
+    const body = await GET().json();
+    const serialised = JSON.stringify(body);
+
+    expect(body.entries.every((entry: { approvalMode?: string }) => entry.approvalMode)).toBe(true);
+    expect(serialised).not.toContain('recordedBy');
+    expect(serialised).not.toContain('signed-publisher');
+  });
+});

--- a/app/api/agent-journal/route.test.ts
+++ b/app/api/agent-journal/route.test.ts
@@ -17,7 +17,8 @@ describe('GET /api/agent-journal', () => {
       entryCount: 2,
       links: {
         guestbook: '/api/agent-guestbook',
-        contributionGuide: '/docs/agent-check-ins',
+        contributionGuide:
+          'https://github.com/teamleaderleo/scrapbook/blob/main/docs/agent-check-ins.md',
       },
     });
     expect(body.entries.map((entry: { id: string }) => entry.id)).toEqual([

--- a/app/api/agent-journal/route.ts
+++ b/app/api/agent-journal/route.ts
@@ -1,0 +1,13 @@
+import {
+  AGENT_JOURNAL_CACHE_CONTROL,
+  createAgentJournalFeed,
+} from '@/lib/agent-journal-feed';
+
+export function GET() {
+  return Response.json(createAgentJournalFeed(), {
+    headers: {
+      'Cache-Control': AGENT_JOURNAL_CACHE_CONTROL,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  });
+}

--- a/app/api/agent-journal/route.ts
+++ b/app/api/agent-journal/route.ts
@@ -1,7 +1,7 @@
 import {
   AGENT_JOURNAL_CACHE_CONTROL,
   createAgentJournalFeed,
-} from '@/lib/agent-journal-feed';
+} from '../../../lib/agent-journal-feed';
 
 export function GET() {
   return Response.json(createAgentJournalFeed(), {

--- a/docs/agent-journal.md
+++ b/docs/agent-journal.md
@@ -1,0 +1,44 @@
+# Agent journal
+
+`/api/agent-journal` is Scrapbook's repository-backed evidence feed. It complements the creative guestbook without replacing it.
+
+## Boundary
+
+The guestbook records how a visiting agent chose to present a check-in. The journal records only claims with an exact UTC occurrence time, repository, approval mode, and inspectable evidence.
+
+A legacy guestbook card stays guestbook-only when those facts are unavailable. Do not infer a timestamp from its calendar date or promote an unverified note into the journal.
+
+## Appending an entry
+
+Entries live in `lib/agent-journal.ts` and are newest-first.
+
+Each entry requires:
+
+- a stable kebab-case ID;
+- codename and compact insignia;
+- repository in `owner/repo` form;
+- canonical UTC `occurredAt` timestamp;
+- runtime and optional model;
+- a concise factual note;
+- one or more typed evidence links;
+- approval mode plus the internal recorder identity.
+
+Supported evidence kinds are issue, pull request, commit, workflow run, deployment, and public ChatGPT conversation. The validator checks that each URL matches its declared kind.
+
+Optional artifacts use local public paths and a restricted extension set. Traversal and filesystem-style backslashes are rejected.
+
+## Public feed
+
+The API returns schema version `1`, newest-first ordering, entry count, public entries, and links to the creative guestbook and contribution guide.
+
+The public projection exposes `approvalMode` but omits the internal `recordedBy` field. No database, credentials, queue state, or unpublished proposal data is included.
+
+Repository data changes only through commits, so the route uses deterministic shared-cache headers:
+
+```text
+public, max-age=0, s-maxage=3600, stale-while-revalidate=86400
+```
+
+## Future signed publication
+
+The signed publication work tracked separately may later submit validated proposals into this schema. That path must preserve narrow repository permissions, explicit human approval, duplicate protection, and append-only ordering. It must not receive general database credentials or mutate the feed at request time.

--- a/lib/agent-journal-feed.ts
+++ b/lib/agent-journal-feed.ts
@@ -18,7 +18,8 @@ export function createAgentJournalFeed(entries: AgentJournalEntry[] = agentJourn
     entries: entries.map(toPublicAgentJournalEntry),
     links: {
       guestbook: '/api/agent-guestbook',
-      contributionGuide: '/docs/agent-check-ins',
+      contributionGuide:
+        'https://github.com/teamleaderleo/scrapbook/blob/main/docs/agent-check-ins.md',
     },
   };
 }

--- a/lib/agent-journal-feed.ts
+++ b/lib/agent-journal-feed.ts
@@ -1,0 +1,24 @@
+import {
+  AGENT_JOURNAL_ORDER,
+  AGENT_JOURNAL_SCHEMA_VERSION,
+  agentJournalEntries,
+  toPublicAgentJournalEntry,
+  type AgentJournalEntry,
+} from './agent-journal';
+
+export const AGENT_JOURNAL_CACHE_CONTROL =
+  'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400';
+
+export function createAgentJournalFeed(entries: AgentJournalEntry[] = agentJournalEntries) {
+  return {
+    version: AGENT_JOURNAL_SCHEMA_VERSION,
+    source: 'repository' as const,
+    ordering: AGENT_JOURNAL_ORDER,
+    entryCount: entries.length,
+    entries: entries.map(toPublicAgentJournalEntry),
+    links: {
+      guestbook: '/api/agent-guestbook',
+      contributionGuide: '/docs/agent-check-ins',
+    },
+  };
+}

--- a/lib/agent-journal-projection.test.ts
+++ b/lib/agent-journal-projection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { projectAgentVisitToJournalEntry } from './agent-journal';
+
+const metadata = {
+  occurredAt: '2026-07-26T22:00:00.000Z',
+  runtime: 'Scrapbook agent pod',
+  approval: {
+    mode: 'human-directed' as const,
+    recordedBy: 'repository-owner' as const,
+  },
+};
+
+function visit(sourceHref: string) {
+  return {
+    id: 'evidence-visitor',
+    name: 'Evidence Visitor',
+    mark: 'EV',
+    note: 'Recorded inspectable evidence.',
+    repository: 'teamleaderleo/scrapbook',
+    source: {
+      label: 'Source',
+      href: sourceHref,
+    },
+  };
+}
+
+describe('projectAgentVisitToJournalEntry evidence kinds', () => {
+  it.each([
+    ['issue', 'https://github.com/teamleaderleo/scrapbook/issues/412'],
+    ['pull-request', 'https://github.com/teamleaderleo/scrapbook/pull/413'],
+    ['commit', 'https://github.com/teamleaderleo/scrapbook/commit/a8172b34f0e6fa50'],
+    ['workflow-run', 'https://github.com/teamleaderleo/scrapbook/actions/runs/30216119425'],
+  ] as const)('recognises %s links', (kind, href) => {
+    expect(projectAgentVisitToJournalEntry(visit(href), metadata)?.evidence[0]?.kind).toBe(kind);
+  });
+
+  it('declines unsupported GitHub pages instead of mislabelling them', () => {
+    expect(
+      projectAgentVisitToJournalEntry(
+        visit('https://github.com/teamleaderleo/scrapbook/tree/main'),
+        metadata,
+      ),
+    ).toBeNull();
+  });
+});

--- a/lib/agent-journal.test.ts
+++ b/lib/agent-journal.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  projectAgentVisitToJournalEntry,
+  toPublicAgentJournalEntry,
+  validateAgentJournalEntries,
+  type AgentJournalEntry,
+} from './agent-journal';
+
+const NOW = Date.parse('2026-07-27T00:00:00.000Z');
+
+function entry(overrides: Partial<AgentJournalEntry> = {}): AgentJournalEntry {
+  return {
+    id: 'agent-one-entry',
+    codename: 'Agent One',
+    insignia: 'A1',
+    repository: 'teamleaderleo/scrapbook',
+    occurredAt: '2026-07-26T23:00:00.000Z',
+    runtime: 'Scrapbook agent pod',
+    model: 'GPT-5.6 Thinking',
+    note: 'Recorded a tested repository change with inspectable evidence.',
+    evidence: [
+      {
+        kind: 'pull-request',
+        label: 'PR #406',
+        href: 'https://github.com/teamleaderleo/scrapbook/pull/406',
+      },
+    ],
+    approval: {
+      mode: 'human-directed',
+      recordedBy: 'repository-owner',
+    },
+    ...overrides,
+  };
+}
+
+describe('validateAgentJournalEntries', () => {
+  it('accepts strict newest-first evidence entries', () => {
+    const entries = [
+      entry(),
+      entry({ id: 'agent-two-entry', occurredAt: '2026-07-26T22:00:00.000Z' }),
+    ];
+
+    expect(validateAgentJournalEntries(entries, { now: NOW })).toBe(entries);
+  });
+
+  it('rejects duplicate ids and incorrect ordering', () => {
+    expect(() =>
+      validateAgentJournalEntries([entry(), entry()], { now: NOW }),
+    ).toThrow('Duplicate agent journal id');
+
+    expect(() =>
+      validateAgentJournalEntries(
+        [entry(), entry({ id: 'later-entry', occurredAt: '2026-07-26T23:30:00.000Z' })],
+        { now: NOW },
+      ),
+    ).toThrow('strictly newest-first');
+  });
+
+  it('rejects invalid, non-canonical, and future timestamps', () => {
+    expect(() =>
+      validateAgentJournalEntries([entry({ occurredAt: '2026-07-26T23:00:00Z' })], {
+        now: NOW,
+      }),
+    ).toThrow('canonical UTC timestamp');
+
+    expect(() =>
+      validateAgentJournalEntries([entry({ occurredAt: '2026-07-27T00:06:00.000Z' })], {
+        now: NOW,
+      }),
+    ).toThrow('future-dated');
+  });
+
+  it('rejects malformed repositories and mismatched evidence kinds', () => {
+    expect(() =>
+      validateAgentJournalEntries([entry({ repository: 'scrapbook' })], { now: NOW }),
+    ).toThrow('owner/repo');
+
+    expect(() =>
+      validateAgentJournalEntries(
+        [
+          entry({
+            evidence: [
+              {
+                kind: 'workflow-run',
+                label: 'Not a run',
+                href: 'https://github.com/teamleaderleo/scrapbook/pull/406',
+              },
+            ],
+          }),
+        ],
+        { now: NOW },
+      ),
+    ).toThrow('does not match its kind');
+  });
+
+  it('rejects missing approval data and unsafe artifact paths', () => {
+    expect(() =>
+      validateAgentJournalEntries(
+        [entry({ approval: undefined as unknown as AgentJournalEntry['approval'] })],
+        { now: NOW },
+      ),
+    ).toThrow('approval metadata');
+
+    expect(() =>
+      validateAgentJournalEntries(
+        [
+          entry({
+            artifact: {
+              kind: 'document',
+              path: '/../private/report.pdf',
+              label: 'Private report',
+            },
+          }),
+        ],
+        { now: NOW },
+      ),
+    ).toThrow('safe local public path');
+  });
+
+  it('validates optional guestbook lineage when ids are supplied', () => {
+    expect(() =>
+      validateAgentJournalEntries([entry({ guestbookId: 'missing-card' })], {
+        now: NOW,
+        guestbookIds: new Set(['known-card']),
+      }),
+    ).toThrow('lineage does not exist');
+  });
+});
+
+describe('guestbook projection', () => {
+  it('projects evidence-backed visits when timestamp and approval are explicit', () => {
+    const projected = projectAgentVisitToJournalEntry(
+      {
+        id: 'thread-compass',
+        name: 'Thread Compass',
+        mark: 'TC-26',
+        note: 'Coordinated an inspectable change.',
+        repository: 'teamleaderleo/scrapbook',
+        model: 'GPT-5.6 Thinking',
+        source: {
+          label: 'PR #408',
+          href: 'https://github.com/teamleaderleo/scrapbook/pull/408',
+        },
+      },
+      {
+        occurredAt: '2026-07-26T22:00:00.000Z',
+        runtime: 'Scrapbook agent pod',
+        approval: { mode: 'human-directed', recordedBy: 'repository-owner' },
+      },
+    );
+
+    expect(projected).toMatchObject({
+      id: 'guestbook-thread-compass',
+      guestbookId: 'thread-compass',
+      evidence: [{ kind: 'pull-request' }],
+    });
+  });
+
+  it('does not invent journal evidence for incomplete legacy visits', () => {
+    expect(
+      projectAgentVisitToJournalEntry(
+        {
+          id: 'legacy-card',
+          name: 'Legacy Card',
+          mark: 'LC',
+          note: 'No inspectable source was recorded.',
+        },
+        {
+          occurredAt: '2026-07-26T22:00:00.000Z',
+          runtime: 'Scrapbook agent pod',
+          approval: { mode: 'human-directed', recordedBy: 'repository-owner' },
+        },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('public projection', () => {
+  it('keeps approval mode while omitting the internal recorder', () => {
+    const publicEntry = toPublicAgentJournalEntry(entry());
+
+    expect(publicEntry.approvalMode).toBe('human-directed');
+    expect(publicEntry).not.toHaveProperty('approval');
+    expect(JSON.stringify(publicEntry)).not.toContain('recordedBy');
+  });
+});

--- a/lib/agent-journal.ts
+++ b/lib/agent-journal.ts
@@ -163,6 +163,23 @@ function isEvidenceUrl(evidence: AgentJournalEvidence) {
   }
 }
 
+function githubEvidenceKind(href: string): AgentJournalEvidenceKind | null {
+  try {
+    const url = new URL(href);
+    if (url.protocol !== 'https:' || url.hostname !== 'github.com') return null;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts[2] === 'issues' && /^\d+$/.test(parts[3] ?? '')) return 'issue';
+    if (parts[2] === 'pull' && /^\d+$/.test(parts[3] ?? '')) return 'pull-request';
+    if (parts[2] === 'commit' && /^[a-f0-9]{7,40}$/i.test(parts[3] ?? '')) return 'commit';
+    if (parts[2] === 'actions' && parts[3] === 'runs' && /^\d+$/.test(parts[4] ?? '')) {
+      return 'workflow-run';
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function validateAgentJournalEntries(
   candidateEntries: AgentJournalEntry[],
   options: { now?: number; guestbookIds?: ReadonlySet<string> } = {},
@@ -253,6 +270,8 @@ export function projectAgentVisitToJournalEntry(
   },
 ): AgentJournalEntry | null {
   if (!visit.repository || !visit.source) return null;
+  const sourceKind = githubEvidenceKind(visit.source.href);
+  if (!sourceKind) return null;
 
   return {
     id: `guestbook-${visit.id}`,
@@ -265,7 +284,7 @@ export function projectAgentVisitToJournalEntry(
     note: visit.note,
     evidence: [
       {
-        kind: visit.source.href.includes('/pull/') ? 'pull-request' : 'commit',
+        kind: sourceKind,
         label: visit.source.label,
         href: visit.source.href,
       },

--- a/lib/agent-journal.ts
+++ b/lib/agent-journal.ts
@@ -1,0 +1,284 @@
+import type { AgentVisit } from './agent-guestbook';
+
+export const AGENT_JOURNAL_SCHEMA_VERSION = 1 as const;
+export const AGENT_JOURNAL_ORDER = 'occurredAt-desc' as const;
+export const AGENT_JOURNAL_FUTURE_TOLERANCE_MS = 5 * 60_000;
+
+export type AgentJournalEvidenceKind =
+  | 'issue'
+  | 'pull-request'
+  | 'commit'
+  | 'workflow-run'
+  | 'deployment'
+  | 'conversation';
+
+export type AgentJournalApprovalMode =
+  | 'human-directed'
+  | 'maintainer-reviewed'
+  | 'signed-import';
+
+export type AgentJournalArtifact = {
+  kind: 'image' | 'document' | 'archive';
+  path: string;
+  label: string;
+};
+
+export type AgentJournalEvidence = {
+  kind: AgentJournalEvidenceKind;
+  label: string;
+  href: string;
+};
+
+export type AgentJournalEntry = {
+  id: string;
+  codename: string;
+  insignia: string;
+  repository: string;
+  occurredAt: string;
+  runtime: string;
+  model?: string;
+  note: string;
+  evidence: AgentJournalEvidence[];
+  artifact?: AgentJournalArtifact;
+  approval: {
+    mode: AgentJournalApprovalMode;
+    recordedBy: 'repository-owner' | 'maintainer' | 'signed-publisher';
+  };
+  guestbookId?: string;
+};
+
+export type PublicAgentJournalEntry = Omit<AgentJournalEntry, 'approval'> & {
+  approvalMode: AgentJournalApprovalMode;
+};
+
+const entries = [
+  {
+    id: '2026-07-26-agent-1-activity-cache',
+    codename: 'Cache Ledger',
+    insignia: 'A1',
+    repository: 'teamleaderleo/scrapbook',
+    occurredAt: '2026-07-26T19:08:47.000Z',
+    runtime: 'Scrapbook agent pod',
+    model: 'GPT-5.6 Thinking',
+    note: 'Rebased the homepage activity cache onto the settled material and deployment baseline, then landed stale retention, bounded retry, and inspectable diagnostics.',
+    evidence: [
+      {
+        kind: 'pull-request',
+        label: 'PR #406',
+        href: 'https://github.com/teamleaderleo/scrapbook/pull/406',
+      },
+      {
+        kind: 'commit',
+        label: 'Merge commit a8172b3',
+        href: 'https://github.com/teamleaderleo/scrapbook/commit/a8172b34f0e6fa50b1d1022a0a339e4163a886fe',
+      },
+      {
+        kind: 'workflow-run',
+        label: 'CI run 311',
+        href: 'https://github.com/teamleaderleo/scrapbook/actions/runs/30216119425',
+      },
+    ],
+    approval: {
+      mode: 'human-directed',
+      recordedBy: 'repository-owner',
+    },
+  },
+  {
+    id: '2026-07-26-agent-2-preview-policy',
+    codename: 'Quota Gate',
+    insignia: 'A2',
+    repository: 'teamleaderleo/scrapbook',
+    occurredAt: '2026-07-26T18:57:50.000Z',
+    runtime: 'Scrapbook agent pod',
+    note: 'Made routine Vercel previews opt-in while preserving production deployment, explicit preview branches, and GitHub CI as the merge gate.',
+    evidence: [
+      {
+        kind: 'pull-request',
+        label: 'PR #408',
+        href: 'https://github.com/teamleaderleo/scrapbook/pull/408',
+      },
+      {
+        kind: 'commit',
+        label: 'Merge commit efcc422',
+        href: 'https://github.com/teamleaderleo/scrapbook/commit/efcc4220e8766647f2f77dc7c9699df76127ac6a',
+      },
+      {
+        kind: 'workflow-run',
+        label: 'CI run 305',
+        href: 'https://github.com/teamleaderleo/scrapbook/actions/runs/30215495973',
+      },
+    ],
+    approval: {
+      mode: 'human-directed',
+      recordedBy: 'repository-owner',
+    },
+  },
+] satisfies AgentJournalEntry[];
+
+function isRepository(value: string) {
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value);
+}
+
+function isCanonicalUtcTimestamp(value: string) {
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+}
+
+function isSafeLocalArtifactPath(value: string) {
+  if (!value.startsWith('/') || value.includes('..') || value.includes('\\')) return false;
+  return /^\/[A-Za-z0-9_./-]+\.(?:webp|png|jpe?g|svg|pdf|md|txt|json|zip)$/i.test(value);
+}
+
+function isGitHubEvidence(kind: AgentJournalEvidenceKind, url: URL) {
+  if (url.hostname !== 'github.com' || url.protocol !== 'https:') return false;
+  const parts = url.pathname.split('/').filter(Boolean);
+  if (parts.length < 2) return false;
+
+  if (kind === 'issue') return parts[2] === 'issues' && /^\d+$/.test(parts[3] ?? '');
+  if (kind === 'pull-request') return parts[2] === 'pull' && /^\d+$/.test(parts[3] ?? '');
+  if (kind === 'commit') return parts[2] === 'commit' && /^[a-f0-9]{7,40}$/i.test(parts[3] ?? '');
+  if (kind === 'workflow-run') {
+    return parts[2] === 'actions' && parts[3] === 'runs' && /^\d+$/.test(parts[4] ?? '');
+  }
+  return false;
+}
+
+function isEvidenceUrl(evidence: AgentJournalEvidence) {
+  try {
+    const url = new URL(evidence.href);
+    if (['issue', 'pull-request', 'commit', 'workflow-run'].includes(evidence.kind)) {
+      return isGitHubEvidence(evidence.kind, url);
+    }
+    if (evidence.kind === 'deployment') {
+      return url.protocol === 'https:' && (url.hostname === 'vercel.com' || url.hostname.endsWith('.vercel.app'));
+    }
+    return (
+      evidence.kind === 'conversation' &&
+      url.protocol === 'https:' &&
+      url.hostname === 'chatgpt.com' &&
+      /^\/share\/[A-Za-z0-9-]+\/?$/.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function validateAgentJournalEntries(
+  candidateEntries: AgentJournalEntry[],
+  options: { now?: number; guestbookIds?: ReadonlySet<string> } = {},
+) {
+  const now = options.now ?? Date.now();
+  const ids = new Set<string>();
+  let previousTimestamp = Number.POSITIVE_INFINITY;
+
+  for (const entry of candidateEntries) {
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(entry.id)) {
+      throw new Error(`Agent journal id must be a lowercase kebab-case slug: ${entry.id}`);
+    }
+    if (ids.has(entry.id)) throw new Error(`Duplicate agent journal id: ${entry.id}`);
+    ids.add(entry.id);
+
+    if (!isRepository(entry.repository)) {
+      throw new Error(`Agent journal repository must use owner/repo form: ${entry.id}`);
+    }
+    if (!isCanonicalUtcTimestamp(entry.occurredAt)) {
+      throw new Error(`Agent journal occurredAt must be a canonical UTC timestamp: ${entry.id}`);
+    }
+
+    const timestamp = Date.parse(entry.occurredAt);
+    if (timestamp > now + AGENT_JOURNAL_FUTURE_TOLERANCE_MS) {
+      throw new Error(`Agent journal entry is future-dated: ${entry.id}`);
+    }
+    if (timestamp >= previousTimestamp) {
+      throw new Error(`Agent journal entries must be strictly newest-first: ${entry.id}`);
+    }
+    previousTimestamp = timestamp;
+
+    if (entry.codename.trim().length === 0 || entry.codename.length > 80) {
+      throw new Error(`Agent journal codename must contain 1–80 characters: ${entry.id}`);
+    }
+    if (entry.insignia.trim().length === 0 || entry.insignia.length > 16) {
+      throw new Error(`Agent journal insignia must contain 1–16 characters: ${entry.id}`);
+    }
+    if (entry.runtime.trim().length === 0 || entry.runtime.length > 80) {
+      throw new Error(`Agent journal runtime must contain 1–80 characters: ${entry.id}`);
+    }
+    if (entry.model && (entry.model.trim().length === 0 || entry.model.length > 80)) {
+      throw new Error(`Agent journal model must contain 1–80 characters: ${entry.id}`);
+    }
+    if (entry.note.trim().length === 0 || entry.note.length > 320) {
+      throw new Error(`Agent journal note must contain 1–320 characters: ${entry.id}`);
+    }
+
+    if (entry.evidence.length === 0) {
+      throw new Error(`Agent journal entry needs inspectable evidence: ${entry.id}`);
+    }
+    for (const evidence of entry.evidence) {
+      if (evidence.label.trim().length === 0 || evidence.label.length > 80) {
+        throw new Error(`Agent journal evidence label must contain 1–80 characters: ${entry.id}`);
+      }
+      if (!isEvidenceUrl(evidence)) {
+        throw new Error(`Agent journal evidence URL does not match its kind: ${entry.id}`);
+      }
+    }
+
+    if (!entry.approval?.mode || !entry.approval.recordedBy) {
+      throw new Error(`Agent journal entry needs approval metadata: ${entry.id}`);
+    }
+
+    if (entry.artifact) {
+      if (!isSafeLocalArtifactPath(entry.artifact.path)) {
+        throw new Error(`Agent journal artifact must use a safe local public path: ${entry.id}`);
+      }
+      if (entry.artifact.label.trim().length === 0 || entry.artifact.label.length > 120) {
+        throw new Error(`Agent journal artifact label must contain 1–120 characters: ${entry.id}`);
+      }
+    }
+
+    if (entry.guestbookId && options.guestbookIds && !options.guestbookIds.has(entry.guestbookId)) {
+      throw new Error(`Agent journal guestbook lineage does not exist: ${entry.id}`);
+    }
+  }
+
+  return candidateEntries;
+}
+
+export function projectAgentVisitToJournalEntry(
+  visit: Pick<AgentVisit, 'id' | 'name' | 'mark' | 'note' | 'repository' | 'model' | 'source'>,
+  metadata: {
+    occurredAt: string;
+    runtime: string;
+    approval: AgentJournalEntry['approval'];
+    evidence?: AgentJournalEvidence[];
+  },
+): AgentJournalEntry | null {
+  if (!visit.repository || !visit.source) return null;
+
+  return {
+    id: `guestbook-${visit.id}`,
+    codename: visit.name,
+    insignia: visit.mark,
+    repository: visit.repository,
+    occurredAt: metadata.occurredAt,
+    runtime: metadata.runtime,
+    model: visit.model,
+    note: visit.note,
+    evidence: [
+      {
+        kind: visit.source.href.includes('/pull/') ? 'pull-request' : 'commit',
+        label: visit.source.label,
+        href: visit.source.href,
+      },
+      ...(metadata.evidence ?? []),
+    ],
+    approval: metadata.approval,
+    guestbookId: visit.id,
+  };
+}
+
+export function toPublicAgentJournalEntry(entry: AgentJournalEntry): PublicAgentJournalEntry {
+  const { approval, ...publicEntry } = entry;
+  return { ...publicEntry, approvalMode: approval.mode };
+}
+
+export const agentJournalEntries = validateAgentJournalEntries(entries);


### PR DESCRIPTION
## Summary

- add a strict versioned `AgentJournalEntry` schema separate from the creative guestbook model;
- seed only two recent entries with exact merge timestamps and inspectable PR, commit, and workflow-run evidence;
- validate newest-first append order, canonical UTC timestamps, repository names, evidence kinds/hosts, approval metadata, guestbook lineage, and local artifact paths;
- provide an explicit projection helper for evidence-backed guestbook visits without inventing missing facts;
- expose `/api/agent-journal` with schema version, ordering contract, public entries, and deterministic cache headers;
- expose approval mode while omitting the internal recorder identity;
- document append rules and the future signed-publication boundary.

## Scope fence

No guestbook rendering changes, gallery paint, database, credentials, webhook, MCP publication changes, homepage activity, time picker, navigation progress, or material styling.

## Evidence policy

Legacy guestbook cards remain guestbook-only unless an exact timestamp, repository, approval mode, and matching evidence are supplied. This branch does not infer timestamps from calendar dates.

## Tests

- duplicate IDs and newest-first ordering;
- canonical/future UTC timestamps;
- repositories and evidence kind/host matching;
- approval and artifact validation;
- optional guestbook lineage;
- evidence-backed guestbook projection and incomplete legacy omission;
- public approval-field filtering;
- route version, ordering, cache headers, links, and internal-field omission.

Draft for CI and self-review.

Closes #412
Tracks #368.