### PR TITLE
Integrate the present-first homepage honeycomb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
           name: homepage-density-screenshots
           path: test-results/homepage-density
           if-no-files-found: ignore
+      - name: Upload homepage honeycomb screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: homepage-honeycomb-screenshots
+          path: test-results/homepage-honeycomb
+          if-no-files-found: ignore
       - name: Upload material study screenshots
         if: always()
         uses: actions/upload-artifact@v4

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,10 +1,36 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  EngravedLabel,
+  HardwareScrew,
+  InsetSeam,
+  MaterialSurface,
+} from '@/components/material/material-primitives';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+} from 'react';
 
 export type ActivityGridDay = {
   date: string;
   count: number;
+};
+
+type HoneycombPosition = {
+  row: number;
+  column: number;
+  style: CSSProperties;
+};
+
+const FIELD_STYLE: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(13, 22px)',
+  gridTemplateRows: 'repeat(5, 38px)',
+  width: 286,
+  height: 196,
 };
 
 function formatDay(date: string): string {
@@ -16,14 +42,22 @@ function formatDay(date: string): string {
   }).format(new Date(`${date}T00:00:00Z`));
 }
 
+function formatCompactDay(date: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
 function activityClass(count: number, maximum: number): string {
-  const base = 'ring-1 ring-inset ring-black/[0.07] dark:ring-white/[0.1]';
-  if (count === 0) return `${base} bg-[#c5c1b8] dark:bg-[#303238]`;
+  const base = 'ring-1 ring-inset ring-black/[0.08] dark:ring-white/[0.12]';
+  if (count === 0) return `${base} bg-[#c8c4bb] dark:bg-[#303238]`;
 
   const ratio = maximum === 0 ? 0 : count / maximum;
-  if (ratio > 0.8) return `${base} bg-[#f7f2e9] dark:bg-[#eeeaf2]`;
-  if (ratio > 0.55) return `${base} bg-[#e4dce9] dark:bg-[#c9c2d0]`;
-  if (ratio > 0.3) return `${base} bg-[#cec4d6] dark:bg-[#918a9b]`;
+  if (ratio > 0.8) return `${base} bg-[#f8f3e9] dark:bg-[#eeeaf2]`;
+  if (ratio > 0.55) return `${base} bg-[#e6ddea] dark:bg-[#c9c2d0]`;
+  if (ratio > 0.3) return `${base} bg-[#cec4d7] dark:bg-[#918a9b]`;
   if (ratio > 0.12) return `${base} bg-[#b7adbf] dark:bg-[#696270]`;
   return `${base} bg-[#9f97a7] dark:bg-[#504a54]`;
 }
@@ -32,32 +66,53 @@ function labelForDay(day: ActivityGridDay, unit: string) {
   return `${formatDay(day.date)} · ${day.count.toLocaleString('en-GB')} ${unit}`;
 }
 
+function honeycombPosition(index: number, total: number): HoneycombPosition {
+  const recencyIndex = total - 1 - index;
+  const row = Math.floor(recencyIndex / 6);
+  const position = recencyIndex % 6;
+  const column = row % 2 === 0 ? position : 5 - position;
+  const trackStart = column * 2 + (row % 2 === 0 ? 1 : 2);
+
+  return {
+    row,
+    column,
+    style: {
+      gridColumn: `${trackStart} / span 2`,
+      gridRowStart: row + 1,
+    },
+  };
+}
+
+function moveFocus(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+  if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
+    return;
+  }
+
+  const field = event.currentTarget.closest<HTMLElement>('[data-home-activity-field]');
+  const buttons = Array.from(
+    field?.querySelectorAll<HTMLButtonElement>('button[data-activity-day]') ?? [],
+  );
+  if (buttons.length === 0) return;
+
+  event.preventDefault();
+  let nextIndex = index;
+  if (event.key === 'Home') nextIndex = 0;
+  if (event.key === 'End') nextIndex = buttons.length - 1;
+  if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') nextIndex = Math.max(0, index - 1);
+  if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+    nextIndex = Math.min(buttons.length - 1, index + 1);
+  }
+  buttons[nextIndex]?.focus();
+}
+
 export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: string }) {
   const maximum = Math.max(...days.map((day) => day.count), 0);
   const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
-  const [tooltipDate, setTooltipDate] = useState<string | null>(null);
-  const [tooltipVisible, setTooltipVisible] = useState(false);
-  const [finePointer, setFinePointer] = useState(false);
+  const [interactive, setInteractive] = useState(false);
   const previousLatest = useRef(days.at(-1)?.date ?? '');
-  const hideTimer = useRef<number | null>(null);
-  const positionFrame = useRef<number | null>(null);
-  const pendingPosition = useRef({ x: 12, y: 12 });
 
   useEffect(() => {
-    const media = window.matchMedia('(hover: hover) and (pointer: fine)');
-    const update = () => setFinePointer(media.matches);
-    update();
-    media.addEventListener('change', update);
-    return () => media.removeEventListener('change', update);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
-      if (positionFrame.current !== null) window.cancelAnimationFrame(positionFrame.current);
-      document.documentElement.style.removeProperty('--activity-tooltip-x');
-      document.documentElement.style.removeProperty('--activity-tooltip-y');
-    };
+    setInteractive(true);
   }, []);
 
   useEffect(() => {
@@ -71,114 +126,118 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     previousLatest.current = latest;
   }, [days]);
 
