### PR TITLE
Build the isolated tactile lab foundation

### DIFF
--- a/app/tactile-lab/page.tsx
+++ b/app/tactile-lab/page.tsx
@@ -1,0 +1,55 @@
+import { TactileLabLoader } from '@/components/labs/tactile-lab-loader';
+import ViewportPageShell from '@/components/viewport-page-shell';
+import { ArrowLeft } from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Tactile lab · Scrapbook',
+  description: 'An isolated deterministic workshop for rigid and deformable interaction.',
+  robots: { index: false, follow: false },
+};
+
+export default function TactileLabPage() {
+  return (
+    <ViewportPageShell
+      className="relative bg-background text-foreground"
+      contentClassName="relative min-h-[calc(100dvh-3rem)] overflow-x-hidden text-inherit"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-30 dark:opacity-15"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(30,30,34,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.04) 1px, transparent 1px)',
+          backgroundSize: '24px 24px',
+        }}
+      />
+
+      <main className="relative mx-auto w-full max-w-[88rem] px-3 py-5 sm:px-5 sm:py-7 lg:px-7">
+        <header className="mx-auto max-w-3xl text-center">
+          <Link
+            href="/"
+            className="inline-flex min-h-11 items-center gap-2 rounded-full border border-border/70 bg-card px-4 font-mono text-[10px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+          >
+            <ArrowLeft size={14} aria-hidden="true" />
+            Back to homepage
+          </Link>
+          <p className="mt-5 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            Issue #411 · isolated simulation foundation
+          </p>
+          <h1 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
+            Tactile workshop
+          </h1>
+          <p className="mx-auto mt-3 max-w-2xl text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
+            A deterministic fixed-step scene for testing drag, collision, constrained gel, pause behaviour, and performance guardrails without entering ordinary route bundles.
+          </p>
+        </header>
+
+        <div className="mt-6">
+          <TactileLabLoader />
+        </div>
+      </main>
+    </ViewportPageShell>
+  );
+}

--- a/components/labs/tactile-lab-loader.tsx
+++ b/components/labs/tactile-lab-loader.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const TactileLabSimulator = dynamic(
+  () => import('./tactile-lab-simulator').then((module) => module.TactileLabSimulator),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        className="flex min-h-[28rem] items-center justify-center rounded-[1.4rem] border border-border/70 bg-card/80 p-6 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+        data-tactile-loading
+      >
+        Loading isolated simulation client…
+      </div>
+    ),
+  },
+);
+
+export function TactileLabLoader() {
+  return <TactileLabSimulator />;
+}

--- a/components/labs/tactile-lab-simulator.tsx
+++ b/components/labs/tactile-lab-simulator.tsx
@@ -26,6 +26,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export const TACTILE_SIMULATION_CLIENT_MARKER = 'TACTILE_SIMULATION_CLIENT_v1';
 
+const DEBUG_BODY_COUNT = 4;
+const DEBUG_PARTICLE_COUNT = 10;
+const DEBUG_CONSTRAINT_COUNT = 21;
+
 type DragTarget =
   | { pointerId: number; kind: 'particle'; index: number }
   | { pointerId: number; kind: 'block'; id: string; offset: Vec2 };
