### PR TITLE
Render the agent journal as an inspectable surface

### DIFF
--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -1,0 +1,242 @@
+import ViewportPageShell from '@/components/viewport-page-shell';
+import {
+  agentJournalEntries,
+  type AgentJournalApprovalMode,
+  type AgentJournalEvidenceKind,
+} from '@/lib/agent-journal';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Agent journal',
+  description: 'Evidence-backed execution records from the Scrapbook agent pod.',
+  alternates: { canonical: '/journal' },
+};
+
+const contributionGuideUrl =
+  'https://github.com/teamleaderleo/scrapbook/blob/main/docs/agent-journal.md';
+
+const evidenceKindLabels: Record<AgentJournalEvidenceKind, string> = {
+  issue: 'Issue',
+  'pull-request': 'Pull request',
+  commit: 'Commit',
+  'workflow-run': 'Workflow run',
+  deployment: 'Deployment',
+  conversation: 'Conversation',
+};
+
+const approvalLabels: Record<AgentJournalApprovalMode, string> = {
+  'human-directed': 'Human directed',
+  'maintainer-reviewed': 'Maintainer reviewed',
+  'signed-import': 'Signed import',
+};
+
+function formatOccurredAt(value: string) {
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+    hour12: false,
+  }).format(new Date(value));
+}
+
+export default function AgentJournalPage() {
+  return (
+    <ViewportPageShell
+      className="bg-background text-foreground"
+      contentClassName="relative min-h-[calc(100dvh-3rem)] overflow-x-hidden"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-18"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(54,48,40,0.045) 1px, transparent 1px), linear-gradient(90deg, rgba(54,48,40,0.045) 1px, transparent 1px)',
+          backgroundSize: '24px 24px',
+        }}
+      />
+
+      <main className="relative mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
+        <header className="overflow-hidden rounded-[1.4rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.1)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.32)]">
+          <div className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.38fr)] lg:items-end">
+            <div>
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.19em] text-muted-foreground">
+                Repository-backed record
+              </p>
+              <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">Agent journal</h1>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+                Execution notes with exact timestamps, approval modes, and inspectable evidence. Creative visitor cards remain in the gallery; this ledger records work that can be checked.
+              </p>
+            </div>
+
+            <div className="grid gap-2 rounded-xl border border-border/65 bg-background/45 p-4 font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground">
+              <p>
+                <span className="text-foreground">{agentJournalEntries.length}</span>{' '}
+                {agentJournalEntries.length === 1 ? 'entry' : 'entries'}
+              </p>
+              <p>Newest first · UTC</p>
+              <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2">
+                <a
+                  href="/api/agent-journal"
+                  className="rounded-sm underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  JSON feed
+                </a>
+                <a
+                  href={contributionGuideUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="rounded-sm underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Append guide
+                </a>
+                <Link
+                  href="/gallery"
+                  className="rounded-sm underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Guestbook
+                </Link>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section aria-labelledby="journal-records-heading" className="mt-5">
+          <div className="flex items-end justify-between gap-4 px-1">
+            <div>
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Evidence ledger
+              </p>
+              <h2 id="journal-records-heading" className="mt-1 text-xl font-semibold tracking-tight">
+                Recorded work
+              </h2>
+            </div>
+            <p className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+              Native disclosures
+            </p>
+          </div>
+
+          <ol className="mt-3 grid gap-4">
+            {agentJournalEntries.map((entry, index) => (
+              <li key={entry.id} data-journal-entry={entry.id}>
+                <article className="relative overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground shadow-[0_12px_34px_rgba(24,24,26,0.08)] dark:shadow-[0_14px_38px_rgba(0,0,0,0.26)]">
+                  <div
+                    aria-hidden="true"
+                    className="absolute inset-y-0 left-0 w-1.5 bg-foreground/75"
+                  />
+                  <div className="grid min-w-0 gap-5 p-4 pl-6 sm:p-5 sm:pl-7 lg:grid-cols-[minmax(0,1fr)_15rem]">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="rounded-md border border-border/70 bg-background/45 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em]">
+                          {entry.insignia}
+                        </span>
+                        <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+                          Record {String(index + 1).padStart(2, '0')}
+                        </span>
+                        <span className="rounded-full border border-border/65 bg-background/35 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground">
+                          {approvalLabels[entry.approval.mode]}
+                        </span>
+                      </div>
+
+                      <h3 className="mt-4 text-xl font-semibold tracking-tight">{entry.codename}</h3>
+                      <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{entry.note}</p>
+
+                      <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+                        <div className="min-w-0 rounded-lg border border-border/60 bg-background/35 p-3">
+                          <dt className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+                            Repository
+                          </dt>
+                          <dd className="mt-1 break-all font-mono text-xs text-foreground">{entry.repository}</dd>
+                        </div>
+                        <div className="min-w-0 rounded-lg border border-border/60 bg-background/35 p-3">
+                          <dt className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+                            Runtime
+                          </dt>
+                          <dd className="mt-1 text-xs text-foreground">
+                            {[entry.runtime, entry.model].filter(Boolean).join(' · ')}
+                          </dd>
+                        </div>
+                      </dl>
+                    </div>
+
+                    <div className="flex min-w-0 flex-col gap-3 lg:border-l lg:border-dashed lg:border-border/70 lg:pl-5">
+                      <div>
+                        <p className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+                          Occurred
+                        </p>
+                        <time
+                          dateTime={entry.occurredAt}
+                          className="mt-1 block font-mono text-xs font-semibold text-foreground"
+                        >
+                          {formatOccurredAt(entry.occurredAt)} UTC
+                        </time>
+                      </div>
+
+                      <p className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+                        {entry.evidence.length} evidence {entry.evidence.length === 1 ? 'item' : 'items'}
+                      </p>
+
+                      {entry.guestbookId ? (
+                        <Link
+                          href={`/gallery#visit-${entry.guestbookId}`}
+                          className="w-fit rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          Guestbook lineage
+                        </Link>
+                      ) : null}
+
+                      {entry.artifact ? (
+                        <a
+                          href={entry.artifact.path}
+                          className="w-fit rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          {entry.artifact.label}
+                        </a>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <details className="group border-t border-border/70 bg-background/32" data-journal-provenance>
+                    <summary className="cursor-pointer list-none px-6 py-3 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground marker:hidden hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+                      <span className="inline-flex items-center gap-2">
+                        <span aria-hidden="true" className="inline-block w-3 text-center group-open:rotate-90">
+                          ▸
+                        </span>
+                        Inspect provenance
+                      </span>
+                    </summary>
+                    <div className="border-t border-border/60 px-6 py-4">
+                      <ul className="grid gap-2">
+                        {entry.evidence.map((evidence) => (
+                          <li
+                            key={`${entry.id}-${evidence.kind}-${evidence.href}`}
+                            className="flex min-w-0 flex-col gap-1 rounded-lg border border-border/60 bg-card/75 p-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                          >
+                            <div className="min-w-0">
+                              <p className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
+                                {evidenceKindLabels[evidence.kind]}
+                              </p>
+                              <p className="mt-1 break-words text-sm text-foreground">{evidence.label}</p>
+                            </div>
+                            <a
+                              href={evidence.href}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="w-fit shrink-0 rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            >
+                              Open evidence
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </details>
+                </article>
+              </li>
+            ))}
+          </ol>
+        </section>
+      </main>
+    </ViewportPageShell>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,6 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/time`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/blog`, changeFrequency: 'monthly', priority: 0.7 },
     { url: `${BASE_URL}/gallery`, changeFrequency: 'monthly', priority: 0.5 },
+    { url: `${BASE_URL}/journal`, changeFrequency: 'weekly', priority: 0.5 },
     { url: `${BASE_URL}/atelier`, changeFrequency: 'monthly', priority: 0.4 },
   ];
 }

--- a/components/gallery/guestbook-arrival-shelf.tsx
+++ b/components/gallery/guestbook-arrival-shelf.tsx
@@ -4,6 +4,9 @@ import {
   agentVisitStylePresets,
 } from '@/lib/agent-guestbook-creative';
 
+const arrivalLinkClassName =
+  'inline-flex rounded-full border border-border/70 bg-background/45 px-3 py-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
 export function GuestbookArrivalShelf() {
   return (
     <section
@@ -22,12 +25,14 @@ export function GuestbookArrivalShelf() {
             There is no house style. A visitor can make a careful field note, a ridiculous mascot, a bad car selfie,
             a soft painted card, or something nobody has tried here yet. The source record still needs to be real.
           </p>
-          <a
-            href="/api/agent-guestbook"
-            className="mt-5 inline-flex rounded-full border border-border/70 bg-background/45 px-3 py-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            Agent options JSON
-          </a>
+          <div className="mt-5 flex flex-wrap gap-2">
+            <a href="/api/agent-guestbook" className={arrivalLinkClassName}>
+              Agent options JSON
+            </a>
+            <a href="/journal" className={arrivalLinkClassName}>
+              Open evidence journal
+            </a>
+          </div>
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">

--- a/tests/e2e/agent-journal.spec.ts
+++ b/tests/e2e/agent-journal.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+test('agent journal renders repository records newest first with inspectable provenance', async ({ page }) => {
+  await page.goto('/journal');
+
+  await expect(page.getByRole('heading', { name: 'Agent journal', exact: true })).toBeVisible();
+  await expect(page.getByText('2 entries', { exact: true })).toBeVisible();
+
+  const entries = page.locator('[data-journal-entry]');
+  await expect(entries).toHaveCount(2);
+  await expect(entries.nth(0)).toHaveAttribute('data-journal-entry', '2026-07-26-agent-1-activity-cache');
+  await expect(entries.nth(1)).toHaveAttribute('data-journal-entry', '2026-07-26-agent-2-preview-policy');
+
+  const first = entries.first();
+  await expect(first.getByRole('heading', { name: 'Cache Ledger', exact: true })).toBeVisible();
+  await expect(first.getByText('Human directed', { exact: true })).toBeVisible();
+  await expect(first.getByText('26 Jul 2026, 19:08 UTC', { exact: true })).toBeVisible();
+  await expect(first.getByText('3 evidence items', { exact: true })).toBeVisible();
+
+  const disclosure = first.locator('details[data-journal-provenance]');
+  await expect(disclosure).not.toHaveAttribute('open', '');
+  await disclosure.locator('summary').click();
+  await expect(disclosure).toHaveAttribute('open', '');
+
+  const evidenceLinks = disclosure.getByRole('link', { name: 'Open evidence' });
+  await expect(evidenceLinks).toHaveCount(3);
+  await expect(evidenceLinks.nth(0)).toHaveAttribute(
+    'href',
+    'https://github.com/teamleaderleo/scrapbook/pull/406',
+  );
+  await expect(evidenceLinks.nth(0)).toHaveAttribute('target', '_blank');
+  await expect(evidenceLinks.nth(0)).toHaveAttribute('rel', /noreferrer/);
+
+  await expect(page.locator('body')).not.toContainText('recordedBy');
+  await expect(page.locator('body')).not.toContainText('repository-owner');
+});
+
+test('gallery links to the evidence journal without changing the guestbook wall', async ({ page }) => {
+  await page.goto('/gallery');
+
+  const journalLink = page.getByRole('link', { name: 'Open evidence journal', exact: true });
+  await expect(journalLink).toHaveAttribute('href', '/journal');
+  await expect(page.locator('[data-agent-visit]')).not.toHaveCount(0);
+});
+
+test('agent journal remains within a narrow mobile viewport', async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 640 });
+  await page.goto('/journal');
+
+  await expect(page.getByRole('heading', { name: 'Agent journal', exact: true })).toBeVisible();
+  const dimensions = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    viewportWidth: window.innerWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
+});
+
+test('native provenance disclosure works without JavaScript', async ({ browser }) => {
+  const context = await browser.newContext({ javaScriptEnabled: false });
+  const page = await context.newPage();
+
+  await page.goto('/journal');
+  const first = page.locator('[data-journal-entry]').first();
+  const disclosure = first.locator('details[data-journal-provenance]');
+
+  await disclosure.locator('summary').click();
+  await expect(disclosure).toHaveAttribute('open', '');
+  await expect(disclosure.getByRole('link', { name: 'Open evidence' })).toHaveCount(3);
+
+  await context.close();
+});


### PR DESCRIPTION
## Summary

- add a standalone server-rendered `/journal` route backed directly by `agentJournalEntries`;
- present evidence-backed work as restrained records, separate from creative guestbook card styling;
- expose exact UTC occurrence time, repository, runtime/model, public approval mode, and evidence totals;
- use native `<details>` provenance disclosures so inspection works without client JavaScript;
- list every evidence item with kind, label, and safely configured external link;
- support optional guestbook lineage and local artifacts when entries provide them;
- link the gallery arrival shelf to the evidence journal;
- add `/journal` to the sitemap.

## Scope fence

No Space, tactile-lab, time-picker, navigation-progress, homepage activity, shared material tokens, or guestbook card rendering changes.

## Tests

- strict newest-first entry order;
- visible UTC timestamps and approval modes;
- native disclosure open state;
- evidence count, destination, target, and rel attributes;
- omission of internal approval recorder fields;
- gallery discovery link;
- 360 px mobile overflow;
- provenance disclosure with JavaScript disabled.

Draft for CI and self-review.

Closes #415
Tracks #368.