-  const selected = days.find((day) => day.date === selectedDate);
-  const tooltipDay = days.find((day) => day.date === tooltipDate);
-  const selectedLabel = useMemo(
-    () => (selected ? labelForDay(selected, unit) : ''),
-    [selected, unit],
-  );
-  const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
-
-  const placeTooltip = (clientX: number, clientY: number) => {
-    pendingPosition.current = {
-      x: Math.min(Math.max(12, window.innerWidth - 300), Math.max(12, clientX + 14)),
-      y: Math.min(Math.max(12, window.innerHeight - 48), Math.max(12, clientY + 14)),
-    };
-
-    if (positionFrame.current !== null) return;
-    positionFrame.current = window.requestAnimationFrame(() => {
-      const { x, y } = pendingPosition.current;
-      document.documentElement.style.setProperty('--activity-tooltip-x', `${x}px`);
-      document.documentElement.style.setProperty('--activity-tooltip-y', `${y}px`);
-      positionFrame.current = null;
-    });
-  };
-
-  const showTooltip = (date: string, clientX: number, clientY: number) => {
-    if (!finePointer) return;
-    if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
-    placeTooltip(clientX, clientY);
-    setTooltipDate(date);
-    setTooltipVisible(true);
-  };
-
-  const hideTooltip = () => {
-    setTooltipVisible(false);
-    if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
-    hideTimer.current = window.setTimeout(() => setTooltipDate(null), 120);
-  };
+  const selected = days.find((day) => day.date === selectedDate) ?? days.at(-1);
 
   return (
-    <section
-      className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-4"
+    <MaterialSurface
+      as="section"
+      material="steel"
+      className="min-w-0 overflow-visible rounded-[1.25rem] border p-3.5 text-foreground sm:p-4"
       data-home-activity-grid
+      data-material-exemplar="activity-honeycomb"
     >
-      <div className="flex items-center justify-between gap-4">
-        <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+      <InsetSeam />
+      <HardwareScrew className="left-2 top-2" />
+      <HardwareScrew className="bottom-2 right-2" />
+
+      <div className="relative z-[2] flex items-center justify-between gap-4 px-1">
+        <EngravedLabel className="text-[9px] font-semibold text-foreground/70">
           28 days · UTC
-        </span>
-        <div className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground" aria-hidden="true">
+        </EngravedLabel>
+        <div
+          className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-foreground/65"
+          aria-hidden="true"
+        >
           <span>less</span>
           <span className="h-2.5 w-2.5 rounded-[3px] bg-[#9f97a7]" />
           <span className="h-2.5 w-2.5 rounded-[3px] bg-[#cec4d6]" />
-          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#f7f2e9] ring-1 ring-inset ring-black/[0.07]" />
+          <span className="h-2.5 w-2.5 rounded-[3px] bg-[#f8f3e9] ring-1 ring-inset ring-black/[0.08]" />
           <span>more</span>
         </div>
       </div>
 
-      <div
-        className="mx-auto mt-3 grid w-full max-w-[25rem] min-w-0 grid-cols-7 gap-2 sm:gap-2.5 [@media(max-height:780px)]:max-w-[24rem]"
-        aria-label="Four weeks of GitHub activity"
-      >
-        {days.map((day, index) => {
-          const label = labelForDay(day, unit);
-          const isSelected = day.date === selected?.date;
-          const isLatest = index === days.length - 1;
-          const tilt = index % 2 === 0 ? 'hover:rotate-[1.5deg]' : 'hover:-rotate-[1.5deg]';
-
-          return (
-            <button
-              key={day.date}
-              type="button"
-              className={`relative aspect-square min-w-0 rounded-[0.6rem] transition-[transform,filter,box-shadow] duration-150 ease-out will-change-transform hover:z-10 hover:-translate-y-1 hover:scale-[1.08] hover:shadow-[0_14px_24px_rgba(35,31,26,0.2)] focus-visible:z-10 focus-visible:-translate-y-1 focus-visible:scale-[1.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:shadow-[0_16px_28px_rgba(0,0,0,0.44)] ${tilt} ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
-              aria-label={label}
-              aria-pressed={isSelected}
-              onPointerEnter={(event) => {
-                setSelectedDate(day.date);
-                showTooltip(day.date, event.clientX, event.clientY);
-              }}
-              onPointerMove={(event) => {
-                if (finePointer) placeTooltip(event.clientX, event.clientY);
-              }}
-              onPointerLeave={hideTooltip}
-              onFocus={(event) => {
-                setSelectedDate(day.date);
-                if (!event.currentTarget.matches(':focus-visible')) return;
-                const rect = event.currentTarget.getBoundingClientRect();
-                showTooltip(day.date, rect.left + rect.width / 2, rect.bottom);
-              }}
-              onBlur={hideTooltip}
-              onClick={() => setSelectedDate(day.date)}
-            />
-          );
-        })}
-      </div>
-
-      <div className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden" aria-live="polite">
-        {selectedLabel}
-      </div>
-
-      {finePointer && tooltipLabel ? (
+      <div className="relative z-[2] mt-2 flex min-w-0 justify-center">
         <div
-          className={`pointer-events-none fixed left-0 top-0 z-[90] whitespace-nowrap rounded-lg border border-border/70 bg-popover/88 px-2.5 py-1.5 font-mono text-[10px] font-semibold text-popover-foreground shadow-[0_8px_24px_rgba(20,20,24,0.2)] backdrop-blur-xl transition-opacity duration-100 ${tooltipVisible ? 'opacity-100' : 'opacity-0'}`}
-          style={{
-            transform:
-              'translate3d(var(--activity-tooltip-x, 12px), var(--activity-tooltip-y, 12px), 0)',
-          }}
+          data-home-activity-field
+          data-layout="honeycomb"
+          data-interactive={interactive ? 'true' : undefined}
+          aria-label="Four weeks of GitHub activity"
+          style={FIELD_STYLE}
         >
-          {tooltipLabel}
+          {days.map((day, index) => {
+            const label = labelForDay(day, unit);
+            const isSelected = day.date === selected?.date;
+            const isToday = index === days.length - 1;
+            const position = honeycombPosition(index, days.length);
+            const alignRight = position.column >= 3;
+            const placeAbove = position.row >= 3;
+
+            return (
+              <button
+                key={day.date}
+                type="button"
+                data-activity-day
+                data-date={day.date}
+                data-today={isToday ? 'true' : undefined}
+                data-selected={isSelected ? 'true' : undefined}
+                aria-label={label}
+                aria-pressed={isSelected}
+                className={`group relative h-11 w-11 shrink-0 transform-gpu touch-manipulation rounded-[0.7rem] outline-none transition-[filter,box-shadow] duration-150 ease-out hover:z-30 hover:brightness-[1.06] hover:shadow-[0_8px_18px_rgba(35,31,26,0.18)] focus-visible:z-30 focus-visible:brightness-[1.06] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-ring dark:hover:shadow-[0_10px_20px_rgba(0,0,0,0.38)] motion-reduce:transition-none ${isSelected ? 'after:pointer-events-none after:absolute after:-inset-[3px] after:z-20 after:rounded-[0.85rem] after:border-2 after:border-foreground' : ''}`}
+                style={position.style}
+                onClick={() => setSelectedDate(day.date)}
+                onKeyDown={(event) => moveFocus(event, index)}
+              >
+                <span
+                  aria-hidden="true"
+                  className={`pointer-events-none absolute inset-0 ${activityClass(day.count, maximum)}`}
+                  style={{
+                    clipPath: 'polygon(25% 4%, 75% 4%, 100% 50%, 75% 96%, 25% 96%, 0 50%)',
+                  }}
+                />
+                {day.count === 0 ? (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute left-1/2 top-1/2 z-10 h-1 w-1 -translate-x-1/2 -translate-y-1/2 rounded-full bg-foreground/35"
+                  />
+                ) : null}
+                {isToday ? (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute right-1 top-1 z-10 h-2 w-2 rounded-full border border-background/80 bg-foreground shadow-[0_0_0_2px_rgba(255,255,255,0.35)] dark:shadow-[0_0_0_2px_rgba(0,0,0,0.35)]"
+                  />
+                ) : null}
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none fixed z-[90] hidden whitespace-nowrap rounded-lg border border-border/70 bg-popover/92 px-2.5 py-1.5 font-mono text-[10px] font-semibold text-popover-foreground opacity-0 shadow-[0_8px_24px_rgba(20,20,24,0.2)] backdrop-blur-xl transition-opacity duration-100 group-hover:block group-hover:opacity-100 group-focus-visible:block group-focus-visible:opacity-100 motion-reduce:transition-none [@media(pointer:coarse)]:!hidden"
+                  style={{
+                    ...(alignRight ? { right: 0 } : { left: 0 }),
+                    ...(placeAbove ? { bottom: 'calc(100% + 8px)' } : { top: 'calc(100% + 8px)' }),
+                  }}
+                >
+                  {label}
+                </div>
+              </button>
+            );
+          })}
+
+          <MaterialSurface
+            material="slate"
+            className="pointer-events-none z-10 flex min-h-11 min-w-0 flex-col justify-center rounded-[0.58rem] border px-2 py-1 font-mono"
+            data-selected-readout
+            aria-live="polite"
+            aria-atomic="true"
+            aria-label={selected ? labelForDay(selected, unit) : undefined}
+            style={{ gridColumn: '9 / 14', gridRowStart: 5 }}
+          >
+            <span className="truncate text-[8px] font-semibold uppercase tracking-[0.11em] opacity-75">
+              {selected ? formatCompactDay(selected.date) : 'No date'}
+            </span>
+            <span className="truncate text-[10px] font-semibold leading-tight">
+              {selected ? `${selected.count.toLocaleString('en-GB')} ${unit}` : ''}
+            </span>
+          </MaterialSurface>
         </div>
-      ) : null}
-    </section>
+      </div>
+    </MaterialSurface>
   );
 }

--- a/tests/e2e/homepage-activity-honeycomb.spec.ts
+++ b/tests/e2e/homepage-activity-honeycomb.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const route = '/';
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    viewport: document.documentElement.clientWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+
+  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+}
+
+async function activityField(page: Page) {
+  const field = page.locator('[data-home-activity-field]');
+  await expect(field).toHaveAttribute('data-interactive', 'true');
+  return field;
+}
+
+async function activityDates(page: Page) {
+  return page.locator('[data-home-activity-field] [data-activity-day]').evaluateAll((elements) =>
+    elements.map((element) => (element as HTMLElement).dataset.date ?? ''),
+  );
+}
+
+test('keeps chronological DOM order while placing today at the visual origin', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  const response = await page.goto(route);
+  expect(response?.ok()).toBe(true);
+
+  const field = await activityField(page);
+  await expect(field).toHaveAttribute('data-layout', 'honeycomb');
+
+  const dates = await activityDates(page);
+  expect(dates).toHaveLength(28);
+  expect(dates).toEqual([...dates].sort());
+
+  const today = field.locator('[data-today="true"]');
+  await expect(today).toHaveCount(1);
+  await expect(today).toHaveAttribute('data-date', dates.at(-1)!);
+
+  const todayBox = await today.boundingBox();
+  const boxes = await field.locator('[data-activity-day]').evaluateAll((elements) =>
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.x, y: rect.y };
+    }),
+  );
+  expect(todayBox).toBeTruthy();
+  expect(todayBox!.y).toBeCloseTo(Math.min(...boxes.map((box) => box.y)), 0);
+  const topRow = boxes.filter((box) => Math.abs(box.y - todayBox!.y) < 2);
+  expect(todayBox!.x).toBeCloseTo(Math.min(...topRow.map((box) => box.x)), 0);
+});
+
+test('keeps today, selection, keyboard focus, hover, and zero-count marks independent', async ({
+  page,
+}) => {
+  await page.goto(route);
+
+  const field = await activityField(page);
+  const buttons = field.locator('[data-activity-day]');
+  await expect(buttons).toHaveCount(28);
+
+  const selected = buttons.nth(26);
+  const today = buttons.nth(27);
+  await selected.click();
+
+  await expect(selected).toHaveAttribute('aria-pressed', 'true');
+  await expect(today).toHaveAttribute('data-today', 'true');
+  await expect(today).toHaveAttribute('aria-pressed', 'false');
+
+  await buttons.nth(25).focus();
+  await page.keyboard.press('ArrowLeft');
+  const focusedDate = await page.evaluate(
+    () => (document.activeElement as HTMLElement | null)?.dataset.date,
+  );
+  await expect(buttons.nth(24)).toHaveAttribute('data-date', focusedDate!);
+  await expect(buttons.nth(24)).toHaveAttribute('aria-pressed', 'false');
+  await expect(buttons.nth(24)).not.toHaveAttribute('data-today', 'true');
+
+  await page.keyboard.press('Enter');
+  await expect(buttons.nth(24)).toHaveAttribute('aria-pressed', 'true');
+  await expect(today).toHaveAttribute('data-today', 'true');
+
+  await buttons.nth(5).hover();
+  await expect(buttons.nth(24)).toHaveAttribute('aria-pressed', 'true');
+
+  const zeroCount = buttons.filter({ has: page.locator('span.h-1.w-1') }).first();
+  await expect(zeroCount).toBeVisible();
+  await expect(page.locator('[data-selected-readout]')).toBeVisible();
+});
+
+test('preserves 44px targets and natural overflow across compact viewports', async ({ page }) => {
+  for (const viewport of [
+    { width: 360, height: 780 },
+    { width: 390, height: 844 },
+    { width: 740, height: 360 },
+    { width: 820, height: 720 },
+    { width: 860, height: 720 },
+  ]) {
+    await page.setViewportSize(viewport);
+    const response = await page.goto(route);
+    expect(response?.ok()).toBe(true);
+    const field = await activityField(page);
+    await expectNoHorizontalOverflow(page);
+
+    const smallestTarget = await field.locator('[data-activity-day]').evaluateAll((elements) =>
+      Math.min(
+        ...elements.flatMap((element) => {
+          const rect = element.getBoundingClientRect();
+          return [rect.width, rect.height];
+        }),
+      ),
+    );
+    expect(smallestTarget).toBeGreaterThanOrEqual(44);
+  }
+});
+
+test('keeps selection and geometry stable when live activity refreshes', async ({ page }) => {
+  await page.addInitScript(() => {
+    Date.now = () => Date.parse('2030-01-01T00:00:00.000Z');
+  });
+  await page.setViewportSize({ width: 1280, height: 720 });
+  const response = await page.goto(route);
+  expect(response?.ok()).toBe(true);
+
+  const field = await activityField(page);
+  const dates = await activityDates(page);
+  let refreshes = 0;
+  await page.route('**/api/github-activity', async (request) => {
+    refreshes += 1;
+    await request.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        today: 727,
+        weekTotal: 5_068,
+        yearTotal: 18_240,
+        generatedAt: '2030-01-01T00:00:00.000Z',
+        days: dates.map((date, index) => ({ date, count: 700 + index })),
+      }),
+    });
+  });
+
+  const card = page.locator('[data-home-activity-grid]');
+  const selected = field.locator('[data-activity-day]').nth(10);
+  const selectedDate = await selected.getAttribute('data-date');
+  await selected.click();
+  await expect(selected).toHaveAttribute('aria-pressed', 'true');
+
+  const beforeCard = await card.boundingBox();
+  const beforeField = await field.boundingBox();
+  await page.waitForTimeout(3_400);
+
+  expect(refreshes).toBe(1);
+  await expect(field.locator(`[data-date="${selectedDate}"]`)).toHaveAttribute(
+    'aria-pressed',
+    'true',
+  );
+  await expect(field.locator('[data-activity-day]').nth(10)).toHaveAttribute(
+    'aria-label',
+    /710 contributions/,
+  );
+
+  const afterCard = await card.boundingBox();
+  const afterField = await field.boundingBox();
+  expect(beforeCard).toBeTruthy();
+  expect(afterCard).toBeTruthy();
+  expect(beforeField).toBeTruthy();
+  expect(afterField).toBeTruthy();
+  expect(Math.abs(afterCard!.width - beforeCard!.width)).toBeLessThan(1);
+  expect(Math.abs(afterCard!.height - beforeCard!.height)).toBeLessThan(1);
+  expect(Math.abs(afterField!.width - beforeField!.width)).toBeLessThan(1);
+  expect(Math.abs(afterField!.height - beforeField!.height)).toBeLessThan(1);
+});
+
+const evidenceStudies = [
+  { theme: 'light', width: 390, height: 844 },
+  { theme: 'dark', width: 390, height: 844 },
+  { theme: 'light', width: 1366, height: 768 },
+  { theme: 'dark', width: 1440, height: 900 },
+] as const;
+
+for (const study of evidenceStudies) {
+  test(`captures ${study.theme} homepage honeycomb evidence at ${study.width}x${study.height}`, async ({
+    page,
+  }, testInfo) => {
+    await page.setViewportSize({ width: study.width, height: study.height });
+    await page.addInitScript((theme) => {
+      window.localStorage.setItem('theme', theme);
+    }, study.theme);
+
+    const response = await page.goto(route);
+    expect(response?.ok()).toBe(true);
+    await activityField(page);
+    await expect(page.locator('[data-material-exemplar="activity-honeycomb"]')).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+
+    const screenshotPath = path.join(
+      'test-results',
+      'homepage-honeycomb',
+      study.theme,
+      testInfo.project.name,
+      `${study.width}x${study.height}.png`,
+    );
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, animations: 'disabled' });
+  });
+}


### PR DESCRIPTION
Closes #398

## Reconstruction

The previously reported implementation was not present as a branch or pull request. This PR reconstructs the production integration from current post-material `main` rather than claiming that missing work survived.

- branch: `feature/issue-398-homepage-honeycomb`
- exact head: `9cf44a3e19a70ed4239043b7b733cbb97e95dbc6`
- exact current-main base: `d91ca326a9fd805d44316478be79a95c479b8943`
- current-main CI: [run 343](https://github.com/teamleaderleo/scrapbook/actions/runs/30220675289), successful
- PR merge-gate CI: [run 350](https://github.com/teamleaderleo/scrapbook/actions/runs/30221364235), successful

## Production result

- replaces the production square field with the proven 286 × 196 px, six-column present-first honeycomb;
- keeps all 28 live days in oldest → today DOM and screen-reader order;
- puts today at the upper-left visual origin with the restrained recency snake;
- keeps today, selected, keyboard focus, pointer hover, and zero-count states independent;
- keeps native 44 × 44 px buttons, chronological arrow-key movement, Home/End, and native Enter/Space selection;
- keeps a desktop hover/focus label without making hover mutate selection;
- places the persistent selected date/count readout inside the honeycomb’s unused bottom-row slots, preserving the surrounding card footprint;
- reuses the settled steel/slate material roles and existing primitives without adding a palette;
- keeps `/activity-lab` unchanged.

## Density and transition proof

`homepage-density.spec.ts` passed in Chromium and WebKit at:

- 1180 × 720;
- 1280 × 720;
- 1366 × 768;
- 1440 × 900;
- 1536 × 864.

The same suite passed the 820 × 720 stacked state and 860 × 720 side-by-side state, including its bounded field-size handoff and fold assertions. The scoreboard keeps the existing 15.5rem / 14.5rem contract, compact metric rail, and dashboard column threshold.

Density artifact: [homepage-density-screenshots](https://github.com/teamleaderleo/scrapbook/actions/runs/30221364235/artifacts/8637337645)

## Interaction and refresh proof

`homepage-activity-honeycomb.spec.ts` passed in both browser projects for:

- chronological DOM order and today at the visual origin;
- independent selected/today/focus/hover/zero-count states;
- chronological keyboard navigation and keyboard selection;
- minimum 44 px interaction boxes;
- mobile portrait, mobile landscape, 820 × 720, and 860 × 720 overflow;
- live refresh selection retention and less than 1 px card/field geometry change.

## Browser and visual evidence

- Chromium: 65 checks scheduled;
- WebKit: 65 checks scheduled;
- combined result: 128 passed, 2 intentional skips, 0 failures, 0 retries/flakes.

Light/dark evidence was captured in both Chromium and WebKit for:

- light 390 × 844;
- dark 390 × 844;
- light 1366 × 768;
- dark 1440 × 900.

Evidence artifact: [homepage-honeycomb-screenshots](https://github.com/teamleaderleo/scrapbook/actions/runs/30221364235/artifacts/8637337843)

Full browser log: [playwright-log](https://github.com/teamleaderleo/scrapbook/actions/runs/30221364235/artifacts/8637338248)

## Self-review

- replaced hydration-sensitive pointer timing with labels that are available before client hydration;
- removed pointer geometry motion so labels remain anchored through click;
- retained a single atomic live readout instead of duplicate announcements;
- confirmed the diff is limited to the production activity component, focused tests, and CI evidence retention;
- confirmed `/activity-lab`, homepage composition, scoreboard dimensions, time picker, navigation progress, and material primitives are unchanged.

## Agent 1 review request

Please perform the final footprint review on exact head `9cf44a3e19a70ed4239043b7b733cbb97e95dbc6`: confirm the five short-desktop folds, 820 → 860 transition, unchanged scoreboard contract, and no activity-card inflation.