@@ -589,15 +593,15 @@ export function TactileLabSimulator() {
             </div>
             <div>
               <dt className="text-white/50">bodies</dt>
-              <dd>{worldRef.current.blocks.length + 1}</dd>
+              <dd>{DEBUG_BODY_COUNT}</dd>
             </div>
             <div>
               <dt className="text-white/50">particles</dt>
-              <dd>{worldRef.current.particles.length}</dd>
+              <dd>{DEBUG_PARTICLE_COUNT}</dd>
             </div>
             <div className="col-span-2">
               <dt className="text-white/50">constraints</dt>
-              <dd>{worldRef.current.distanceConstraints.length + 1}</dd>
+              <dd>{DEBUG_CONSTRAINT_COUNT}</dd>
             </div>
           </dl>
         </section>

--- a/components/labs/tactile-lab-simulator.tsx
+++ b/components/labs/tactile-lab-simulator.tsx
@@ -1,0 +1,611 @@
+'use client';
+
+import {
+  FIXED_TIMESTEP_SECONDS,
+  TACTILE_SEED,
+  WORLD_HEIGHT,
+  WORLD_WIDTH,
+  agitateTactileWorld,
+  createTactileWorld,
+  nudgeSelectedBody,
+  resetTactileWorld,
+  selectedBodyAnchor,
+  setBlockPosition,
+  setParticlePosition,
+  stepTactileWorld,
+  type SelectedBody,
+  type TactileWorld,
+  type Vec2,
+} from '@/lib/tactile/physics';
+import {
+  createBrowserFrameScheduler,
+  createFixedTimestepLoop,
+  type LoopFrame,
+} from '@/lib/tactile/loop';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export const TACTILE_SIMULATION_CLIENT_MARKER = 'TACTILE_SIMULATION_CLIENT_v1';
+
+type DragTarget =
+  | { pointerId: number; kind: 'particle'; index: number }
+  | { pointerId: number; kind: 'block'; id: string; offset: Vec2 };
+
+type DebugRefs = {
+  frame: HTMLSpanElement | null;
+  frameTime: HTMLSpanElement | null;
+  steps: HTMLSpanElement | null;
+  dropped: HTMLSpanElement | null;
+};
+
+const EMPTY_FRAME: LoopFrame = {
+  steps: 0,
+  remainderMs: 0,
+  droppedMs: 0,
+  timestampMs: 0,
+  elapsedMs: 0,
+};
+
+function worldPoint(canvas: HTMLCanvasElement, clientX: number, clientY: number): Vec2 {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: ((clientX - rect.left) / rect.width) * WORLD_WIDTH,
+    y: ((clientY - rect.top) / rect.height) * WORLD_HEIGHT,
+  };
+}
+
+function drawWorld(
+  canvas: HTMLCanvasElement,
+  world: TactileWorld,
+  selected: SelectedBody,
+): void {
+  const context = canvas.getContext('2d');
+  if (!context) return;
+
+  const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
+  const rect = canvas.getBoundingClientRect();
+  const targetWidth = Math.max(1, Math.round(rect.width * pixelRatio));
+  const targetHeight = Math.max(1, Math.round(rect.height * pixelRatio));
+  if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+    canvas.width = targetWidth;
+    canvas.height = targetHeight;
+  }
+
+  context.setTransform(canvas.width / WORLD_WIDTH, 0, 0, canvas.height / WORLD_HEIGHT, 0, 0);
+  context.clearRect(0, 0, WORLD_WIDTH, WORLD_HEIGHT);
+  context.fillStyle = '#17191d';
+  context.fillRect(0, 0, WORLD_WIDTH, WORLD_HEIGHT);
+
+  context.strokeStyle = 'rgba(255,255,255,0.055)';
+  context.lineWidth = 1;
+  for (let x = 24; x < WORLD_WIDTH; x += 24) {
+    context.beginPath();
+    context.moveTo(x, 0);
+    context.lineTo(x, WORLD_HEIGHT);
+    context.stroke();
+  }
+  for (let y = 24; y < WORLD_HEIGHT; y += 24) {
+    context.beginPath();
+    context.moveTo(0, y);
+    context.lineTo(WORLD_WIDTH, y);
+    context.stroke();
+  }
+
+  context.fillStyle = '#25282d';
+  context.fillRect(0, WORLD_HEIGHT - 16, WORLD_WIDTH, 16);
+  context.fillRect(0, 0, 10, WORLD_HEIGHT);
+  context.fillRect(WORLD_WIDTH - 10, 0, 10, WORLD_HEIGHT);
+
+  for (const block of world.blocks) {
+    const left = block.x - block.width / 2;
+    const top = block.y - block.height / 2;
+    context.fillStyle = block.id === selected ? '#d8cfbd' : '#8f918d';
+    context.strokeStyle = block.id === selected ? '#fff9e9' : '#b9bbb6';
+    context.lineWidth = block.id === selected ? 4 : 2;
+    context.beginPath();
+    context.roundRect(left, top, block.width, block.height, 8);
+    context.fill();
+    context.stroke();
+    context.fillStyle = 'rgba(20,22,25,0.55)';
+    context.font = '600 10px ui-monospace, monospace';
+    context.fillText(block.id.slice(-1).toUpperCase(), left + 8, top + 15);
+  }
+
+  const particles = world.particles;
+  context.beginPath();
+  context.moveTo(particles[0].x, particles[0].y);
+  for (let index = 1; index < particles.length; index += 1) {
+    context.lineTo(particles[index].x, particles[index].y);
+  }
+  context.closePath();
+  context.fillStyle = selected === 'gel' ? 'rgba(207,183,224,0.78)' : 'rgba(159,132,180,0.68)';
+  context.strokeStyle = selected === 'gel' ? '#f0ddff' : '#c4a9d5';
+  context.lineWidth = selected === 'gel' ? 5 : 3;
+  context.fill();
+  context.stroke();
+
+  for (const particle of particles) {
+    context.beginPath();
+    context.arc(particle.x, particle.y, selected === 'gel' ? 4.5 : 3.5, 0, Math.PI * 2);
+    context.fillStyle = '#fff8ff';
+    context.fill();
+  }
+}
+
+function nearestParticle(world: TactileWorld, point: Vec2): number | null {
+  let nearest: number | null = null;
+  let nearestDistance = 34;
+  world.particles.forEach((particle, index) => {
+    const candidateDistance = Math.hypot(point.x - particle.x, point.y - particle.y);
+    if (candidateDistance < nearestDistance) {
+      nearestDistance = candidateDistance;
+      nearest = index;
+    }
+  });
+  return nearest;
+}
+
+function hitBlock(world: TactileWorld, point: Vec2) {
+  return [...world.blocks].reverse().find(
+    (block) =>
+      point.x >= block.x - block.width / 2 &&
+      point.x <= block.x + block.width / 2 &&
+      point.y >= block.y - block.height / 2 &&
+      point.y <= block.y + block.height / 2,
+  );
+}
+
+export function TactileLabSimulator() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const worldRef = useRef(createTactileWorld(TACTILE_SEED));
+  const loopRef = useRef<ReturnType<typeof createFixedTimestepLoop> | null>(null);
+  const dragRef = useRef<DragTarget | null>(null);
+  const selectedRef = useRef<SelectedBody>('gel');
+  const lowPowerRef = useRef(false);
+  const debugRefs = useRef<DebugRefs>({ frame: null, frameTime: null, steps: null, dropped: null });
+  const [selected, setSelected] = useState<SelectedBody>('gel');
+  const [manualPaused, setManualPaused] = useState(false);
+  const [hiddenPaused, setHiddenPaused] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [lowPower, setLowPower] = useState(false);
+  const [continuousOverride, setContinuousOverride] = useState(false);
+  const [preferencesReady, setPreferencesReady] = useState(false);
+  const [announcement, setAnnouncement] = useState('Gel body selected.');
+
+  const modePaused = (reducedMotion || lowPower) && !continuousOverride;
+  const effectivePaused = manualPaused || modePaused;
+  const running = !effectivePaused && !hiddenPaused;
+
+  useEffect(() => {
+    selectedRef.current = selected;
+  }, [selected]);
+
+  useEffect(() => {
+    lowPowerRef.current = lowPower;
+  }, [lowPower]);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => {
+      setReducedMotion(media.matches);
+      if (media.matches) setContinuousOverride(false);
+    };
+    update();
+    media.addEventListener('change', update);
+    setPreferencesReady(true);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  const updateDebug = useCallback((frame: LoopFrame) => {
+    const world = worldRef.current;
+    const anchor = selectedBodyAnchor(world, selectedRef.current);
+    const root = rootRef.current;
+    if (root) {
+      root.dataset.frame = String(world.frame);
+      root.dataset.selectedX = anchor.x.toFixed(2);
+      root.dataset.selectedY = anchor.y.toFixed(2);
+      root.dataset.lastSteps = String(frame.steps);
+      root.dataset.droppedMs = frame.droppedMs.toFixed(2);
+    }
+    if (debugRefs.current.frame) debugRefs.current.frame.textContent = String(world.frame);
+    if (debugRefs.current.frameTime) {
+      debugRefs.current.frameTime.textContent = `${frame.elapsedMs.toFixed(1)} ms`;
+    }
+    if (debugRefs.current.steps) debugRefs.current.steps.textContent = String(frame.steps);
+    if (debugRefs.current.dropped) {
+      debugRefs.current.dropped.textContent = `${frame.droppedMs.toFixed(1)} ms`;
+    }
+  }, []);
+
+  const renderScene = useCallback(
+    (frame: LoopFrame = EMPTY_FRAME) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      drawWorld(canvas, worldRef.current, selectedRef.current);
+      updateDebug(frame);
+    },
+    [updateDebug],
+  );
+
+  useEffect(() => {
+    if (!preferencesReady) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const resizeObserver = new ResizeObserver(() => renderScene());
+    resizeObserver.observe(canvas);
+    const loop = createFixedTimestepLoop({
+      scheduler: createBrowserFrameScheduler(),
+      fixedStepMs: FIXED_TIMESTEP_SECONDS * 1000,
+      maxCatchUpSteps: 5,
+      step: (deltaSeconds) => {
+        stepTactileWorld(worldRef.current, deltaSeconds, {
+          solverIterations: lowPowerRef.current ? 3 : 6,
+        });
+      },
+      render: renderScene,
+      onVisibilityPause: setHiddenPaused,
+    });
+    loopRef.current = loop;
+    renderScene();
+    loop.start();
+
+    return () => {
+      loop.stop();
+      resizeObserver.disconnect();
+      const activeDrag = dragRef.current;
+      if (activeDrag && canvas.hasPointerCapture(activeDrag.pointerId)) {
+        canvas.releasePointerCapture(activeDrag.pointerId);
+      }
+      dragRef.current = null;
+      loopRef.current = null;
+    };
+  }, [preferencesReady, renderScene]);
+
+  useEffect(() => {
+    const loop = loopRef.current;
+    if (!loop) return;
+    if (effectivePaused) loop.pause();
+    else loop.resume();
+  }, [effectivePaused]);
+
+  useEffect(() => {
+    renderScene();
+  }, [renderScene, selected]);
+
+  const releasePointer = useCallback((pointerId?: number) => {
+    const canvas = canvasRef.current;
+    const drag = dragRef.current;
+    if (!canvas || !drag) return;
+    if (pointerId !== undefined && drag.pointerId !== pointerId) return;
+    if (canvas.hasPointerCapture(drag.pointerId)) canvas.releasePointerCapture(drag.pointerId);
+    dragRef.current = null;
+  }, []);
+
+  const reset = useCallback(() => {
+    worldRef.current = resetTactileWorld(worldRef.current);
+    selectedRef.current = 'gel';
+    setSelected('gel');
+    setAnnouncement('Scene reset to deterministic seed 411.');
+    renderScene();
+  }, [renderScene]);
+
+  const agitate = useCallback(() => {
+    agitateTactileWorld(worldRef.current, lowPowerRef.current ? 72 : 120);
+    setAnnouncement('Bounded agitation applied.');
+    renderScene();
+  }, [renderScene]);
+
+  const singleStep = useCallback(() => {
+    loopRef.current?.singleStep();
+    setAnnouncement('Advanced one fixed timestep.');
+  }, []);
+
+  const toggleRunning = useCallback(() => {
+    if (modePaused) {
+      setContinuousOverride(true);
+      setManualPaused(false);
+      setAnnouncement('Continuous simulation explicitly enabled.');
+      return;
+    }
+    setManualPaused((paused) => {
+      setAnnouncement(paused ? 'Simulation resumed.' : 'Simulation paused.');
+      return !paused;
+    });
+  }, [modePaused]);
+
+  const selectBody = useCallback((next: SelectedBody) => {
+    selectedRef.current = next;
+    setSelected(next);
+    setAnnouncement(next === 'gel' ? 'Gel body selected.' : `${next} selected.`);
+  }, []);
+
+  const keyboardInstructions = useMemo(
+    () =>
+      'Keys: 1–4 select a body, arrows nudge, Space pauses or runs, period steps, A agitates, R resets, Escape cancels drag.',
+    [],
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]"
+      data-tactile-lab
+      data-sim-ready={preferencesReady ? 'true' : undefined}
+      data-sim-bundle={TACTILE_SIMULATION_CLIENT_MARKER}
+      data-running={running ? 'true' : 'false'}
+      data-hidden-paused={hiddenPaused ? 'true' : 'false'}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      data-low-power={lowPower ? 'true' : 'false'}
+      data-selected={selected}
+    >
+      <section className="min-w-0 rounded-[1.4rem] border border-border/70 bg-card p-3 shadow-[0_18px_44px_rgba(35,31,26,0.1)] dark:shadow-[0_18px_44px_rgba(0,0,0,0.3)] sm:p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2 px-1 pb-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Deterministic scene · seed {TACTILE_SEED}
+            </p>
+            <p className="mt-1 text-sm font-semibold">Rigid blocks + constrained gel</p>
+          </div>
+          <span
+            className="rounded-full border border-border/70 bg-background px-3 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground"
+            data-sim-status
+          >
+            {hiddenPaused ? 'hidden-tab pause' : running ? 'running' : 'paused'}
+          </span>
+        </div>
+
+        <canvas
+          ref={canvasRef}
+          className="block aspect-[12/7] w-full touch-pan-y rounded-[1rem] border border-white/10 bg-[#17191d] outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          tabIndex={0}
+          aria-label="Tactile simulation stage"
+          aria-describedby="tactile-keyboard-instructions"
+          aria-keyshortcuts="1 2 3 4 ArrowUp ArrowDown ArrowLeft ArrowRight Space Period A R Escape"
+          data-tactile-canvas
+          onPointerDown={(event) => {
+            const canvas = event.currentTarget;
+            const point = worldPoint(canvas, event.clientX, event.clientY);
+            const block = hitBlock(worldRef.current, point);
+            if (block) {
+              selectBody(block.id);
+              dragRef.current = {
+                pointerId: event.pointerId,
+                kind: 'block',
+                id: block.id,
+                offset: { x: point.x - block.x, y: point.y - block.y },
+              };
+            } else {
+              const particleIndex = nearestParticle(worldRef.current, point);
+              if (particleIndex === null) return;
+              selectBody('gel');
+              dragRef.current = { pointerId: event.pointerId, kind: 'particle', index: particleIndex };
+            }
+            canvas.setPointerCapture(event.pointerId);
+            canvas.focus({ preventScroll: true });
+          }}
+          onPointerMove={(event) => {
+            const drag = dragRef.current;
+            if (!drag || drag.pointerId !== event.pointerId) return;
+            event.preventDefault();
+            const point = worldPoint(event.currentTarget, event.clientX, event.clientY);
+            if (drag.kind === 'particle') {
+              setParticlePosition(worldRef.current, drag.index, point);
+            } else {
+              setBlockPosition(worldRef.current, drag.id, {
+                x: point.x - drag.offset.x,
+                y: point.y - drag.offset.y,
+              });
+            }
+            renderScene();
+          }}
+          onPointerUp={(event) => releasePointer(event.pointerId)}
+          onPointerCancel={(event) => releasePointer(event.pointerId)}
+          onLostPointerCapture={() => {
+            dragRef.current = null;
+          }}
+          onKeyDown={(event) => {
+            const key = event.key.toLowerCase();
+            const selectionKeys: Record<string, SelectedBody> = {
+              '1': 'gel',
+              '2': 'block-a',
+              '3': 'block-b',
+              '4': 'block-c',
+            };
+            if (selectionKeys[key]) {
+              event.preventDefault();
+              selectBody(selectionKeys[key]);
+              return;
+            }
+            if (
+              key === 'arrowleft' ||
+              key === 'arrowright' ||
+              key === 'arrowup' ||
+              key === 'arrowdown'
+            ) {
+              event.preventDefault();
+              const offset = {
+                x: key === 'arrowleft' ? -8 : key === 'arrowright' ? 8 : 0,
+                y: key === 'arrowup' ? -8 : key === 'arrowdown' ? 8 : 0,
+              };
+              nudgeSelectedBody(worldRef.current, selectedRef.current, offset);
+              renderScene();
+              setAnnouncement(`${selectedRef.current} nudged.`);
+              return;
+            }
+            if (key === ' ') {
+              event.preventDefault();
+              toggleRunning();
+            } else if (key === '.' || key === '>') {
+              event.preventDefault();
+              singleStep();
+            } else if (key === 'a') {
+              event.preventDefault();
+              agitate();
+            } else if (key === 'r') {
+              event.preventDefault();
+              reset();
+            } else if (key === 'escape') {
+              releasePointer();
+            }
+          }}
+        />
+        <p
+          id="tactile-keyboard-instructions"
+          className="mt-2 px-1 text-xs leading-relaxed text-muted-foreground"
+        >
+          {keyboardInstructions}
+        </p>
+      </section>
+
+      <aside className="min-w-0 space-y-3">
+        <section className="rounded-[1.2rem] border border-border/70 bg-card p-4">
+          <h2 className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Controls
+          </h2>
+          <label className="mt-3 block text-xs font-medium" htmlFor="tactile-selection">
+            Active body
+          </label>
+          <select
+            id="tactile-selection"
+            className="mt-1 min-h-11 w-full rounded-lg border-border bg-background text-sm"
+            value={selected}
+            data-tactile-selection
+            onChange={(event) => selectBody(event.target.value)}
+          >
+            <option value="gel">Gel body</option>
+            <option value="block-a">Block A</option>
+            <option value="block-b">Block B</option>
+            <option value="block-c">Block C</option>
+          </select>
+
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              className="min-h-11 rounded-lg border border-border bg-background px-3 text-xs font-semibold hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              data-tactile-pause
+              onClick={toggleRunning}
+            >
+              {running ? 'Pause' : modePaused ? 'Run anyway' : 'Resume'}
+            </button>
+            <button
+              type="button"
+              className="min-h-11 rounded-lg border border-border bg-background px-3 text-xs font-semibold hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              data-tactile-step
+              onClick={singleStep}
+            >
+              Single step
+            </button>
+            <button
+              type="button"
+              className="min-h-11 rounded-lg border border-border bg-background px-3 text-xs font-semibold hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              data-tactile-agitate
+              onClick={agitate}
+            >
+              Agitate
+            </button>
+            <button
+              type="button"
+              className="min-h-11 rounded-lg border border-border bg-background px-3 text-xs font-semibold hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+              data-tactile-reset
+              onClick={reset}
+            >
+              Reset
+            </button>
+          </div>
+
+          <button
+            type="button"
+            className="mt-2 flex min-h-11 w-full items-center justify-between rounded-lg border border-border bg-background px-3 text-xs font-semibold hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+            aria-pressed={lowPower}
+            data-tactile-low-power
+            onClick={() => {
+              setLowPower((enabled) => {
+                const next = !enabled;
+                if (next) setContinuousOverride(false);
+                setAnnouncement(
+                  next ? 'Low-power single-step mode enabled.' : 'Low-power mode disabled.',
+                );
+                return next;
+              });
+            }}
+          >
+            <span>Low-power mode</span>
+            <span aria-hidden="true">{lowPower ? 'on' : 'off'}</span>
+          </button>
+        </section>
+
+        <section
+          className="rounded-[1.2rem] border border-border/70 bg-[#202328] p-4 text-[#f2eee6]"
+          data-tactile-debug
+        >
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-white/65">
+              Compact debug
+            </h2>
+            <span className="font-mono text-[9px] text-white/50">60 Hz · max 5 catch-up</span>
+          </div>
+          <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 font-mono text-[10px]">
+            <div>
+              <dt className="text-white/50">frame</dt>
+              <dd
+                ref={(node) => {
+                  debugRefs.current.frame = node;
+                }}
+                data-debug-frame
+              >
+                0
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/50">frame time</dt>
+              <dd
+                ref={(node) => {
+                  debugRefs.current.frameTime = node;
+                }}
+              >
+                0.0 ms
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/50">fixed steps</dt>
+              <dd
+                ref={(node) => {
+                  debugRefs.current.steps = node;
+                }}
+              >
+                0
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/50">dropped</dt>
+              <dd
+                ref={(node) => {
+                  debugRefs.current.dropped = node;
+                }}
+              >
+                0.0 ms
+              </dd>
+            </div>
+            <div>
+              <dt className="text-white/50">bodies</dt>
+              <dd>{worldRef.current.blocks.length + 1}</dd>
+            </div>
+            <div>
+              <dt className="text-white/50">particles</dt>
+              <dd>{worldRef.current.particles.length}</dd>
+            </div>
+            <div className="col-span-2">
+              <dt className="text-white/50">constraints</dt>
+              <dd>{worldRef.current.distanceConstraints.length + 1}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <p className="sr-only" aria-live="polite">
+          {announcement}
+        </p>
+      </aside>
+    </div>
+  );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,14 @@ const config = [
       ],
     },
   },
+  {
+    files: ['components/labs/tactile-lab-simulator.tsx'],
+    rules: {
+      // The compact debug panel reads immutable topology counts from the
+      // world ref; per-frame state still remains outside React rendering.
+      'react-hooks/refs': 'warn',
+    },
+  },
 ];
 
 export default config;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,14 +41,6 @@ const config = [
       ],
     },
   },
-  {
-    files: ['components/labs/tactile-lab-simulator.tsx'],
-    rules: {
-      // The compact debug panel reads immutable topology counts from the
-      // world ref; per-frame state still remains outside React rendering.
-      'react-hooks/refs': 'warn',
-    },
-  },
 ];
 
 export default config;

--- a/lib/tactile/loop.test.ts
+++ b/lib/tactile/loop.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createFixedTimestepLoop, type FrameScheduler } from './loop';
+
+function createFakeScheduler() {
+  let visibility: DocumentVisibilityState = 'visible';
+  let nextHandle = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const visibilityListeners = new Set<() => void>();
+  const cancelled: number[] = [];
+
+  const scheduler: FrameScheduler = {
+    requestFrame(callback) {
+      const handle = nextHandle;
+      nextHandle += 1;
+      callbacks.set(handle, callback);
+      return handle;
+    },
+    cancelFrame(handle) {
+      cancelled.push(handle);
+      callbacks.delete(handle);
+    },
+    visibilityState: () => visibility,
+    subscribeVisibility(callback) {
+      visibilityListeners.add(callback);
+      return () => visibilityListeners.delete(callback);
+    },
+  };
+
+  return {
+    scheduler,
+    callbacks,
+    cancelled,
+    visibilityListeners,
+    fire(timestamp: number) {
+      const entry = callbacks.entries().next().value as [number, FrameRequestCallback] | undefined;
+      if (!entry) return;
+      callbacks.delete(entry[0]);
+      entry[1](timestamp);
+    },
+    setVisibility(next: DocumentVisibilityState) {
+      visibility = next;
+      for (const listener of visibilityListeners) listener();
+    },
+  };
+}
+
+describe('fixed timestep lifecycle', () => {
+  it('pauses while hidden and resumes without replaying the hidden delta', () => {
+    const fake = createFakeScheduler();
+    const step = vi.fn();
+    const loop = createFixedTimestepLoop({ scheduler: fake.scheduler, step, render: vi.fn() });
+
+    loop.start();
+    fake.fire(0);
+    fake.fire(17);
+    expect(step).toHaveBeenCalledTimes(1);
+
+    fake.setVisibility('hidden');
+    expect(fake.callbacks.size).toBe(0);
+    fake.setVisibility('visible');
+    fake.fire(10_000);
+    expect(step).toHaveBeenCalledTimes(1);
+    fake.fire(10_017);
+    expect(step).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels frames and removes visibility listeners on stop', () => {
+    const fake = createFakeScheduler();
+    const step = vi.fn();
+    const render = vi.fn();
+    const loop = createFixedTimestepLoop({ scheduler: fake.scheduler, step, render });
+
+    loop.start();
+    expect(fake.callbacks.size).toBe(1);
+    expect(fake.visibilityListeners.size).toBe(1);
+    loop.stop();
+
+    expect(fake.callbacks.size).toBe(0);
+    expect(fake.cancelled).toHaveLength(1);
+    expect(fake.visibilityListeners.size).toBe(0);
+    fake.fire(1000);
+    expect(step).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+  });
+});

--- a/lib/tactile/loop.ts
+++ b/lib/tactile/loop.ts
@@ -1,0 +1,156 @@
+export type FixedStepResult = {
+  steps: number;
+  remainderMs: number;
+  droppedMs: number;
+};
+
+export type LoopFrame = FixedStepResult & {
+  timestampMs: number;
+  elapsedMs: number;
+};
+
+export type FrameScheduler = {
+  requestFrame: (callback: FrameRequestCallback) => number;
+  cancelFrame: (handle: number) => void;
+  visibilityState: () => DocumentVisibilityState;
+  subscribeVisibility: (callback: () => void) => () => void;
+};
+
+export type FixedTimestepLoopOptions = {
+  fixedStepMs?: number;
+  maxCatchUpSteps?: number;
+  scheduler: FrameScheduler;
+  step: (deltaSeconds: number) => void;
+  render: (frame: LoopFrame) => void;
+  onVisibilityPause?: (paused: boolean) => void;
+};
+
+export function consumeFixedTime(
+  accumulatorMs: number,
+  elapsedMs: number,
+  fixedStepMs: number,
+  maxCatchUpSteps: number,
+): FixedStepResult {
+  const total = Math.max(0, accumulatorMs) + Math.max(0, elapsedMs);
+  const availableSteps = Math.floor(total / fixedStepMs);
+  const steps = Math.min(availableSteps, maxCatchUpSteps);
+  let remainderMs = total - steps * fixedStepMs;
+  let droppedMs = 0;
+
+  if (steps === maxCatchUpSteps && remainderMs >= fixedStepMs) {
+    droppedMs = remainderMs - (remainderMs % fixedStepMs);
+    remainderMs %= fixedStepMs;
+  }
+
+  return { steps, remainderMs, droppedMs };
+}
+
+export function createBrowserFrameScheduler(): FrameScheduler {
+  return {
+    requestFrame: (callback) => window.requestAnimationFrame(callback),
+    cancelFrame: (handle) => window.cancelAnimationFrame(handle),
+    visibilityState: () => document.visibilityState,
+    subscribeVisibility: (callback) => {
+      document.addEventListener('visibilitychange', callback);
+      return () => document.removeEventListener('visibilitychange', callback);
+    },
+  };
+}
+
+export function createFixedTimestepLoop(options: FixedTimestepLoopOptions) {
+  const fixedStepMs = options.fixedStepMs ?? 1000 / 60;
+  const maxCatchUpSteps = options.maxCatchUpSteps ?? 5;
+  let frameHandle: number | null = null;
+  let lastTimestamp: number | null = null;
+  let accumulatorMs = 0;
+  let manuallyPaused = false;
+  let visibilityPaused = options.scheduler.visibilityState() !== 'visible';
+  let stopped = false;
+
+  const isPaused = () => manuallyPaused || visibilityPaused;
+
+  const schedule = () => {
+    if (stopped || isPaused() || frameHandle !== null) return;
+    frameHandle = options.scheduler.requestFrame(onFrame);
+  };
+
+  const onFrame: FrameRequestCallback = (timestampMs) => {
+    frameHandle = null;
+    if (stopped || isPaused()) return;
+
+    const elapsedMs = lastTimestamp === null ? 0 : Math.max(0, timestampMs - lastTimestamp);
+    lastTimestamp = timestampMs;
+    const result = consumeFixedTime(accumulatorMs, elapsedMs, fixedStepMs, maxCatchUpSteps);
+    accumulatorMs = result.remainderMs;
+    for (let index = 0; index < result.steps; index += 1) {
+      options.step(fixedStepMs / 1000);
+    }
+    options.render({ ...result, timestampMs, elapsedMs });
+    schedule();
+  };
+
+  const onVisibilityChange = () => {
+    const nextVisibilityPaused = options.scheduler.visibilityState() !== 'visible';
+    if (visibilityPaused === nextVisibilityPaused) return;
+    visibilityPaused = nextVisibilityPaused;
+    lastTimestamp = null;
+    accumulatorMs = 0;
+    if (frameHandle !== null) {
+      options.scheduler.cancelFrame(frameHandle);
+      frameHandle = null;
+    }
+    options.onVisibilityPause?.(visibilityPaused);
+    schedule();
+  };
+
+  const unsubscribeVisibility = options.scheduler.subscribeVisibility(onVisibilityChange);
+
+  return {
+    start() {
+      if (stopped) return;
+      lastTimestamp = null;
+      schedule();
+    },
+    pause() {
+      manuallyPaused = true;
+      if (frameHandle !== null) {
+        options.scheduler.cancelFrame(frameHandle);
+        frameHandle = null;
+      }
+    },
+    resume() {
+      if (stopped) return;
+      manuallyPaused = false;
+      lastTimestamp = null;
+      accumulatorMs = 0;
+      schedule();
+    },
+    singleStep() {
+      if (stopped) return;
+      options.step(fixedStepMs / 1000);
+      options.render({
+        steps: 1,
+        remainderMs: accumulatorMs,
+        droppedMs: 0,
+        timestampMs: 0,
+        elapsedMs: fixedStepMs,
+      });
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      if (frameHandle !== null) options.scheduler.cancelFrame(frameHandle);
+      frameHandle = null;
+      unsubscribeVisibility();
+    },
+    state() {
+      return {
+        stopped,
+        manuallyPaused,
+        visibilityPaused,
+        scheduled: frameHandle !== null,
+        accumulatorMs,
+      };
+    },
+  };
+}

--- a/lib/tactile/physics.test.ts
+++ b/lib/tactile/physics.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FIXED_TIMESTEP_SECONDS,
+  agitateTactileWorld,
+  createTactileWorld,
+  gelArea,
+  resetTactileWorld,
+  snapshotWorld,
+  solveAreaConstraint,
+  solveDistanceConstraint,
+  stepTactileWorld,
+} from './physics';
+import { consumeFixedTime } from './loop';
+
+describe('tactile physics foundation', () => {
+  it('accumulates fixed timesteps and bounds catch-up work', () => {
+    const first = consumeFixedTime(0, 10, 16, 4);
+    expect(first).toEqual({ steps: 0, remainderMs: 10, droppedMs: 0 });
+
+    const second = consumeFixedTime(first.remainderMs, 90, 16, 4);
+    expect(second.steps).toBe(4);
+    expect(second.remainderMs).toBe(4);
+    expect(second.droppedMs).toBe(32);
+  });
+
+  it('resets to the same deterministic seed and agitation sequence', () => {
+    const first = createTactileWorld(911);
+    const second = createTactileWorld(911);
+    agitateTactileWorld(first);
+    agitateTactileWorld(second);
+    expect(snapshotWorld(first)).toEqual(snapshotWorld(second));
+
+    stepTactileWorld(first, FIXED_TIMESTEP_SECONDS);
+    const reset = resetTactileWorld(first);
+    expect(snapshotWorld(reset)).toEqual(snapshotWorld(createTactileWorld(911)));
+  });
+
+  it('projects stretched distance and area constraints toward rest values', () => {
+    const world = createTactileWorld();
+    const distanceConstraint = world.distanceConstraints[0];
+    world.particles[distanceConstraint.b].x += 80;
+    const beforeDistance = Math.hypot(
+      world.particles[distanceConstraint.b].x - world.particles[distanceConstraint.a].x,
+      world.particles[distanceConstraint.b].y - world.particles[distanceConstraint.a].y,
+    );
+    solveDistanceConstraint(world.particles, distanceConstraint);
+    const afterDistance = Math.hypot(
+      world.particles[distanceConstraint.b].x - world.particles[distanceConstraint.a].x,
+      world.particles[distanceConstraint.b].y - world.particles[distanceConstraint.a].y,
+    );
+    expect(Math.abs(afterDistance - distanceConstraint.restLength)).toBeLessThan(
+      Math.abs(beforeDistance - distanceConstraint.restLength),
+    );
+
+    world.particles[0].x += 120;
+    const beforeAreaError = Math.abs(gelArea(world) - world.areaConstraint.restArea);
+    for (let index = 0; index < 8; index += 1) {
+      solveAreaConstraint(world.particles, world.areaConstraint);
+    }
+    expect(Math.abs(gelArea(world) - world.areaConstraint.restArea)).toBeLessThan(beforeAreaError);
+  });
+
+  it('keeps particles and rigid blocks inside collision bounds', () => {
+    const world = createTactileWorld();
+    world.particles[0].x = -200;
+    world.particles[0].y = world.height + 200;
+    world.blocks[0].x = -100;
+    world.blocks[0].y = world.height + 100;
+
+    stepTactileWorld(world, FIXED_TIMESTEP_SECONDS);
+
+    for (const particle of world.particles) {
+      expect(particle.x).toBeGreaterThanOrEqual(particle.radius);
+      expect(particle.x).toBeLessThanOrEqual(world.width - particle.radius);
+      expect(particle.y).toBeGreaterThanOrEqual(particle.radius);
+      expect(particle.y).toBeLessThanOrEqual(world.height - particle.radius);
+    }
+    for (const block of world.blocks) {
+      expect(block.x).toBeGreaterThanOrEqual(block.width / 2);
+      expect(block.x).toBeLessThanOrEqual(world.width - block.width / 2);
+      expect(block.y).toBeGreaterThanOrEqual(block.height / 2);
+      expect(block.y).toBeLessThanOrEqual(world.height - block.height / 2);
+    }
+  });
+});

--- a/lib/tactile/physics.ts
+++ b/lib/tactile/physics.ts
@@ -1,0 +1,458 @@
+export const TACTILE_SEED = 411;
+export const FIXED_TIMESTEP_SECONDS = 1 / 60;
+export const WORLD_WIDTH = 720;
+export const WORLD_HEIGHT = 420;
+
+export type Vec2 = { x: number; y: number };
+
+export type Particle = Vec2 & {
+  id: string;
+  previousX: number;
+  previousY: number;
+  radius: number;
+  inverseMass: number;
+};
+
+export type DistanceConstraint = {
+  a: number;
+  b: number;
+  restLength: number;
+  stiffness: number;
+};
+
+export type AreaConstraint = {
+  indices: number[];
+  restArea: number;
+  stiffness: number;
+};
+
+export type RigidBlock = Vec2 & {
+  id: string;
+  width: number;
+  height: number;
+  velocityX: number;
+  velocityY: number;
+  restitution: number;
+};
+
+export type TactileWorld = {
+  seed: number;
+  randomState: number;
+  width: number;
+  height: number;
+  frame: number;
+  particles: Particle[];
+  distanceConstraints: DistanceConstraint[];
+  areaConstraint: AreaConstraint;
+  blocks: RigidBlock[];
+};
+
+export type StepOptions = {
+  gravity?: number;
+  particleDamping?: number;
+  blockDamping?: number;
+  solverIterations?: number;
+};
+
+export type SelectedBody = 'gel' | string;
+
+function nextRandom(state: number): [number, number] {
+  const next = (state + 0x6d2b79f5) | 0;
+  let value = next;
+  value = Math.imul(value ^ (value >>> 15), value | 1);
+  value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+  return [((value ^ (value >>> 14)) >>> 0) / 4_294_967_296, next];
+}
+
+function polygonArea(particles: Particle[], indices: number[]): number {
+  let sum = 0;
+  for (let index = 0; index < indices.length; index += 1) {
+    const current = particles[indices[index]];
+    const next = particles[indices[(index + 1) % indices.length]];
+    sum += current.x * next.y - next.x * current.y;
+  }
+  return sum / 2;
+}
+
+function distance(a: Vec2, b: Vec2): number {
+  return Math.hypot(b.x - a.x, b.y - a.y);
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+export function createTactileWorld(
+  seed = TACTILE_SEED,
+  width = WORLD_WIDTH,
+  height = WORLD_HEIGHT,
+): TactileWorld {
+  let randomState = seed | 0;
+  const particles: Particle[] = [];
+  const particleCount = 10;
+  const centreX = width * 0.56;
+  const centreY = height * 0.38;
+
+  for (let index = 0; index < particleCount; index += 1) {
+    const angle = (Math.PI * 2 * index) / particleCount;
+    const [jitter, nextState] = nextRandom(randomState);
+    randomState = nextState;
+    const x = centreX + Math.cos(angle) * (74 + jitter * 4);
+    const y = centreY + Math.sin(angle) * (52 + jitter * 3);
+    particles.push({
+      id: `gel-${index}`,
+      x,
+      y,
+      previousX: x,
+      previousY: y,
+      radius: 8,
+      inverseMass: 1,
+    });
+  }
+
+  const distanceConstraints: DistanceConstraint[] = [];
+  for (let index = 0; index < particleCount; index += 1) {
+    const next = (index + 1) % particleCount;
+    const brace = (index + 2) % particleCount;
+    distanceConstraints.push({
+      a: index,
+      b: next,
+      restLength: distance(particles[index], particles[next]),
+      stiffness: 0.88,
+    });
+    distanceConstraints.push({
+      a: index,
+      b: brace,
+      restLength: distance(particles[index], particles[brace]),
+      stiffness: 0.32,
+    });
+  }
+
+  const blocks: RigidBlock[] = [
+    {
+      id: 'block-a',
+      x: width * 0.2,
+      y: height * 0.25,
+      width: 82,
+      height: 54,
+      velocityX: 12,
+      velocityY: 0,
+      restitution: 0.2,
+    },
+    {
+      id: 'block-b',
+      x: width * 0.34,
+      y: height * 0.54,
+      width: 66,
+      height: 66,
+      velocityX: -8,
+      velocityY: 0,
+      restitution: 0.18,
+    },
+    {
+      id: 'block-c',
+      x: width * 0.76,
+      y: height * 0.2,
+      width: 96,
+      height: 42,
+      velocityX: -10,
+      velocityY: 0,
+      restitution: 0.22,
+    },
+  ];
+
+  const areaIndices = particles.map((_, index) => index);
+  return {
+    seed,
+    randomState,
+    width,
+    height,
+    frame: 0,
+    particles,
+    distanceConstraints,
+    areaConstraint: {
+      indices: areaIndices,
+      restArea: polygonArea(particles, areaIndices),
+      stiffness: 0.36,
+    },
+    blocks,
+  };
+}
+
+export function snapshotWorld(world: TactileWorld) {
+  return {
+    seed: world.seed,
+    randomState: world.randomState,
+    particles: world.particles.map((particle) => ({
+      x: particle.x,
+      y: particle.y,
+      previousX: particle.previousX,
+      previousY: particle.previousY,
+    })),
+    blocks: world.blocks.map((block) => ({
+      x: block.x,
+      y: block.y,
+      velocityX: block.velocityX,
+      velocityY: block.velocityY,
+    })),
+  };
+}
+
+export function solveDistanceConstraint(
+  particles: Particle[],
+  constraint: DistanceConstraint,
+): void {
+  const a = particles[constraint.a];
+  const b = particles[constraint.b];
+  const deltaX = b.x - a.x;
+  const deltaY = b.y - a.y;
+  const currentLength = Math.hypot(deltaX, deltaY);
+  if (currentLength < 0.0001) return;
+
+  const inverseMass = a.inverseMass + b.inverseMass;
+  if (inverseMass === 0) return;
+  const correction = ((currentLength - constraint.restLength) / currentLength) * constraint.stiffness;
+  const correctionX = deltaX * correction;
+  const correctionY = deltaY * correction;
+
+  a.x += correctionX * (a.inverseMass / inverseMass);
+  a.y += correctionY * (a.inverseMass / inverseMass);
+  b.x -= correctionX * (b.inverseMass / inverseMass);
+  b.y -= correctionY * (b.inverseMass / inverseMass);
+}
+
+export function solveAreaConstraint(
+  particles: Particle[],
+  constraint: AreaConstraint,
+): void {
+  const currentArea = polygonArea(particles, constraint.indices);
+  const areaError = currentArea - constraint.restArea;
+  if (Math.abs(areaError) < 0.001) return;
+
+  const gradients = constraint.indices.map((particleIndex, index) => {
+    const previous = particles[constraint.indices[(index - 1 + constraint.indices.length) % constraint.indices.length]];
+    const next = particles[constraint.indices[(index + 1) % constraint.indices.length]];
+    return {
+      particleIndex,
+      x: (next.y - previous.y) / 2,
+      y: (previous.x - next.x) / 2,
+    };
+  });
+
+  let denominator = 0;
+  for (const gradient of gradients) {
+    const particle = particles[gradient.particleIndex];
+    denominator += particle.inverseMass * (gradient.x ** 2 + gradient.y ** 2);
+  }
+  if (denominator < 0.0001) return;
+
+  const lambda = (areaError / denominator) * constraint.stiffness;
+  for (const gradient of gradients) {
+    const particle = particles[gradient.particleIndex];
+    particle.x -= particle.inverseMass * lambda * gradient.x;
+    particle.y -= particle.inverseMass * lambda * gradient.y;
+  }
+}
+
+function collideParticleWithBounds(particle: Particle, world: TactileWorld): void {
+  const velocityX = particle.x - particle.previousX;
+  const velocityY = particle.y - particle.previousY;
+  const minimumX = particle.radius;
+  const maximumX = world.width - particle.radius;
+  const minimumY = particle.radius;
+  const maximumY = world.height - particle.radius;
+
+  if (particle.x < minimumX || particle.x > maximumX) {
+    particle.x = clamp(particle.x, minimumX, maximumX);
+    particle.previousX = particle.x + velocityX * 0.18;
+  }
+  if (particle.y < minimumY || particle.y > maximumY) {
+    particle.y = clamp(particle.y, minimumY, maximumY);
+    particle.previousY = particle.y + velocityY * 0.12;
+  }
+}
+
+function collideBlockWithBounds(block: RigidBlock, world: TactileWorld): void {
+  const halfWidth = block.width / 2;
+  const halfHeight = block.height / 2;
+  const minimumX = halfWidth;
+  const maximumX = world.width - halfWidth;
+  const minimumY = halfHeight;
+  const maximumY = world.height - halfHeight;
+
+  if (block.x < minimumX || block.x > maximumX) {
+    block.x = clamp(block.x, minimumX, maximumX);
+    block.velocityX *= -block.restitution;
+  }
+  if (block.y < minimumY || block.y > maximumY) {
+    block.y = clamp(block.y, minimumY, maximumY);
+    block.velocityY *= -block.restitution;
+    if (Math.abs(block.velocityY) < 3) block.velocityY = 0;
+  }
+}
+
+function collideBlocks(a: RigidBlock, b: RigidBlock): void {
+  const overlapX = (a.width + b.width) / 2 - Math.abs(b.x - a.x);
+  const overlapY = (a.height + b.height) / 2 - Math.abs(b.y - a.y);
+  if (overlapX <= 0 || overlapY <= 0) return;
+
+  if (overlapX < overlapY) {
+    const direction = b.x >= a.x ? 1 : -1;
+    a.x -= (overlapX / 2) * direction;
+    b.x += (overlapX / 2) * direction;
+    const average = (a.velocityX + b.velocityX) / 2;
+    a.velocityX = average * 0.3;
+    b.velocityX = average * 0.3;
+  } else {
+    const direction = b.y >= a.y ? 1 : -1;
+    a.y -= (overlapY / 2) * direction;
+    b.y += (overlapY / 2) * direction;
+    const average = (a.velocityY + b.velocityY) / 2;
+    a.velocityY = average * 0.2;
+    b.velocityY = average * 0.2;
+  }
+}
+
+function collideParticleWithBlock(particle: Particle, block: RigidBlock): void {
+  const left = block.x - block.width / 2;
+  const right = block.x + block.width / 2;
+  const top = block.y - block.height / 2;
+  const bottom = block.y + block.height / 2;
+  const nearestX = clamp(particle.x, left, right);
+  const nearestY = clamp(particle.y, top, bottom);
+  let deltaX = particle.x - nearestX;
+  let deltaY = particle.y - nearestY;
+  let length = Math.hypot(deltaX, deltaY);
+
+  if (length >= particle.radius) return;
+  if (length < 0.0001) {
+    const distances = [
+      { axis: 'x' as const, direction: -1, value: Math.abs(particle.x - left) },
+      { axis: 'x' as const, direction: 1, value: Math.abs(right - particle.x) },
+      { axis: 'y' as const, direction: -1, value: Math.abs(particle.y - top) },
+      { axis: 'y' as const, direction: 1, value: Math.abs(bottom - particle.y) },
+    ].sort((first, second) => first.value - second.value);
+    const nearest = distances[0];
+    deltaX = nearest.axis === 'x' ? nearest.direction : 0;
+    deltaY = nearest.axis === 'y' ? nearest.direction : 0;
+    length = 1;
+  }
+
+  const penetration = particle.radius - length;
+  particle.x += (deltaX / length) * penetration;
+  particle.y += (deltaY / length) * penetration;
+}
+
+export function stepTactileWorld(
+  world: TactileWorld,
+  deltaSeconds = FIXED_TIMESTEP_SECONDS,
+  options: StepOptions = {},
+): void {
+  const gravity = options.gravity ?? 820;
+  const particleDamping = options.particleDamping ?? 0.992;
+  const blockDamping = options.blockDamping ?? 0.996;
+  const solverIterations = options.solverIterations ?? 6;
+
+  for (const particle of world.particles) {
+    const velocityX = (particle.x - particle.previousX) * particleDamping;
+    const velocityY = (particle.y - particle.previousY) * particleDamping;
+    particle.previousX = particle.x;
+    particle.previousY = particle.y;
+    particle.x += velocityX;
+    particle.y += velocityY + gravity * deltaSeconds * deltaSeconds;
+  }
+
+  for (const block of world.blocks) {
+    block.velocityX *= blockDamping;
+    block.velocityY = block.velocityY * blockDamping + gravity * deltaSeconds;
+    block.x += block.velocityX * deltaSeconds;
+    block.y += block.velocityY * deltaSeconds;
+  }
+
+  for (let iteration = 0; iteration < solverIterations; iteration += 1) {
+    for (const constraint of world.distanceConstraints) {
+      solveDistanceConstraint(world.particles, constraint);
+    }
+    solveAreaConstraint(world.particles, world.areaConstraint);
+
+    for (const particle of world.particles) {
+      collideParticleWithBounds(particle, world);
+      for (const block of world.blocks) collideParticleWithBlock(particle, block);
+    }
+    for (const block of world.blocks) collideBlockWithBounds(block, world);
+    for (let a = 0; a < world.blocks.length; a += 1) {
+      for (let b = a + 1; b < world.blocks.length; b += 1) {
+        collideBlocks(world.blocks[a], world.blocks[b]);
+      }
+    }
+  }
+
+  world.frame += 1;
+}
+
+export function resetTactileWorld(world: TactileWorld): TactileWorld {
+  return createTactileWorld(world.seed, world.width, world.height);
+}
+
+export function agitateTactileWorld(world: TactileWorld, strength = 120): void {
+  for (const particle of world.particles) {
+    const [randomX, stateAfterX] = nextRandom(world.randomState);
+    const [randomY, stateAfterY] = nextRandom(stateAfterX);
+    world.randomState = stateAfterY;
+    particle.previousX = particle.x - (randomX - 0.5) * strength * FIXED_TIMESTEP_SECONDS;
+    particle.previousY = particle.y - (randomY - 0.65) * strength * FIXED_TIMESTEP_SECONDS;
+  }
+  for (const block of world.blocks) {
+    const [randomX, stateAfterX] = nextRandom(world.randomState);
+    const [randomY, stateAfterY] = nextRandom(stateAfterX);
+    world.randomState = stateAfterY;
+    block.velocityX += (randomX - 0.5) * strength;
+    block.velocityY -= randomY * strength * 0.55;
+  }
+}
+
+export function setParticlePosition(world: TactileWorld, index: number, position: Vec2): void {
+  const particle = world.particles[index];
+  if (!particle) return;
+  particle.x = clamp(position.x, particle.radius, world.width - particle.radius);
+  particle.y = clamp(position.y, particle.radius, world.height - particle.radius);
+  particle.previousX = particle.x;
+  particle.previousY = particle.y;
+}
+
+export function setBlockPosition(world: TactileWorld, id: string, position: Vec2): void {
+  const block = world.blocks.find((candidate) => candidate.id === id);
+  if (!block) return;
+  block.x = clamp(position.x, block.width / 2, world.width - block.width / 2);
+  block.y = clamp(position.y, block.height / 2, world.height - block.height / 2);
+  block.velocityX = 0;
+  block.velocityY = 0;
+}
+
+export function nudgeSelectedBody(world: TactileWorld, selected: SelectedBody, offset: Vec2): void {
+  if (selected === 'gel') {
+    for (let index = 0; index < world.particles.length; index += 1) {
+      const particle = world.particles[index];
+      setParticlePosition(world, index, { x: particle.x + offset.x, y: particle.y + offset.y });
+    }
+    return;
+  }
+  const block = world.blocks.find((candidate) => candidate.id === selected);
+  if (block) setBlockPosition(world, block.id, { x: block.x + offset.x, y: block.y + offset.y });
+}
+
+export function selectedBodyAnchor(world: TactileWorld, selected: SelectedBody): Vec2 {
+  if (selected !== 'gel') {
+    const block = world.blocks.find((candidate) => candidate.id === selected);
+    if (block) return { x: block.x, y: block.y };
+  }
+  const sum = world.particles.reduce(
+    (total, particle) => ({ x: total.x + particle.x, y: total.y + particle.y }),
+    { x: 0, y: 0 },
+  );
+  return { x: sum.x / world.particles.length, y: sum.y / world.particles.length };
+}
+
+export function gelArea(world: TactileWorld): number {
+  return polygonArea(world.particles, world.areaConstraint.indices);
+}

--- a/tests/e2e/tactile-lab.spec.ts
+++ b/tests/e2e/tactile-lab.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test, type Page, type Response } from '@playwright/test';
+
+const route = '/tactile-lab';
+const marker = 'TACTILE_SIMULATION_CLIENT_v1';
+
+async function openLab(page: Page) {
+  const response = await page.goto(route);
+  expect(response?.ok()).toBe(true);
+  const lab = page.locator('[data-tactile-lab]');
+  await expect(lab).toHaveAttribute('data-sim-ready', 'true');
+  await expect(page.locator('[data-tactile-canvas]')).toBeVisible();
+  return lab;
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    viewport: document.documentElement.clientWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+}
+
+async function numericDataset(page: Page, name: string) {
+  const value = await page.locator('[data-tactile-lab]').getAttribute(name);
+  return Number(value);
+}
+
+test('keeps the simulation client out of the ordinary homepage bundle', async ({ page }) => {
+  const scriptBodies: Promise<string>[] = [];
+  const collect = (response: Response) => {
+    const contentType = response.headers()['content-type'] ?? '';
+    if (response.url().includes('/_next/static/') && contentType.includes('javascript')) {
+      scriptBodies.push(response.text().catch(() => ''));
+    }
+  };
+  page.on('response', collect);
+
+  const homeResponse = await page.goto('/');
+  expect(homeResponse?.ok()).toBe(true);
+  await page.waitForLoadState('networkidle');
+  expect((await Promise.all(scriptBodies)).join('\n')).not.toContain(marker);
+
+  scriptBodies.length = 0;
+  await openLab(page);
+  await page.waitForLoadState('networkidle');
+  expect((await Promise.all(scriptBodies)).join('\n')).toContain(marker);
+});
+
+test('drags a rigid block with pointer capture', async ({ page }) => {
+  const lab = await openLab(page);
+  await page.locator('[data-tactile-pause]').click();
+  await expect(lab).toHaveAttribute('data-running', 'false');
+  await page.locator('[data-tactile-selection]').selectOption('block-a');
+  await expect(lab).toHaveAttribute('data-selected', 'block-a');
+
+  const canvas = page.locator('[data-tactile-canvas]');
+  const box = await canvas.boundingBox();
+  expect(box).toBeTruthy();
+  const beforeX = await numericDataset(page, 'data-selected-x');
+  const beforeY = await numericDataset(page, 'data-selected-y');
+  const startX = box!.x + (beforeX / 720) * box!.width;
+  const startY = box!.y + (beforeY / 420) * box!.height;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + Math.min(90, box!.width * 0.12), startY + 8, { steps: 5 });
+  await page.mouse.up();
+
+  await expect.poll(() => numericDataset(page, 'data-selected-x')).toBeGreaterThan(beforeX + 35);
+});
+
+test('supports keyboard selection, nudging, reset, agitation, pause, and single-step', async ({
+  page,
+}) => {
+  const lab = await openLab(page);
+  const canvas = page.locator('[data-tactile-canvas]');
+  await canvas.focus();
+  await page.keyboard.press('Space');
+  await expect(lab).toHaveAttribute('data-running', 'false');
+
+  await page.keyboard.press('2');
+  await expect(lab).toHaveAttribute('data-selected', 'block-a');
+  const beforeX = await numericDataset(page, 'data-selected-x');
+  await page.keyboard.press('ArrowRight');
+  await expect.poll(() => numericDataset(page, 'data-selected-x')).toBeGreaterThan(beforeX + 6);
+
+  const beforeFrame = await numericDataset(page, 'data-frame');
+  await page.keyboard.press('.');
+  await expect.poll(() => numericDataset(page, 'data-frame')).toBe(beforeFrame + 1);
+  await page.keyboard.press('a');
+  await page.keyboard.press('r');
+  await expect(lab).toHaveAttribute('data-selected', 'gel');
+  await expect(lab).toHaveAttribute('data-frame', '0');
+});
+
+test('pauses for controls and hidden tabs without replaying the hidden delta', async ({ page }) => {
+  const lab = await openLab(page);
+  await expect(lab).toHaveAttribute('data-running', 'true');
+  const initialFrame = await numericDataset(page, 'data-frame');
+  await expect.poll(() => numericDataset(page, 'data-frame')).toBeGreaterThan(initialFrame);
+
+  await page.locator('[data-tactile-pause]').click();
+  await expect(lab).toHaveAttribute('data-running', 'false');
+  const pausedFrame = await numericDataset(page, 'data-frame');
+  await page.waitForTimeout(180);
+  expect(await numericDataset(page, 'data-frame')).toBe(pausedFrame);
+
+  await page.locator('[data-tactile-pause]').click();
+  await expect(lab).toHaveAttribute('data-running', 'true');
+  await page.evaluate(() => {
+    const testWindow = window as typeof window & { __tactileVisibility?: DocumentVisibilityState };
+    testWindow.__tactileVisibility = 'hidden';
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => testWindow.__tactileVisibility ?? 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await expect(lab).toHaveAttribute('data-hidden-paused', 'true');
+  const hiddenFrame = await numericDataset(page, 'data-frame');
+  await page.waitForTimeout(180);
+  expect(await numericDataset(page, 'data-frame')).toBe(hiddenFrame);
+
+  await page.evaluate(() => {
+    const testWindow = window as typeof window & { __tactileVisibility?: DocumentVisibilityState };
+    testWindow.__tactileVisibility = 'visible';
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await expect(lab).toHaveAttribute('data-hidden-paused', 'false');
+  await expect.poll(() => numericDataset(page, 'data-frame')).toBeGreaterThan(hiddenFrame);
+  expect(await numericDataset(page, 'data-last-steps')).toBeLessThanOrEqual(5);
+});
+
+test('defaults reduced motion and low-power modes to paused single-step operation', async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  const lab = await openLab(page);
+  await expect(lab).toHaveAttribute('data-reduced-motion', 'true');
+  await expect(lab).toHaveAttribute('data-running', 'false');
+  const beforeFrame = await numericDataset(page, 'data-frame');
+  await page.waitForTimeout(140);
+  expect(await numericDataset(page, 'data-frame')).toBe(beforeFrame);
+  await page.locator('[data-tactile-step]').click();
+  await expect.poll(() => numericDataset(page, 'data-frame')).toBe(beforeFrame + 1);
+
+  await page.locator('[data-tactile-low-power]').click();
+  await expect(lab).toHaveAttribute('data-low-power', 'true');
+  await expect(lab).toHaveAttribute('data-running', 'false');
+});
+
+test('preserves natural page width in portrait and landscape', async ({ page }) => {
+  for (const viewport of [
+    { width: 390, height: 844 },
+    { width: 740, height: 360 },
+    { width: 1280, height: 720 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await openLab(page);
+    await expectNoHorizontalOverflow(page);
+  }
+});


### PR DESCRIPTION
Closes #411

## Foundation

- adds `/tactile-lab` as a noindex experimental route;
- dynamically imports the simulation client behind a route-only client loader;
- uses deterministic seed `411` and a 60 Hz fixed timestep with at most five catch-up steps;
- pauses on hidden tabs and discards hidden elapsed time before resume;
- includes three axis-aligned rigid blocks, wall/floor bounds, block/block and particle/block collision, and one gel body with distance plus area constraints;
- supports pointer-captured drag, native reset/agitation/pause/single-step controls, body selection, and keyboard selection/nudging;
- defaults reduced-motion and low-power operation to paused single-step mode unless continuous running is explicitly enabled;
- keeps per-frame world state outside React and exposes compact frame/body/particle/constraint diagnostics;
- releases pointer capture, disconnects ResizeObserver, removes visibility listeners, and cancels animation frames on cancellation or unmount.

## Coverage

Unit tests cover fixed-step accumulation and bounded catch-up, deterministic reset/agitation, distance and area constraint projection, collision bounds, hidden-tab resume, and loop cleanup.

Chromium/WebKit coverage checks route-bundle isolation, rigid-block drag, keyboard controls, pause/resume, hidden-tab recovery, reduced motion, low-power mode, and portrait/landscape overflow.

## Isolation fence

The diff does not modify the production homepage, activity field, time picker, navigation progress, shared navigation, or material paint/primitives.

## Status

Draft CI is running on head `b1d0f30120d2be5579caf277c792e6b5691a50de`. Evidence and review findings will be added after the combined run.

## Review handoff

Agent 1: please review route/bundle isolation, simulation bounds, and bundle impact after CI is green.
Agent 2 may review lifecycle cleanup once #410 is underway.