### PR TITLE
Add mobile Space actions and a full-screen editor sheet

### DIFF
--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -7,6 +7,7 @@ import { ItemsProvider } from '../lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/server';
 import { SearchCommand } from '@/components/space/search-command';
 import { MonacoEditorPanel } from '@/components/space/monaco-editor-panel';
+import { SpaceShortcutProvider } from '@/components/space/space-shortcut-provider';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import { isAdminUser } from '@/app/lib/auth/admin';
 import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
@@ -93,12 +94,14 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
         initialNowMs={nowMs}
         initialHasMore={hasMore}
       >
-        <div className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
-          <SearchCommand />
-          <AppSidebar />
-          <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
-          <MonacoEditorPanel />
-        </div>
+        <SpaceShortcutProvider>
+          <div className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
+            <SearchCommand />
+            <AppSidebar />
+            <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
+            <MonacoEditorPanel />
+          </div>
+        </SpaceShortcutProvider>
       </ItemsProvider>
     </SidebarProvider>
   );

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -37,6 +37,7 @@ const REVIEW_SELECT = [
   'suspended',
 ].join(',');
 
+const E2E_NOW_MS = Date.parse('2026-07-27T00:00:00.000Z');
 const E2E_ITEMS: Item[] = [
   {
     id: '00000000-0000-4000-8000-000000000001',
@@ -91,18 +92,18 @@ const E2E_USER = {
 } as User;
 
 async function getInitialData() {
-  const nowMs = Date.now();
   if (process.env.SCRAPBOOK_E2E_SPACE_FIXTURE === '1') {
     return {
       items: E2E_ITEMS,
       isAdmin: true,
       user: E2E_USER,
-      nowMs,
+      nowMs: E2E_NOW_MS,
       hasMore: false,
     };
   }
 
   const supabase = await createClient();
+  const nowMs = Date.now();
   const [authResult, itemsResult] = await Promise.all([
     supabase.auth.getUser(),
     supabase

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
+import type { User } from '@supabase/supabase-js';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/space/app-sidebar';
 import { SpaceShellSkeleton } from '@/components/space/space-shell-skeleton';
@@ -12,6 +13,7 @@ import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import { isAdminUser } from '@/app/lib/auth/admin';
 import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
 import type { DbItem, DbReview } from '@/app/lib/db/supabase';
+import type { Item } from '@/app/lib/item-types';
 
 export const metadata: Metadata = {
   title: 'Space',
@@ -35,10 +37,72 @@ const REVIEW_SELECT = [
   'suspended',
 ].join(',');
 
-async function getInitialData() {
-  const supabase = await createClient();
-  const nowMs = Date.now();
+const E2E_ITEMS: Item[] = [
+  {
+    id: '00000000-0000-4000-8000-000000000001',
+    title: 'Shortcut Alpha',
+    slug: 'shortcut-alpha',
+    url: null,
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'notes',
+        content: 'Alpha review content',
+        contentHtml: '<p>Alpha review content</p>',
+        code: 'print("alpha")',
+        codeHtml: '<pre><code>print(&quot;alpha&quot;)</code></pre>',
+      },
+    ],
+    tags: ['topic:shortcuts', 'type:test'],
+    category: 'reference',
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000002',
+    title: 'Shortcut Beta',
+    slug: 'shortcut-beta',
+    url: null,
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'notes',
+        content: 'Beta review content',
+        contentHtml: '<p>Beta review content</p>',
+        code: null,
+        codeHtml: '',
+      },
+    ],
+    tags: ['topic:shortcuts', 'type:test'],
+    category: 'reference',
+    createdAt: 2,
+    updatedAt: 2,
+  },
+];
 
+const E2E_USER = {
+  id: '00000000-0000-4000-8000-000000000099',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'space-e2e@example.com',
+  app_metadata: {},
+  user_metadata: {},
+  created_at: '2026-07-27T00:00:00.000Z',
+} as User;
+
+async function getInitialData() {
+  const nowMs = Date.now();
+  if (process.env.SCRAPBOOK_E2E_SPACE_FIXTURE === '1') {
+    return {
+      items: E2E_ITEMS,
+      isAdmin: true,
+      user: E2E_USER,
+      nowMs,
+      hasMore: false,
+    };
+  }
+
+  const supabase = await createClient();
   const [authResult, itemsResult] = await Promise.all([
     supabase.auth.getUser(),
     supabase

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -8,6 +8,7 @@ import { ItemsProvider } from '../lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/server';
 import { SearchCommand } from '@/components/space/search-command';
 import { MonacoEditorPanel } from '@/components/space/monaco-editor-panel';
+import { SpaceMobileActions } from '@/components/space/space-mobile-actions';
 import { SpaceShortcutProvider } from '@/components/space/space-shortcut-provider';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import { isAdminUser } from '@/app/lib/auth/admin';
@@ -160,10 +161,19 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
         initialHasMore={hasMore}
       >
         <SpaceShortcutProvider>
-          <div className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
-            <SearchCommand />
-            <AppSidebar />
-            <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
+          <div
+            data-space-shell
+            className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground"
+          >
+            <div
+              data-space-background
+              className="flex h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+            >
+              <SearchCommand />
+              <AppSidebar />
+              <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
+              <SpaceMobileActions />
+            </div>
             <MonacoEditorPanel />
           </div>
         </SpaceShortcutProvider>

--- a/components/space/app-sidebar.tsx
+++ b/components/space/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Sidebar,
   SidebarContent,
@@ -18,7 +18,15 @@ import {
 } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { ArrowLeft, ArrowRight, Loader2, LogOut, Plus, Search } from 'lucide-react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  CircleHelp,
+  Loader2,
+  LogOut,
+  Plus,
+  Search,
+} from 'lucide-react';
 import { shortcuts } from '@/app/lib/sidebar-data';
 import { useItems } from '@/app/lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/client';
@@ -26,12 +34,14 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { GoogleIcon } from '@/components/icons/google-icon';
 import { GitHubIcon } from '@/components/icons/github-icon';
 import { SpaceLinkHint } from '@/components/space/space-link-hint';
+import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
 
 export function AppSidebar() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
+  const { openHelp, openSearch } = useSpaceShortcuts();
   const currentQuery = searchParams.get('tags') || '';
   const isReviewLike =
     pathname === '/space/review' ||
@@ -52,41 +62,6 @@ export function AppSidebar() {
   const closeMobile = () => {
     if (isMobile) setOpenMobile(false);
   };
-
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      const role = target?.getAttribute?.('role');
-      const isTyping =
-        tag === 'input' ||
-        tag === 'textarea' ||
-        target?.getAttribute('contenteditable') === 'true' ||
-        role === 'textbox';
-      if (isTyping) return;
-
-      const isMod = event.metaKey || event.ctrlKey;
-      if (isMod && event.altKey && (event.key === 'a' || event.code === 'KeyA')) {
-        event.preventDefault();
-        router.push('/space/add');
-        return;
-      }
-
-      if (isMod && !event.altKey && !event.shiftKey && (event.key === 'e' || event.code === 'KeyE')) {
-        event.preventDefault();
-        router.push(isReviewLike ? listHref : reviewHref);
-        return;
-      }
-
-      if (isMod && !event.altKey && event.shiftKey && (event.key === 'e' || event.code === 'KeyE')) {
-        event.preventDefault();
-        router.push(isReviewLike ? listHref : reviewHref);
-      }
-    };
-
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [isReviewLike, listHref, reviewHref, router]);
 
   const handleOAuthSignIn = async (provider: 'google' | 'github') => {
     setLoading(true);
@@ -112,7 +87,12 @@ export function AppSidebar() {
   };
 
   const triggerSearch = () => {
-    window.dispatchEvent(new Event('open-search'));
+    openSearch();
+    closeMobile();
+  };
+
+  const triggerHelp = () => {
+    openHelp();
     closeMobile();
   };
 
@@ -127,20 +107,35 @@ export function AppSidebar() {
         </div>
       </SidebarHeader>
 
-      <div className="shrink-0 border-b p-3">
+      <div className="shrink-0 space-y-2 border-b p-3">
         <button
           onClick={triggerSearch}
           className="flex w-full items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted"
           type="button"
         >
-          <Search className="h-4 w-4" />
+          <Search className="h-4 w-4" aria-hidden="true" />
           <span className="flex-1 text-left">Search</span>
-          <span className="hidden gap-1 sm:flex">
+          <span className="hidden gap-1 sm:flex" aria-hidden="true">
             <kbd className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold">
               {isMac ? '⌘' : 'Ctrl'}
             </kbd>
             <kbd className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold">K</kbd>
           </span>
+        </button>
+        <button
+          onClick={triggerHelp}
+          className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted"
+          type="button"
+          aria-label="Keyboard shortcuts"
+        >
+          <CircleHelp className="h-4 w-4" aria-hidden="true" />
+          <span className="flex-1 text-left">Keyboard reference</span>
+          <kbd
+            className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold"
+            aria-hidden="true"
+          >
+            ?
+          </kbd>
         </button>
       </div>
 
@@ -233,7 +228,11 @@ export function AppSidebar() {
               disabled={loading}
               className="w-full"
             >
-              {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <GoogleIcon className="mr-2 h-4 w-4" />}
+              {loading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <GoogleIcon className="mr-2 h-4 w-4" />
+              )}
               Google
             </Button>
             <Button
@@ -243,7 +242,11 @@ export function AppSidebar() {
               disabled={loading}
               className="w-full"
             >
-              {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <GitHubIcon className="mr-2 h-4 w-4" />}
+              {loading ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <GitHubIcon className="mr-2 h-4 w-4" />
+              )}
               GitHub
             </Button>
           </>

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -1,40 +1,185 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { X } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useSidebar } from '@/components/ui/sidebar';
 import { useItems } from '@/app/lib/contexts/item-context';
-import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
+import {
+  useSpaceShortcut,
+  useSpaceShortcuts,
+} from '@/components/space/space-shortcut-provider';
+import {
+  createBrowserEditorSheetRestoration,
+  createEditorSheetHistoryState,
+  ownsEditorSheetHistoryState,
+  resolveEditorSheetViewport,
+  type EditorSheetViewport,
+} from '@/lib/space-editor-sheet';
+
+const DEFAULT_EDITOR_HEIGHT = 384;
+
+function visibleEditorTrigger() {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-space-editor-trigger]'),
+  ).find((element) => element.offsetParent !== null) ?? null;
+}
 
 export function MonacoEditorPanel() {
   const { editorOpen, setEditorOpen } = useItems();
   const { executeShortcut } = useSpaceShortcuts();
   const editorRef = useRef<HTMLDivElement>(null);
+  const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
+  const executeShortcutRef = useRef(executeShortcut);
+  const historyTokenRef = useRef<string | null>(null);
+  const restorationRef = useRef<ReturnType<typeof createBrowserEditorSheetRestoration> | null>(
+    null,
+  );
   const { resolvedTheme } = useTheme();
-  const { state } = useSidebar();
-  const [editorHeight, setEditorHeight] = useState(384);
+  const { state, isMobile } = useSidebar();
+  const [editorHeight, setEditorHeight] = useState(DEFAULT_EDITOR_HEIGHT);
+  const [hasOpened, setHasOpened] = useState(editorOpen);
   const [isInitializing, setIsInitializing] = useState(false);
   const [initializationError, setInitializationError] = useState<string | null>(null);
+  const [sheetViewport, setSheetViewport] = useState<EditorSheetViewport>({
+    top: 0,
+    height: 0,
+    bottom: 0,
+  });
 
   const isDark = resolvedTheme === 'dark';
   const shikiTheme = isDark ? 'catppuccin-macchiato' : 'one-light';
   const sidebarWidth = state === 'collapsed' ? '3rem' : '16rem';
+
+  useLayoutEffect(() => {
+    executeShortcutRef.current = executeShortcut;
+  }, [executeShortcut]);
+
+  useEffect(() => {
+    if (editorOpen) setHasOpened(true);
+    if (!editorOpen && !isMobile) setEditorHeight(DEFAULT_EDITOR_HEIGHT);
+  }, [editorOpen, isMobile]);
 
   useEffect(() => {
     if (!monacoRef.current) return;
     monacoRef.current.editor.setTheme(shikiTheme);
   }, [shikiTheme]);
 
-  useEffect(() => {
-    if (!editorOpen) {
-      setEditorHeight(384);
-      setIsInitializing(false);
-      setInitializationError(null);
-      return;
+  const closeMobileEditor = useCallback(() => {
+    const token = historyTokenRef.current;
+    historyTokenRef.current = null;
+    setEditorOpen(false);
+
+    if (token && ownsEditorSheetHistoryState(window.history.state, token)) {
+      window.history.back();
+    }
+  }, [setEditorOpen]);
+
+  const toggleEditorRegistration = useMemo(
+    () => ({
+      run: () => {
+        if (editorOpen && isMobile) {
+          closeMobileEditor();
+          return;
+        }
+        setEditorOpen(!editorOpen);
+      },
+    }),
+    [closeMobileEditor, editorOpen, isMobile, setEditorOpen],
+  );
+
+  const closeEditorRegistration = useMemo(
+    () => ({
+      active: editorOpen && isMobile,
+      run: closeMobileEditor,
+    }),
+    [closeMobileEditor, editorOpen, isMobile],
+  );
+
+  useSpaceShortcut('editor.toggle', toggleEditorRegistration);
+  useSpaceShortcut('editor.close', closeEditorRegistration);
+
+  useLayoutEffect(() => {
+    if (!editorOpen || !isMobile) return;
+
+    const restoration =
+      restorationRef.current ??
+      (restorationRef.current = createBrowserEditorSheetRestoration());
+    const focusTarget =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const scrollRegions = document.querySelectorAll<HTMLElement>('[data-space-scroll-region]');
+    restoration.capture(focusTarget, scrollRegions);
+
+    const background = document.querySelector<HTMLElement>('[data-space-background]');
+    const previousAriaHidden = background?.getAttribute('aria-hidden') ?? null;
+    if (background) {
+      background.inert = true;
+      background.setAttribute('aria-hidden', 'true');
     }
 
-    if (!editorRef.current) return;
+    const token = `space-editor-${crypto.randomUUID()}`;
+    historyTokenRef.current = token;
+    window.history.pushState(
+      createEditorSheetHistoryState(window.history.state, token),
+      '',
+      window.location.href,
+    );
+
+    const updateViewport = () => {
+      const viewport = window.visualViewport;
+      setSheetViewport(
+        resolveEditorSheetViewport(
+          window.innerHeight,
+          viewport
+            ? { height: viewport.height, offsetTop: viewport.offsetTop }
+            : null,
+        ),
+      );
+      window.requestAnimationFrame(() => editorInstanceRef.current?.layout());
+    };
+
+    const dismissFromHistory = () => {
+      historyTokenRef.current = null;
+      setEditorOpen(false);
+    };
+
+    updateViewport();
+    const viewport = window.visualViewport;
+    viewport?.addEventListener('resize', updateViewport);
+    viewport?.addEventListener('scroll', updateViewport);
+    window.addEventListener('resize', updateViewport);
+    window.addEventListener('popstate', dismissFromHistory);
+
+    return () => {
+      viewport?.removeEventListener('resize', updateViewport);
+      viewport?.removeEventListener('scroll', updateViewport);
+      window.removeEventListener('resize', updateViewport);
+      window.removeEventListener('popstate', dismissFromHistory);
+
+      if (background) {
+        background.inert = false;
+        if (previousAriaHidden === null) background.removeAttribute('aria-hidden');
+        else background.setAttribute('aria-hidden', previousAriaHidden);
+      }
+
+      restoration.restore(visibleEditorTrigger());
+    };
+  }, [editorOpen, isMobile, setEditorOpen]);
+
+  useEffect(() => {
+    return () => restorationRef.current?.cancel();
+  }, []);
+
+  useEffect(() => {
+    if (!hasOpened || !editorRef.current || editorInstanceRef.current) return;
 
     setIsInitializing(true);
     setInitializationError(null);
@@ -48,20 +193,19 @@ export function MonacoEditorPanel() {
     }
 
     let disposed = false;
-    let cleanup: (() => void) | undefined;
+    let editor: any;
+    let contentSizeDisposable: { dispose: () => void } | undefined;
 
     const initEditor = async () => {
-      if (typeof window !== 'undefined') {
-        (window as any).MonacoEnvironment = {
-          getWorker() {
-            return new Worker(
-              URL.createObjectURL(
-                new Blob(['self.onmessage = () => {}'], { type: 'text/javascript' }),
-              ),
-            );
-          },
-        };
-      }
+      (window as any).MonacoEnvironment = {
+        getWorker() {
+          return new Worker(
+            URL.createObjectURL(
+              new Blob(['self.onmessage = () => {}'], { type: 'text/javascript' }),
+            ),
+          );
+        },
+      };
 
       const [{ createHighlighter }, { shikiToMonaco }, _pythonContribution, monaco] =
         await Promise.all([
@@ -84,7 +228,7 @@ export function MonacoEditorPanel() {
       monaco.languages.register?.({ id: 'python' });
       shikiToMonaco(highlighter, monaco);
 
-      const editor = monaco.editor.create(editorRef.current, {
+      editor = monaco.editor.create(editorRef.current, {
         value: '',
         language: 'python',
         theme: shikiTheme,
@@ -105,23 +249,26 @@ export function MonacoEditorPanel() {
         lineNumbersMinChars: 3,
       });
 
+      editorInstanceRef.current = editor;
       monaco.editor.setTheme(shikiTheme);
       setIsInitializing(false);
 
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI, () => {
-        executeShortcut('editor.toggle');
+        executeShortcutRef.current('editor.toggle');
       });
 
-      editor.focus();
-
-      editor.onDidContentSizeChange(() => {
+      contentSizeDisposable = editor.onDidContentSizeChange(() => {
+        if (window.matchMedia('(max-width: 767px)').matches) return;
         const contentHeight = editor.getContentHeight();
         const maxHeight = window.innerHeight - 112;
-        const newHeight = Math.max(384, Math.min(contentHeight + 32, maxHeight));
-        setEditorHeight(newHeight);
+        const nextHeight = Math.max(
+          DEFAULT_EDITOR_HEIGHT,
+          Math.min(contentHeight + 32, maxHeight),
+        );
+        setEditorHeight(nextHeight);
       });
 
-      cleanup = () => editor.dispose();
+      if (editorOpen) editor.focus();
     };
 
     void initEditor().catch((error) => {
@@ -133,46 +280,97 @@ export function MonacoEditorPanel() {
 
     return () => {
       disposed = true;
-      cleanup?.();
+      contentSizeDisposable?.dispose();
+      editor?.dispose();
+      editorInstanceRef.current = null;
     };
-  }, [editorOpen, executeShortcut, shikiTheme]);
+  }, [editorOpen, hasOpened, shikiTheme]);
 
-  if (!editorOpen) return null;
+  useEffect(() => {
+    if (!editorOpen || !editorInstanceRef.current) return;
+    const frame = window.requestAnimationFrame(() => {
+      editorInstanceRef.current?.layout();
+      editorInstanceRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [editorOpen, isMobile, sheetViewport.height, sheetViewport.top]);
+
+  if (!hasOpened && !editorOpen) return null;
+
+  const mobileStyle = {
+    left: 0,
+    top: `${sheetViewport.top}px`,
+    width: '100vw',
+    height: `${sheetViewport.height || window.innerHeight}px`,
+  };
+  const desktopStyle = {
+    left: `calc(${sidebarWidth} + 1rem)`,
+    width: 'calc((100vw - var(--sidebar-width) - 2rem) / 2 - 0.375rem)',
+    height: `${editorHeight}px`,
+  };
 
   return (
-    <div
+    <section
+      data-space-editor-sheet={isMobile ? 'true' : undefined}
       data-space-shortcut-scope="editor"
-      className="fixed top-24 z-50 overflow-hidden rounded-lg border border-border shadow-2xl transition-[left,width] duration-200 ease-linear"
-      style={{
-        left: `calc(${sidebarWidth} + 1rem)`,
-        width: 'calc((100vw - var(--sidebar-width) - 2rem) / 2 - 0.375rem)',
-        height: `${editorHeight}px`,
-      }}
+      role={isMobile && editorOpen ? 'dialog' : undefined}
+      aria-modal={isMobile && editorOpen ? true : undefined}
+      aria-labelledby={isMobile ? 'space-editor-title' : undefined}
+      aria-describedby={isMobile ? 'space-editor-description' : undefined}
+      aria-hidden={!editorOpen}
+      className={`fixed z-[60] flex overflow-hidden bg-[#f4f1ea] text-[#383a42] shadow-2xl transition-opacity duration-150 motion-reduce:transition-none dark:bg-[#202126] dark:text-[#cad3f5] md:top-24 md:rounded-lg md:border md:border-border md:transition-[left,width,opacity] md:duration-200 md:ease-linear ${
+        editorOpen ? 'visible pointer-events-auto opacity-100' : 'invisible pointer-events-none opacity-0'
+      } ${isMobile ? 'inset-x-0 flex-col' : ''}`}
+      style={isMobile ? mobileStyle : desktopStyle}
     >
-      {isInitializing ? (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
-          <p className="animate-pulse text-sm text-[#383a42] dark:text-[#cad3f5]">
-            Opening a clean workbench…
-          </p>
-        </div>
-      ) : null}
-
-      {initializationError ? (
-        <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
-          <p className="max-w-sm text-sm leading-relaxed text-[#383a42] dark:text-[#cad3f5]">
-            {initializationError}
-          </p>
+      {isMobile ? (
+        <header className="flex shrink-0 items-center gap-3 border-b border-black/10 px-3 pb-2 pt-[calc(0.5rem+env(safe-area-inset-top))] dark:border-white/10">
+          <div className="min-w-0 flex-1">
+            <h2 id="space-editor-title" className="truncate text-sm font-semibold">
+              Code editor
+            </h2>
+            <p id="space-editor-description" className="text-xs text-black/55 dark:text-white/55">
+              Unsaved code stays here when the sheet closes.
+            </p>
+          </div>
           <button
             type="button"
-            onClick={() => setEditorOpen(false)}
-            className="rounded-md border border-black/15 bg-white px-3 py-1.5 text-sm font-medium text-black/75 transition hover:bg-black/[0.04] active:scale-[0.98] dark:border-white/15 dark:bg-[#18191d] dark:text-white/80 dark:hover:bg-[#25262c]"
+            data-space-editor-close
+            onClick={closeMobileEditor}
+            className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-md border border-black/15 bg-white/70 transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none dark:border-white/15 dark:bg-black/20 dark:hover:bg-black/35"
+            aria-label="Close code editor"
           >
-            Close editor
+            <X className="h-5 w-5" aria-hidden="true" />
           </button>
-        </div>
+        </header>
       ) : null}
 
-      <div ref={editorRef} className="h-full w-full" />
-    </div>
+      <div className="relative min-h-0 flex-1 pb-[env(safe-area-inset-bottom)] md:pb-0">
+        {isInitializing ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
+            <p className="animate-pulse text-sm text-[#383a42] motion-reduce:animate-none dark:text-[#cad3f5]">
+              Opening a clean workbench…
+            </p>
+          </div>
+        ) : null}
+
+        {initializationError ? (
+          <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
+            <p className="max-w-sm text-sm leading-relaxed text-[#383a42] dark:text-[#cad3f5]">
+              {initializationError}
+            </p>
+            <button
+              type="button"
+              onClick={() => (isMobile ? closeMobileEditor() : setEditorOpen(false))}
+              className="rounded-md border border-black/15 bg-white px-3 py-1.5 text-sm font-medium text-black/75 transition hover:bg-black/[0.04] active:scale-[0.98] motion-reduce:transition-none dark:border-white/15 dark:bg-[#18191d] dark:text-white/80 dark:hover:bg-[#25262c]"
+            >
+              Close editor
+            </button>
+          </div>
+        ) : null}
+
+        <div ref={editorRef} className="h-full min-h-0 w-full" />
+      </div>
+    </section>
   );
 }

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -27,9 +27,11 @@ import {
 const DEFAULT_EDITOR_HEIGHT = 384;
 
 function visibleEditorTrigger() {
-  return Array.from(
-    document.querySelectorAll<HTMLElement>('[data-space-editor-trigger]'),
-  ).find((element) => element.offsetParent !== null) ?? null;
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLElement>('[data-space-editor-trigger]'),
+    ).find((element) => element.offsetParent !== null) ?? null
+  );
 }
 
 export function MonacoEditorPanel() {
@@ -39,6 +41,8 @@ export function MonacoEditorPanel() {
   const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
   const executeShortcutRef = useRef(executeShortcut);
+  const editorOpenRef = useRef(editorOpen);
+  const shikiThemeRef = useRef('one-light');
   const historyTokenRef = useRef<string | null>(null);
   const restorationRef = useRef<ReturnType<typeof createBrowserEditorSheetRestoration> | null>(
     null,
@@ -61,7 +65,9 @@ export function MonacoEditorPanel() {
 
   useLayoutEffect(() => {
     executeShortcutRef.current = executeShortcut;
-  }, [executeShortcut]);
+    editorOpenRef.current = editorOpen;
+    shikiThemeRef.current = shikiTheme;
+  }, [editorOpen, executeShortcut, shikiTheme]);
 
   useEffect(() => {
     if (editorOpen) setHasOpened(true);
@@ -231,7 +237,7 @@ export function MonacoEditorPanel() {
       editor = monaco.editor.create(editorRef.current, {
         value: '',
         language: 'python',
-        theme: shikiTheme,
+        theme: shikiThemeRef.current,
         automaticLayout: true,
         minimap: { enabled: false },
         fontSize: 14,
@@ -250,7 +256,7 @@ export function MonacoEditorPanel() {
       });
 
       editorInstanceRef.current = editor;
-      monaco.editor.setTheme(shikiTheme);
+      monaco.editor.setTheme(shikiThemeRef.current);
       setIsInitializing(false);
 
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI, () => {
@@ -268,7 +274,7 @@ export function MonacoEditorPanel() {
         setEditorHeight(nextHeight);
       });
 
-      if (editorOpen) editor.focus();
+      if (editorOpenRef.current) editor.focus();
     };
 
     void initEditor().catch((error) => {
@@ -284,7 +290,7 @@ export function MonacoEditorPanel() {
       editor?.dispose();
       editorInstanceRef.current = null;
     };
-  }, [editorOpen, hasOpened, shikiTheme]);
+  }, [hasOpened]);
 
   useEffect(() => {
     if (!editorOpen || !editorInstanceRef.current) return;
@@ -301,7 +307,7 @@ export function MonacoEditorPanel() {
     left: 0,
     top: `${sheetViewport.top}px`,
     width: '100vw',
-    height: `${sheetViewport.height || window.innerHeight}px`,
+    height: sheetViewport.height ? `${sheetViewport.height}px` : '100dvh',
   };
   const desktopStyle = {
     left: `calc(${sidebarWidth} + 1rem)`,

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -4,9 +4,11 @@ import { useEffect, useRef, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { useSidebar } from '@/components/ui/sidebar';
 import { useItems } from '@/app/lib/contexts/item-context';
+import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
 
 export function MonacoEditorPanel() {
   const { editorOpen, setEditorOpen } = useItems();
+  const { executeShortcut } = useSpaceShortcuts();
   const editorRef = useRef<HTMLDivElement>(null);
   const monacoRef = useRef<any>(null);
   const { resolvedTheme } = useTheme();
@@ -18,20 +20,6 @@ export function MonacoEditorPanel() {
   const isDark = resolvedTheme === 'dark';
   const shikiTheme = isDark ? 'catppuccin-macchiato' : 'one-light';
   const sidebarWidth = state === 'collapsed' ? '3rem' : '16rem';
-
-  useEffect(() => {
-    const handleKey = (event: KeyboardEvent) => {
-      const isMod = event.metaKey || event.ctrlKey;
-
-      if (isMod && !event.altKey && !event.shiftKey && (event.key === 'i' || event.code === 'KeyI')) {
-        event.preventDefault();
-        setEditorOpen(!editorOpen);
-      }
-    };
-
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [editorOpen, setEditorOpen]);
 
   useEffect(() => {
     if (!monacoRef.current) return;
@@ -121,7 +109,7 @@ export function MonacoEditorPanel() {
       setIsInitializing(false);
 
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI, () => {
-        setEditorOpen(false);
+        executeShortcut('editor.toggle');
       });
 
       editor.focus();
@@ -147,12 +135,13 @@ export function MonacoEditorPanel() {
       disposed = true;
       cleanup?.();
     };
-  }, [editorOpen, setEditorOpen, shikiTheme]);
+  }, [editorOpen, executeShortcut, shikiTheme]);
 
   if (!editorOpen) return null;
 
   return (
     <div
+      data-space-shortcut-scope="editor"
       className="fixed top-24 z-50 overflow-hidden rounded-lg border border-border shadow-2xl transition-[left,width] duration-200 ease-linear"
       style={{
         left: `calc(${sidebarWidth} + 1rem)`,

--- a/components/space/review-gallery.tsx
+++ b/components/space/review-gallery.tsx
@@ -157,7 +157,10 @@ export function ReviewGallery() {
           onEditorToggle={() => setEditorOpen(!editorOpen)}
           isEditorOpen={editorOpen}
         />
-        <div className="p-4 text-muted-foreground">
+        <div
+          data-space-scroll-region
+          className="min-h-0 flex-1 overflow-y-auto px-4 pt-4 pb-[calc(5.75rem+env(safe-area-inset-bottom))] text-muted-foreground md:pb-4"
+        >
           {error ? (
             <div
               className="flex max-w-xl items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
@@ -181,7 +184,10 @@ export function ReviewGallery() {
   const progress = `${currentIndex + 1} / ${items.length}${hasMore ? '+' : ''}${refreshing ? ' · Updating' : ''}`;
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background">
+    <div
+      data-space-review-content={showContent ? 'visible' : 'hidden'}
+      className="flex h-full min-h-0 flex-col bg-background"
+    >
       <SpaceHeader
         leftContent={progress}
         onEditorToggle={() => setEditorOpen(!editorOpen)}
@@ -204,7 +210,10 @@ export function ReviewGallery() {
         }
       />
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3 sm:p-6">
+      <div
+        data-space-scroll-region
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto px-3 pt-3 pb-[calc(5.75rem+env(safe-area-inset-bottom))] sm:px-6 sm:pt-6 md:pb-6 lg:overflow-hidden"
+      >
         {error ? (
           <div
             className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm"
@@ -217,7 +226,9 @@ export function ReviewGallery() {
           </div>
         ) : null}
 
-        <h1 className="mb-4 text-2xl font-bold text-foreground">{current.title}</h1>
+        <h1 data-space-current-item={current.id} className="mb-4 text-2xl font-bold text-foreground">
+          {current.title}
+        </h1>
 
         {current.versions.length > 1 && (
           <div className="mb-4 flex flex-wrap gap-2 text-sm">
@@ -241,7 +252,10 @@ export function ReviewGallery() {
         )}
 
         {showContent && active && (
-          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto lg:flex-row lg:overflow-hidden">
+          <div
+            data-space-scroll-region
+            className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto lg:flex-row lg:overflow-hidden"
+          >
             <div className="min-h-48 min-w-0 flex-1 overflow-auto rounded border border-border bg-white p-4 dark:border-sidebar-border dark:bg-sidebar">
               <div className="prose prose-sm max-w-none dark:prose-invert">
                 <MarkdownContent

--- a/components/space/review-gallery.tsx
+++ b/components/space/review-gallery.tsx
@@ -15,6 +15,8 @@ import { createClient } from '@/utils/supabase/client';
 import type { ReviewState } from '@/app/lib/review-types';
 import { SpaceHeader } from './space-header';
 import { CodeDisplay } from './code-display';
+import { useSpaceShortcut } from './space-shortcut-provider';
+import { startNavigationFeedback } from '@/components/navigation-feedback';
 
 export function ReviewGallery() {
   const supabase = createClient();
@@ -54,6 +56,7 @@ export function ReviewGallery() {
 
   const current = items[currentIndex];
   const active = current?.versions[activeIdx];
+  const exitHref = `/space${tagsParam ? `?tags=${encodeURIComponent(tagsParam)}` : ''}`;
 
   useEffect(() => {
     if (hasMore && !loadingMore) void loadMore();
@@ -70,41 +73,50 @@ export function ReviewGallery() {
     }
   }, [itemParam, items]);
 
-  useEffect(() => {
-    const handleKey = (event: KeyboardEvent) => {
-      const target = event.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      const role = target?.getAttribute?.('role');
-      const isTyping =
-        tag === 'input' ||
-        tag === 'textarea' ||
-        target?.getAttribute('contenteditable') === 'true' ||
-        role === 'textbox';
-
-      if (isTyping || event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
-
-      if (event.key === 'ArrowRight' || event.key === 'j') {
-        event.preventDefault();
+  const nextShortcut = useMemo(
+    () => ({
+      enabled: Boolean(current) && currentIndex < items.length - 1,
+      disabledReason: current ? 'Already at the last review item' : 'No review item is available',
+      run: () => {
         setCurrentIndex((index) => Math.min(index + 1, items.length - 1));
         setShowContent(true);
-      }
-      if (event.key === 'ArrowLeft' || event.key === 'k') {
-        event.preventDefault();
+      },
+    }),
+    [current, currentIndex, items.length],
+  );
+  const previousShortcut = useMemo(
+    () => ({
+      enabled: Boolean(current) && currentIndex > 0,
+      disabledReason: current ? 'Already at the first review item' : 'No review item is available',
+      run: () => {
         setCurrentIndex((index) => Math.max(index - 1, 0));
         setShowContent(true);
-      }
-      if (event.key === ' ') {
-        event.preventDefault();
-        setShowContent((visible) => !visible);
-      }
-      if (event.key === 'Escape') {
-        router.push(`/space${tagsParam ? `?tags=${tagsParam}` : ''}`);
-      }
-    };
+      },
+    }),
+    [current, currentIndex],
+  );
+  const toggleContentShortcut = useMemo(
+    () => ({
+      enabled: Boolean(current),
+      disabledReason: current ? undefined : 'No review item is available',
+      run: () => setShowContent((visible) => !visible),
+    }),
+    [current],
+  );
+  const exitShortcut = useMemo(
+    () => ({
+      run: () => {
+        startNavigationFeedback(exitHref, 'item list');
+        router.push(exitHref);
+      },
+    }),
+    [exitHref, router],
+  );
 
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [items.length, router, tagsParam]);
+  useSpaceShortcut('review.next', nextShortcut);
+  useSpaceShortcut('review.previous', previousShortcut);
+  useSpaceShortcut('review.toggle-content', toggleContentShortcut);
+  useSpaceShortcut('review.exit', exitShortcut);
 
   const onReview = async (rating: Rating) => {
     if (!current) return;
@@ -147,7 +159,10 @@ export function ReviewGallery() {
         />
         <div className="p-4 text-muted-foreground">
           {error ? (
-            <div className="flex max-w-xl items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm text-foreground" role="alert">
+            <div
+              className="flex max-w-xl items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+              role="alert"
+            >
               <span>{error}</span>
               <Button variant="outline" size="sm" onClick={() => void reload()}>
                 Retry
@@ -175,10 +190,14 @@ export function ReviewGallery() {
           isAdmin ? (
             <>
               <Button asChild variant="outline" size="sm">
-                <Link href={`/space/edit/${current.slug}`} prefetch>edit</Link>
+                <Link href={`/space/edit/${current.slug}`} prefetch>
+                  edit
+                </Link>
               </Button>
               <Button asChild variant="outline" size="sm">
-                <Link href={`/space/add?duplicate=${current.slug}`} prefetch>duplicate</Link>
+                <Link href={`/space/add?duplicate=${current.slug}`} prefetch>
+                  duplicate
+                </Link>
               </Button>
             </>
           ) : undefined
@@ -187,7 +206,10 @@ export function ReviewGallery() {
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3 sm:p-6">
         {error ? (
-          <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm" role="alert">
+          <div
+            className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm"
+            role="alert"
+          >
             <span className="min-w-0">{error}</span>
             <Button variant="outline" size="sm" className="shrink-0" onClick={() => void reload()}>
               Retry

--- a/components/space/search-command.tsx
+++ b/components/space/search-command.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   CommandDialog,
@@ -18,6 +18,7 @@ import { searchItems } from '@/app/lib/item-search';
 import type { Item } from '@/app/lib/item-types';
 import { Download, Plus, Search } from 'lucide-react';
 import { startNavigationFeedback } from '@/components/navigation-feedback';
+import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
 
 function filterItems(allItems: Item[], search: string, nowMs: number): Item[] {
   if (!search) return allItems.slice(0, 50);
@@ -46,28 +47,11 @@ function filterItems(allItems: Item[], search: string, nowMs: number): Item[] {
 }
 
 export function SearchCommand() {
-  const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
+  const { searchOpen: open, setSearchOpen: setOpen } = useSpaceShortcuts();
   const router = useRouter();
   const { items, isAdmin, hasMore, loadMore, loadingMore } = useItems();
   const [nowMs] = useState(() => Date.now());
-
-  useEffect(() => {
-    const down = (event: KeyboardEvent) => {
-      if (event.key === 'k' && (event.metaKey || event.ctrlKey)) {
-        event.preventDefault();
-        setOpen((current) => !current);
-      }
-    };
-    document.addEventListener('keydown', down);
-    return () => document.removeEventListener('keydown', down);
-  }, []);
-
-  useEffect(() => {
-    const handleOpen = () => setOpen(true);
-    window.addEventListener('open-search', handleOpen);
-    return () => window.removeEventListener('open-search', handleOpen);
-  }, []);
 
   const filteredItems = filterItems(items, search, nowMs);
 

--- a/components/space/space-header.tsx
+++ b/components/space/space-header.tsx
@@ -74,8 +74,9 @@ export function SpaceHeader({
 
         {onEditorToggle ? (
           <button
+            data-space-editor-trigger
             onClick={onEditorToggle}
-            className={`inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            className={`hidden h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:inline-flex ${
               isEditorOpen
                 ? 'bg-muted text-foreground'
                 : 'text-muted-foreground hover:bg-muted hover:text-foreground'
@@ -86,7 +87,7 @@ export function SpaceHeader({
             type="button"
           >
             <Code className="h-4 w-4" />
-            <span className="hidden sm:inline">Editor</span>
+            <span>Editor</span>
           </button>
         ) : null}
 

--- a/components/space/space-header.tsx
+++ b/components/space/space-header.tsx
@@ -31,6 +31,7 @@ export function SpaceHeader({
     pathname === '/space/review' ||
     pathname?.startsWith('/space/add') ||
     pathname?.startsWith('/space/edit');
+  const usesMobileActionRail = pathname === '/space' || pathname === '/space/review';
   const isMac = useMemo(
     () => typeof navigator !== 'undefined' && /Mac|iPhone|iPad/i.test(navigator.platform),
     [],
@@ -76,7 +77,7 @@ export function SpaceHeader({
           <button
             data-space-editor-trigger
             onClick={onEditorToggle}
-            className={`hidden h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:inline-flex ${
+            className={`${usesMobileActionRail ? 'hidden md:inline-flex' : 'inline-flex'} h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
               isEditorOpen
                 ? 'bg-muted text-foreground'
                 : 'text-muted-foreground hover:bg-muted hover:text-foreground'
@@ -87,7 +88,7 @@ export function SpaceHeader({
             type="button"
           >
             <Code className="h-4 w-4" />
-            <span>Editor</span>
+            <span className={usesMobileActionRail ? '' : 'hidden sm:inline'}>Editor</span>
           </button>
         ) : null}
 

--- a/components/space/space-mobile-actions.tsx
+++ b/components/space/space-mobile-actions.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Code2, List, ListChecks, Plus, Search } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { useItems } from '@/app/lib/contexts/item-context';
+import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
+
+export function SpaceMobileActions() {
+  const pathname = usePathname();
+  const { editorOpen, isAdmin } = useItems();
+  const { executeShortcut } = useSpaceShortcuts();
+
+  const isList = pathname === '/space';
+  const isReview = pathname === '/space/review';
+  if (!isList && !isReview) return null;
+
+  return (
+    <nav
+      data-space-mobile-actions
+      aria-label="Space actions"
+      aria-hidden={editorOpen}
+      className={`fixed inset-x-0 bottom-0 z-40 border-t border-border/80 bg-background/95 px-2 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] shadow-[0_-10px_30px_rgba(20,20,24,0.1)] backdrop-blur-md transition-opacity duration-150 motion-reduce:transition-none md:hidden ${
+        editorOpen ? 'pointer-events-none opacity-0' : 'opacity-100'
+      }`}
+    >
+      <div role="toolbar" aria-label="Space mobile actions" className="grid grid-cols-4 gap-1">
+        <button
+          type="button"
+          onClick={() => executeShortcut('search.toggle')}
+          className="flex min-h-12 flex-col items-center justify-center gap-1 rounded-lg px-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+          aria-label="Search items"
+        >
+          <Search className="h-5 w-5" aria-hidden="true" />
+          <span>Search</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => executeShortcut('navigation.toggle-view')}
+          className="flex min-h-12 flex-col items-center justify-center gap-1 rounded-lg px-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+          aria-label={isReview ? 'Open item list' : 'Open review'}
+        >
+          {isReview ? (
+            <List className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <ListChecks className="h-5 w-5" aria-hidden="true" />
+          )}
+          <span>{isReview ? 'List' : 'Review'}</span>
+        </button>
+
+        <button
+          type="button"
+          data-space-editor-trigger
+          onClick={() => executeShortcut('editor.toggle')}
+          className="flex min-h-12 flex-col items-center justify-center gap-1 rounded-lg px-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none"
+          aria-label="Open code editor"
+          aria-pressed={editorOpen}
+        >
+          <Code2 className="h-5 w-5" aria-hidden="true" />
+          <span>Editor</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => executeShortcut('navigation.add')}
+          disabled={!isAdmin}
+          className="flex min-h-12 flex-col items-center justify-center gap-1 rounded-lg px-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-45 motion-reduce:transition-none"
+          aria-label={isAdmin ? 'Add item' : 'Add item unavailable'}
+          title={isAdmin ? 'Add item' : 'Admin access is required'}
+        >
+          <Plus className="h-5 w-5" aria-hidden="true" />
+          <span>Add</span>
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -1,14 +1,16 @@
-"use client";
-import Link from "next/link";
-import { Rating } from "ts-fsrs";
-import { Button } from "@/components/ui/button";
-import type { Item } from "@/app/lib/item-types";
-import { formatInterval, formatDueRelative } from "@/app/lib/interval-format";
-import { useEffect, useState } from "react";
-import { MarkdownContent } from "./markdown-content";
-import { useSearchParams } from "next/navigation";
-import { CodeDisplay } from "./code-display";
-import { ChevronDown, ChevronRight } from "lucide-react";
+'use client';
+
+import Link from 'next/link';
+import { Rating } from 'ts-fsrs';
+import { Button } from '@/components/ui/button';
+import type { Item } from '@/app/lib/item-types';
+import { formatInterval, formatDueRelative } from '@/app/lib/interval-format';
+import { useMemo, useState } from 'react';
+import { MarkdownContent } from './markdown-content';
+import { useSearchParams } from 'next/navigation';
+import { CodeDisplay } from './code-display';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useSpaceShortcut } from './space-shortcut-provider';
 
 export function ResultsClient({
   items,
@@ -26,50 +28,42 @@ export function ResultsClient({
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
 
-  // Toggle the currently hovered row when Shift is pressed
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      // ignore if typing
-      const target = e.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      const role = target?.getAttribute?.("role");
-      const isTyping =
-        tag === "input" ||
-        tag === "textarea" ||
-        target?.getAttribute("contenteditable") === "true" ||
-        role === "textbox";
-
-      if (isTyping) return;
-
-      if (e.key === "Shift" && !e.metaKey && !e.ctrlKey && !e.altKey && !e.repeat) {
-        if (hoveredId) {
-          setExpandedIds((prev) => ({ ...prev, [hoveredId]: !prev[hoveredId] }));
-        }
-      }
-    };
-
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [hoveredId]);
+  const toggleHoveredShortcut = useMemo(
+    () => ({
+      enabled: Boolean(hoveredId),
+      disabledReason: hoveredId ? undefined : 'Hover an item first',
+      run: () => {
+        if (!hoveredId) return;
+        setExpandedIds((previous) => ({
+          ...previous,
+          [hoveredId]: !previous[hoveredId],
+        }));
+      },
+    }),
+    [hoveredId],
+  );
+  useSpaceShortcut('list.toggle-hovered', toggleHoveredShortcut);
 
   return (
     <ul className="space-y-2">
-      {items.map((it) => {
-        const expanded = !!expandedIds[it.id];
+      {items.map((item) => {
+        const expanded = Boolean(expandedIds[item.id]);
         const onToggle = () =>
-          setExpandedIds((prev) => ({ ...prev, [it.id]: !prev[it.id] }));
+          setExpandedIds((previous) => ({ ...previous, [item.id]: !previous[item.id] }));
 
         return (
           <Row
-            key={it.id}
-            it={it}
+            key={item.id}
+            item={item}
             onReview={onReview}
             onEnroll={onEnroll}
             nowMs={nowMs}
             isAdmin={isAdmin}
             expanded={expanded}
             onToggle={onToggle}
-            onHoverChange={(isHovering) => setHoveredId(isHovering ? it.id : (hoveredId === it.id ? null : hoveredId))}
+            onHoverChange={(isHovering) =>
+              setHoveredId(isHovering ? item.id : hoveredId === item.id ? null : hoveredId)
+            }
           />
         );
       })}
@@ -78,7 +72,7 @@ export function ResultsClient({
 }
 
 function Row({
-  it,
+  item,
   onReview,
   onEnroll,
   nowMs,
@@ -87,8 +81,8 @@ function Row({
   onToggle,
   onHoverChange,
 }: {
-  it: Item;
-  onReview: (id: string, r: Rating) => void;
+  item: Item;
+  onReview: (id: string, rating: Rating) => void;
   onEnroll: (id: string) => void;
   nowMs: number;
   isAdmin: boolean;
@@ -96,75 +90,57 @@ function Row({
   onToggle: () => void;
   onHoverChange: (hovering: boolean) => void;
 }) {
-  const [activeIdx, setActiveIdx] = useState(it.defaultIndex);
-  const active = it.versions[activeIdx];
-  
-  const displayTags = it.tags.map((t) => (t.includes(":") ? t.split(":")[1] : t));
-  const sp = useSearchParams();
-  const tagsParam = sp.get("tags") ?? "";
+  const [activeIdx, setActiveIdx] = useState(item.defaultIndex);
+  const active = item.versions[activeIdx];
+  const displayTags = item.tags.map((tag) => (tag.includes(':') ? tag.split(':')[1] : tag));
+  const searchParams = useSearchParams();
+  const tagsParam = searchParams.get('tags') ?? '';
 
   return (
     <li
-      className="rounded border bg-white dark:bg-sidebar border-border dark:border-sidebar-border text-foreground dark:text-sidebar-foreground transition-colors"
+      className="rounded border border-border bg-white text-foreground transition-colors dark:border-sidebar-border dark:bg-sidebar dark:text-sidebar-foreground"
       onMouseEnter={() => onHoverChange(true)}
       onMouseLeave={() => onHoverChange(false)}
     >
-      {/* Clickable header */}
-      <div
-        className="p-3 cursor-pointer hover:bg-muted/50 transition-colors"
-        onClick={onToggle}
-      >
+      <div className="cursor-pointer p-3 transition-colors hover:bg-muted/50" onClick={onToggle}>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            {it.url ? (
+            {item.url ? (
               <Link
-                href={it.url}
-                // prefetch={true} Does nothing since it's an external url
+                href={item.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-medium hover:underline text-foreground"
-                onClick={(e) => e.stopPropagation()}
+                className="font-medium text-foreground hover:underline"
+                onClick={(event) => event.stopPropagation()}
               >
-                {it.title}
+                {item.title}
               </Link>
             ) : (
-              <span className="font-medium text-foreground">{it.title}</span>
+              <span className="font-medium text-foreground">{item.title}</span>
             )}
-            {/* Only show edit/duplicate buttons if admin */}
-            {isAdmin && (
-              <>
-                <Button asChild variant="outline" size="sm">
-                  <Link
-                    href={`/space/edit/${it.slug}`}
-                    prefetch={true}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    edit
-                  </Link>
-                </Button>
-                {/* <Button asChild variant="outline" size="sm">
-                  <Link
-                    href={`/space/add?duplicate=${it.slug}`}
-                    prefetch={true}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    duplicate
-                  </Link>
-                </Button> */}
-              </>
-            )}
+            {isAdmin ? (
+              <Button asChild variant="outline" size="sm">
+                <Link
+                  href={`/space/edit/${item.slug}`}
+                  prefetch
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  edit
+                </Link>
+              </Button>
+            ) : null}
             <Button asChild variant="outline" size="sm">
               <Link
-                href={`/space/review?tags=${tagsParam}&item=${it.slug}`}
-                prefetch={true}
-                onClick={(e) => e.stopPropagation()}
+                href={`/space/review?tags=${tagsParam}&item=${item.slug}`}
+                prefetch
+                onClick={(event) => event.stopPropagation()}
               >
                 review
               </Link>
             </Button>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground capitalize">{it.category}</span>
+            <span className="text-xs capitalize text-muted-foreground">{item.category}</span>
             {expanded ? (
               <ChevronDown className="h-4 w-4 text-muted-foreground" />
             ) : (
@@ -174,106 +150,97 @@ function Row({
         </div>
 
         <div className="mt-1 text-xs text-muted-foreground">
-          tags: {displayTags.join(", ")}
-          {it.review && (
+          tags: {displayTags.join(', ')}
+          {item.review ? (
             <>
-              {" · next: "}
-              {formatDueRelative(nowMs, new Date(it.review.due))}
-              {" · ivl: "}
-              {formatInterval(nowMs, new Date(it.review.due), it.review.scheduled_days)}
-              {it.review.due <= nowMs && (
-                <span className="ml-2 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 px-1 py-0.5">
+              {' · next: '}
+              {formatDueRelative(nowMs, new Date(item.review.due))}
+              {' · ivl: '}
+              {formatInterval(nowMs, new Date(item.review.due), item.review.scheduled_days)}
+              {item.review.due <= nowMs ? (
+                <span className="ml-2 rounded bg-red-100 px-1 py-0.5 text-red-700 dark:bg-red-900/30 dark:text-red-400">
                   due
                 </span>
-              )}
+              ) : null}
             </>
-          )}
+          ) : null}
         </div>
       </div>
 
-      {/* Expanded content */}
-      {expanded && (
+      {expanded ? (
         <div className="border-t border-border p-3">
-          {/* Version tabs */}
-          {it.versions.length > 1 && (
-            <div className="flex gap-2 mb-3 text-xs">
-              {it.versions.map((v, i) => (
+          {item.versions.length > 1 ? (
+            <div className="mb-3 flex gap-2 text-xs">
+              {item.versions.map((version, index) => (
                 <button
-                  key={i}
-                  onMouseEnter={() => setActiveIdx(i)}
-                  className={`px-2 py-1 rounded border transition-colors ${
-                    i === activeIdx
-                      ? 'bg-accent text-accent-foreground border-accent'
+                  key={index}
+                  onMouseEnter={() => setActiveIdx(index)}
+                  className={`rounded border px-2 py-1 transition-colors ${
+                    index === activeIdx
+                      ? 'border-accent bg-accent text-accent-foreground'
                       : 'border-border hover:bg-muted'
                   }`}
                 >
-                  {v.label}
+                  {version.label}
                 </button>
               ))}
             </div>
-          )}
+          ) : null}
 
           <div className="flex gap-3">
-            {/* Writeup */}
-            <div className="flex-1 min-w-0">
-              <div
-                className="p-3 rounded overflow-auto prose prose-sm dark:prose-invert max-w-none
-                bg-white dark:bg-sidebar
-                border border-border dark:border-sidebar-border"
-              >
+            <div className="min-w-0 flex-1">
+              <div className="prose prose-sm max-w-none overflow-auto rounded border border-border bg-white p-3 dark:border-sidebar-border dark:bg-sidebar dark:prose-invert">
                 <MarkdownContent
                   html={active.contentHtml}
-                  className="prose prose-sm dark:prose-invert max-w-none"
+                  className="prose prose-sm max-w-none dark:prose-invert"
                 />
               </div>
             </div>
 
-            {/* Code */}
-            {active.code && <CodeDisplay code={active.code} codeHtml={active.codeHtml} />}
+            {active.code ? <CodeDisplay code={active.code} codeHtml={active.codeHtml} /> : null}
           </div>
         </div>
-      )}
+      ) : null}
 
-      {/* Review controls - only visible for admin */}
-      {isAdmin && (
-        <div className="border-t border-border p-3" onClick={(e) => e.stopPropagation()}>
-          {!it.review ? (
+      {isAdmin ? (
+        <div className="border-t border-border p-3" onClick={(event) => event.stopPropagation()}>
+          {!item.review ? (
             <button
-              className="rounded border border-border px-2 py-1 text-xs hover:bg-muted transition-colors"
-              onClick={() => onEnroll(it.id)}
+              className="rounded border border-border px-2 py-1 text-xs transition-colors hover:bg-muted"
+              onClick={() => onEnroll(item.id)}
             >
               Add to reviews
             </button>
           ) : (
             <div className="flex gap-2 text-xs">
               <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Again)}
+                className="rounded border border-border px-2 py-1 transition-colors hover:bg-muted"
+                onClick={() => onReview(item.id, Rating.Again)}
               >
                 Again
               </button>
               <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Hard)}
+                className="rounded border border-border px-2 py-1 transition-colors hover:bg-muted"
+                onClick={() => onReview(item.id, Rating.Hard)}
               >
                 Hard
               </button>
               <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Good)}
+                className="rounded border border-border px-2 py-1 transition-colors hover:bg-muted"
+                onClick={() => onReview(item.id, Rating.Good)}
               >
                 Good
               </button>
               <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Easy)}
+                className="rounded border border-border px-2 py-1 transition-colors hover:bg-muted"
+                onClick={() => onReview(item.id, Rating.Easy)}
               >
                 Easy
               </button>
             </div>
           )}
         </div>
-      )}
+      ) : null}
     </li>
   );
 }

--- a/components/space/space-shortcut-provider.tsx
+++ b/components/space/space-shortcut-provider.tsx
@@ -6,7 +6,6 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useReducer,
   useRef,
   useState,
   type ReactNode,
@@ -57,9 +56,10 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
   const { toggleSidebar } = useSidebar();
   const [searchOpen, setSearchOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
-  const [registrationVersion, bumpRegistrationVersion] = useReducer((value) => value + 1, 0);
-  const dynamicRegistrations = useRef(new Map<SpaceShortcutId, OwnedRegistration>());
-  const getRuntimeRegistrations = useRef<() => SpaceShortcutRegistrations>(() => new Map());
+  const [dynamicRegistrations, setDynamicRegistrations] = useState(
+    () => new Map<SpaceShortcutId, OwnedRegistration>(),
+  );
+  const runtimeRegistrations = useRef<SpaceShortcutRegistrations>(new Map());
 
   const currentQuery = searchParams.get('tags') ?? '';
   const isReviewLike =
@@ -124,51 +124,57 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
     toggleSidebar,
   ]);
 
-  const getBaseRegistrations = useCallback(() => {
+  const baseRegistrations = useMemo(() => {
     const registrations = new Map<SpaceShortcutId, SpaceShortcutRegistration>();
     for (const [id, registration] of builtInRegistrations) registrations.set(id, registration);
-    for (const [id, registration] of dynamicRegistrations.current) {
-      registrations.set(id, registration);
-    }
+    for (const [id, registration] of dynamicRegistrations) registrations.set(id, registration);
     return registrations;
-  }, [builtInRegistrations]);
+  }, [builtInRegistrations, dynamicRegistrations]);
 
-  const getRegistrationsForDispatch = useCallback(() => {
-    const registrations = getBaseRegistrations();
-    if (!helpOpen) return registrations;
+  const dispatchRegistrations = useMemo(() => {
+    if (!helpOpen) return baseRegistrations;
 
+    const registrations = new Map(baseRegistrations);
     for (const [id, registration] of registrations) {
       if (id === 'help.open' || id === 'help.close') continue;
       registrations.set(id, { ...registration, active: false });
     }
     return registrations;
-  }, [getBaseRegistrations, helpOpen]);
+  }, [baseRegistrations, helpOpen]);
 
-  getRuntimeRegistrations.current = getRegistrationsForDispatch;
+  useEffect(() => {
+    runtimeRegistrations.current = dispatchRegistrations;
+  }, [dispatchRegistrations]);
 
   useEffect(
-    () => installSpaceShortcutListener(document, () => getRuntimeRegistrations.current()),
+    () => installSpaceShortcutListener(document, () => runtimeRegistrations.current),
     [],
   );
 
   const registerShortcut = useCallback(
     (id: SpaceShortcutId, registration: SpaceShortcutRegistration) => {
       const token = Symbol(id);
-      dynamicRegistrations.current.set(id, { ...registration, token });
-      bumpRegistrationVersion();
+      setDynamicRegistrations((current) => {
+        const next = new Map(current);
+        next.set(id, { ...registration, token });
+        return next;
+      });
 
       return () => {
-        const current = dynamicRegistrations.current.get(id);
-        if (current?.token !== token) return;
-        dynamicRegistrations.current.delete(id);
-        bumpRegistrationVersion();
+        setDynamicRegistrations((current) => {
+          const owned = current.get(id);
+          if (owned?.token !== token) return current;
+          const next = new Map(current);
+          next.delete(id);
+          return next;
+        });
       };
     },
     [],
   );
 
   const executeShortcut = useCallback((id: SpaceShortcutId) => {
-    const registration = getRuntimeRegistrations.current().get(id);
+    const registration = runtimeRegistrations.current.get(id);
     if (!registration || registration.active === false || registration.enabled === false) {
       return false;
     }
@@ -192,8 +198,8 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
   );
 
   const referenceEntries = useMemo(
-    () => getSpaceShortcutReference(getBaseRegistrations()),
-    [getBaseRegistrations, registrationVersion],
+    () => getSpaceShortcutReference(baseRegistrations),
+    [baseRegistrations],
   );
   const isMac = useMemo(
     () =>
@@ -233,19 +239,20 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
                   >
                     {category}
                   </h2>
-                  <div className="divide-y rounded-lg border" role="list">
+                  <ul className="divide-y rounded-lg border">
                     {entries.map(({ definition, available, unavailableReason }) => (
-                      <div
+                      <li
                         key={definition.id}
                         data-space-shortcut-id={definition.id}
-                        aria-disabled={!available}
-                        className="flex items-start justify-between gap-4 px-3 py-3 aria-disabled:opacity-55"
-                        role="listitem"
+                        data-available={available ? 'true' : 'false'}
+                        className="flex items-start justify-between gap-4 px-3 py-3 data-[available=false]:opacity-55"
                       >
                         <div className="min-w-0">
                           <p className="text-sm font-medium">{definition.description}</p>
                           {!available ? (
-                            <p className="mt-1 text-xs text-muted-foreground">{unavailableReason}</p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              Unavailable: {unavailableReason}
+                            </p>
                           ) : null}
                         </div>
                         <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
@@ -272,9 +279,9 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
                             );
                           })}
                         </div>
-                      </div>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 </section>
               );
             })}

--- a/components/space/space-shortcut-provider.tsx
+++ b/components/space/space-shortcut-provider.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useItems } from '@/app/lib/contexts/item-context';
+import { startNavigationFeedback } from '@/components/navigation-feedback';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  formatSpaceShortcutBinding,
+  getSpaceShortcutReference,
+  installSpaceShortcutListener,
+  type SpaceShortcutId,
+  type SpaceShortcutRegistration,
+  type SpaceShortcutRegistrations,
+} from '@/lib/space-shortcuts';
+
+const CATEGORIES = ['General', 'Navigation', 'Review', 'Editor', 'List'] as const;
+
+type SpaceShortcutContextValue = {
+  searchOpen: boolean;
+  setSearchOpen: (open: boolean) => void;
+  openSearch: () => void;
+  openHelp: () => void;
+  registerShortcut: (
+    id: SpaceShortcutId,
+    registration: SpaceShortcutRegistration,
+  ) => () => void;
+  executeShortcut: (id: SpaceShortcutId) => boolean;
+};
+
+const SpaceShortcutContext = createContext<SpaceShortcutContextValue | null>(null);
+
+type OwnedRegistration = SpaceShortcutRegistration & { token: symbol };
+
+export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { isAdmin, editorOpen, setEditorOpen } = useItems();
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [registrationVersion, bumpRegistrationVersion] = useReducer((value) => value + 1, 0);
+  const dynamicRegistrations = useRef(new Map<SpaceShortcutId, OwnedRegistration>());
+  const getRuntimeRegistrations = useRef<() => SpaceShortcutRegistrations>(() => new Map());
+
+  const currentQuery = searchParams.get('tags') ?? '';
+  const isReviewLike =
+    pathname === '/space/review' ||
+    pathname.startsWith('/space/add') ||
+    pathname.startsWith('/space/edit');
+  const listHref = `/space${currentQuery ? `?tags=${encodeURIComponent(currentQuery)}` : ''}`;
+  const reviewHref = `/space/review${currentQuery ? `?tags=${encodeURIComponent(currentQuery)}` : ''}`;
+
+  const navigate = useCallback(
+    (href: string, label: string) => {
+      startNavigationFeedback(href, label);
+      router.push(href);
+    },
+    [router],
+  );
+
+  const builtInRegistrations = useMemo<SpaceShortcutRegistrations>(() => {
+    const registrations = new Map<SpaceShortcutId, SpaceShortcutRegistration>();
+
+    registrations.set('help.open', {
+      run: () => setHelpOpen((open) => !open),
+    });
+    registrations.set('help.close', {
+      active: helpOpen,
+      run: () => setHelpOpen(false),
+    });
+    registrations.set('search.toggle', {
+      run: () => setSearchOpen((open) => !open),
+    });
+    registrations.set('editor.toggle', {
+      run: () => setEditorOpen(!editorOpen),
+    });
+    registrations.set('navigation.add', {
+      enabled: isAdmin,
+      disabledReason: isAdmin ? undefined : 'Admin access is required',
+      run: () => navigate('/space/add', 'new item'),
+    });
+    registrations.set('navigation.toggle-view', {
+      run: () =>
+        navigate(isReviewLike ? listHref : reviewHref, isReviewLike ? 'item list' : 'review'),
+    });
+
+    return registrations;
+  }, [editorOpen, helpOpen, isAdmin, isReviewLike, listHref, navigate, reviewHref, setEditorOpen]);
+
+  const getBaseRegistrations = useCallback(() => {
+    const registrations = new Map<SpaceShortcutId, SpaceShortcutRegistration>();
+    for (const [id, registration] of builtInRegistrations) registrations.set(id, registration);
+    for (const [id, registration] of dynamicRegistrations.current) {
+      registrations.set(id, registration);
+    }
+    return registrations;
+  }, [builtInRegistrations]);
+
+  const getRegistrationsForDispatch = useCallback(() => {
+    const registrations = getBaseRegistrations();
+    if (!helpOpen) return registrations;
+
+    for (const [id, registration] of registrations) {
+      if (id === 'help.open' || id === 'help.close') continue;
+      registrations.set(id, { ...registration, active: false });
+    }
+    return registrations;
+  }, [getBaseRegistrations, helpOpen]);
+
+  getRuntimeRegistrations.current = getRegistrationsForDispatch;
+
+  useEffect(
+    () => installSpaceShortcutListener(document, () => getRuntimeRegistrations.current()),
+    [],
+  );
+
+  const registerShortcut = useCallback(
+    (id: SpaceShortcutId, registration: SpaceShortcutRegistration) => {
+      const token = Symbol(id);
+      dynamicRegistrations.current.set(id, { ...registration, token });
+      bumpRegistrationVersion();
+
+      return () => {
+        const current = dynamicRegistrations.current.get(id);
+        if (current?.token !== token) return;
+        dynamicRegistrations.current.delete(id);
+        bumpRegistrationVersion();
+      };
+    },
+    [],
+  );
+
+  const executeShortcut = useCallback(
+    (id: SpaceShortcutId) => {
+      const registration = getBaseRegistrations().get(id);
+      if (!registration || registration.active === false || registration.enabled === false) {
+        return false;
+      }
+      registration.run();
+      return true;
+    },
+    [getBaseRegistrations],
+  );
+
+  const openSearch = useCallback(() => setSearchOpen(true), []);
+  const openHelp = useCallback(() => setHelpOpen(true), []);
+
+  const contextValue = useMemo<SpaceShortcutContextValue>(
+    () => ({
+      searchOpen,
+      setSearchOpen,
+      openSearch,
+      openHelp,
+      registerShortcut,
+      executeShortcut,
+    }),
+    [executeShortcut, openHelp, openSearch, registerShortcut, searchOpen],
+  );
+
+  const referenceEntries = useMemo(
+    () => getSpaceShortcutReference(getBaseRegistrations()),
+    [getBaseRegistrations, registrationVersion],
+  );
+  const isMac = useMemo(
+    () =>
+      typeof navigator !== 'undefined' &&
+      (navigator.platform.includes('Mac') || /iPhone|iPad/i.test(navigator.platform)),
+    [],
+  );
+
+  return (
+    <SpaceShortcutContext.Provider value={contextValue}>
+      {children}
+      <Dialog open={helpOpen} onOpenChange={setHelpOpen}>
+        <DialogContent
+          data-space-shortcut-help
+          className="max-h-[min(42rem,calc(100dvh-2rem))] max-w-2xl overflow-y-auto p-0"
+        >
+          <DialogHeader className="border-b px-5 pb-4 pt-5 text-left sm:px-6">
+            <DialogTitle>Space keyboard shortcuts</DialogTitle>
+            <DialogDescription>
+              This reference is generated from the same registry that handles each command. Plain
+              keys pause while you type, compose text, or use browser-owned controls.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-5 px-5 pb-6 sm:px-6">
+            {CATEGORIES.map((category) => {
+              const entries = referenceEntries.filter(
+                (entry) => entry.definition.category === category,
+              );
+              if (entries.length === 0) return null;
+
+              return (
+                <section key={category} aria-labelledby={`space-shortcut-${category.toLowerCase()}`}>
+                  <h2
+                    id={`space-shortcut-${category.toLowerCase()}`}
+                    className="mb-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground"
+                  >
+                    {category}
+                  </h2>
+                  <div className="divide-y rounded-lg border" role="list">
+                    {entries.map(({ definition, available, unavailableReason }) => (
+                      <div
+                        key={definition.id}
+                        data-space-shortcut-id={definition.id}
+                        aria-disabled={!available}
+                        className="flex items-start justify-between gap-4 px-3 py-3 aria-disabled:opacity-55"
+                        role="listitem"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium">{definition.description}</p>
+                          {!available ? (
+                            <p className="mt-1 text-xs text-muted-foreground">{unavailableReason}</p>
+                          ) : null}
+                        </div>
+                        <div className="flex shrink-0 flex-wrap justify-end gap-1.5">
+                          {definition.keys.map((binding, index) => {
+                            const label = formatSpaceShortcutBinding(binding, isMac);
+                            return (
+                              <span key={`${definition.id}-${index}`}>
+                                <span className="sr-only">{label.spoken}</span>
+                                <kbd
+                                  aria-hidden="true"
+                                  className="inline-flex min-h-7 items-center rounded border bg-muted/45 px-2 font-mono text-[11px] font-semibold"
+                                >
+                                  {label.visual}
+                                </kbd>
+                                {index < definition.keys.length - 1 ? (
+                                  <span
+                                    aria-hidden="true"
+                                    className="mx-1 text-xs text-muted-foreground"
+                                  >
+                                    or
+                                  </span>
+                                ) : null}
+                              </span>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </SpaceShortcutContext.Provider>
+  );
+}
+
+export function useSpaceShortcuts() {
+  const context = useContext(SpaceShortcutContext);
+  if (!context) throw new Error('useSpaceShortcuts must be used inside SpaceShortcutProvider');
+  return context;
+}
+
+export function useSpaceShortcut(
+  id: SpaceShortcutId,
+  registration: SpaceShortcutRegistration,
+) {
+  const { registerShortcut } = useSpaceShortcuts();
+  useEffect(() => registerShortcut(id, registration), [id, registerShortcut, registration]);
+}

--- a/components/space/space-shortcut-provider.tsx
+++ b/components/space/space-shortcut-provider.tsx
@@ -21,6 +21,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useSidebar } from '@/components/ui/sidebar';
 import {
   formatSpaceShortcutBinding,
   getSpaceShortcutReference,
@@ -53,6 +54,7 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { isAdmin, editorOpen, setEditorOpen } = useItems();
+  const { toggleSidebar } = useSidebar();
   const [searchOpen, setSearchOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const [registrationVersion, bumpRegistrationVersion] = useReducer((value) => value + 1, 0);
@@ -88,6 +90,14 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
     registrations.set('search.toggle', {
       run: () => setSearchOpen((open) => !open),
     });
+    registrations.set('sidebar.toggle', {
+      run: (event) => {
+        toggleSidebar();
+        // The shared SidebarProvider retains a window fallback for non-Space consumers.
+        // Stop this handled Space event before that fallback can toggle a second time.
+        event?.stopPropagation();
+      },
+    });
     registrations.set('editor.toggle', {
       run: () => setEditorOpen(!editorOpen),
     });
@@ -102,7 +112,17 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
     });
 
     return registrations;
-  }, [editorOpen, helpOpen, isAdmin, isReviewLike, listHref, navigate, reviewHref, setEditorOpen]);
+  }, [
+    editorOpen,
+    helpOpen,
+    isAdmin,
+    isReviewLike,
+    listHref,
+    navigate,
+    reviewHref,
+    setEditorOpen,
+    toggleSidebar,
+  ]);
 
   const getBaseRegistrations = useCallback(() => {
     const registrations = new Map<SpaceShortcutId, SpaceShortcutRegistration>();

--- a/components/space/space-shortcut-provider.tsx
+++ b/components/space/space-shortcut-provider.tsx
@@ -167,17 +167,14 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
     [],
   );
 
-  const executeShortcut = useCallback(
-    (id: SpaceShortcutId) => {
-      const registration = getBaseRegistrations().get(id);
-      if (!registration || registration.active === false || registration.enabled === false) {
-        return false;
-      }
-      registration.run();
-      return true;
-    },
-    [getBaseRegistrations],
-  );
+  const executeShortcut = useCallback((id: SpaceShortcutId) => {
+    const registration = getRuntimeRegistrations.current().get(id);
+    if (!registration || registration.active === false || registration.enabled === false) {
+      return false;
+    }
+    registration.run();
+    return true;
+  }, []);
 
   const openSearch = useCallback(() => setSearchOpen(true), []);
   const openHelp = useCallback(() => setHelpOpen(true), []);

--- a/components/space/space-shortcut-provider.tsx
+++ b/components/space/space-shortcut-provider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -142,7 +143,7 @@ export function SpaceShortcutProvider({ children }: { children: ReactNode }) {
     return registrations;
   }, [baseRegistrations, helpOpen]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     runtimeRegistrations.current = dispatchRegistrations;
   }, [dispatchRegistrations]);
 
@@ -303,5 +304,8 @@ export function useSpaceShortcut(
   registration: SpaceShortcutRegistration,
 ) {
   const { registerShortcut } = useSpaceShortcuts();
-  useEffect(() => registerShortcut(id, registration), [id, registerShortcut, registration]);
+  useLayoutEffect(
+    () => registerShortcut(id, registration),
+    [id, registerShortcut, registration],
+  );
 }

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -147,7 +147,10 @@ export function SpaceView() {
         onEditorToggle={() => setEditorOpen(!editorOpen)}
         isEditorOpen={editorOpen}
       />
-      <main className="min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:p-4">
+      <main
+        data-space-scroll-region
+        className="min-h-0 flex-1 overflow-y-auto px-3 pt-3 pb-[calc(5.75rem+env(safe-area-inset-bottom))] sm:px-4 sm:pt-4 md:pb-4"
+      >
         {error ? (
           <div
             className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm"

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -71,29 +71,6 @@ export function SpaceView() {
     }
   }, [hasMore, loadMore, loadingMore, page, totalPages]);
 
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      const isMod = event.metaKey || event.ctrlKey;
-      if (!isMod || event.key.toLowerCase() !== 'i') return;
-
-      const target = event.target as HTMLElement | null;
-      const tag = target?.tagName?.toLowerCase();
-      const role = target?.getAttribute?.('role');
-      const isTyping =
-        tag === 'input' ||
-        tag === 'textarea' ||
-        target?.getAttribute('contenteditable') === 'true' ||
-        role === 'textbox';
-
-      if (isTyping) return;
-      event.preventDefault();
-      setEditorOpen(!editorOpen);
-    };
-
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [editorOpen, setEditorOpen]);
-
   const onEnroll = useCallback(
     async (id: string) => {
       const {
@@ -172,7 +149,10 @@ export function SpaceView() {
       />
       <main className="min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:p-4">
         {error ? (
-          <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm" role="alert">
+          <div
+            className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm"
+            role="alert"
+          >
             <span className="min-w-0">{error}</span>
             <Button variant="outline" size="sm" className="shrink-0" onClick={() => void reload()}>
               Retry

--- a/docs/space-mobile-editor-checklist.md
+++ b/docs/space-mobile-editor-checklist.md
@@ -1,0 +1,26 @@
+# Space mobile editor verification checklist
+
+This checklist records follow-up device verification for the mobile Space action rail and editor sheet. The automated Chromium/WebKit matrix exercises the interaction contract, but this document does not claim a physical iPhone, iPad, or Android device run.
+
+## iOS Safari
+
+1. Open `/space` in portrait, scroll the item list, and open the editor from the bottom action rail.
+2. Type a draft, select part of the text, dismiss with Escape from a connected hardware keyboard, and reopen. Confirm the draft and selection remain and the action trigger regains focus.
+3. Repeat with the on-screen keyboard visible. Confirm the sheet tracks the visual viewport while Safari's top and bottom toolbars expand or collapse.
+4. Close with the sheet button and with browser back. Confirm the URL and current list/review item remain unchanged and the saved scroll position returns without a late jump.
+5. Rotate to reduced-height landscape and repeat typing, selection, Escape, close-button, and browser-back dismissal.
+6. Confirm the bottom rail clears the home indicator and remains reachable with Larger Text enabled.
+7. Enable Reduce Motion and confirm the rail and editor visibility changes do not animate.
+
+## Android Chrome / embedded WebView
+
+1. Repeat portrait and landscape open/close cycles with the software keyboard visible.
+2. Use the system back gesture/button to dismiss the editor. Confirm the first back closes the sheet without leaving Space.
+3. Confirm TalkBack announces the `Code editor` dialog, its description, and the close button.
+4. Scroll the underlying list/review before opening. Confirm the same item, reveal state, focus target, and scroll position return after dismissal.
+
+## General regression
+
+1. On desktop, verify `Mod+I` retains the existing panel geometry and toggles once.
+2. Confirm search, list/review, editor, and add actions use the shared shortcut registry and no duplicate keyboard dispatch occurs.
+3. Confirm ordinary page scrolling resumes after the editor closes and no horizontal overflow appears at narrow widths.

--- a/docs/space-shortcut-registry.md
+++ b/docs/space-shortcut-registry.md
@@ -1,0 +1,41 @@
+# Space shortcut registry
+
+Space keyboard commands are defined in `lib/space-shortcuts.ts` and dispatched by `SpaceShortcutProvider` in `components/space/space-shortcut-provider.tsx`.
+
+The same typed definitions generate the visible `?` reference. A command cannot acquire a runtime key without also appearing in that reference unless it is an internal modal command marked `hiddenFromReference`.
+
+## Adding a command
+
+1. Add one definition to `SPACE_SHORTCUTS` with a stable ID, one or more key bindings, scope, category, description, priority, repeat policy, and editable-target policy.
+2. Register its handler through `useSpaceShortcut`, or add a layout-owned registration in `SpaceShortcutProvider` for route-wide navigation and shell commands.
+3. Supply `enabled: false` and a concise `disabledReason` when the command is visible but unavailable.
+4. Add matcher coverage for any new modifier, composition, repeat, editable, or scope behaviour.
+5. Add browser coverage when the command changes navigation, a modal or sheet, review state, or editor state.
+
+Do not add another document or window `keydown` listener. Embedded editors that consume browser events may bridge their native command into `executeShortcut(id)`, but the registry remains the owner of command availability and execution.
+
+## Matching conventions
+
+- Modifier matching is exact. `Mod` means Command on Apple platforms and Control elsewhere. Pressing both does not match.
+- AltGraph combinations are ignored so international text entry does not trigger `Mod+Alt` commands.
+- Editable controls, contenteditable regions, textbox, searchbox, and combobox roles, and IME composition are ignored by default.
+- A command may opt into editable targets only for a narrow documented reason. The editor toggle is limited to the Space editor scope and its Monaco command bridges into the registry.
+- Repeat behaviour is explicit per command. Review next and previous allow key repeat; toggles and navigation commands do not.
+- A higher modal, sheet, or local scope wins before command priority. A disabled winner blocks a lower-scope command with the same keys.
+- The dispatcher respects `defaultPrevented` and calls `preventDefault()` only after an enabled command wins. It does not stop propagation.
+- Mobile continues to use visible controls. The reference is available from the sidebar without requiring a hardware keyboard.
+
+## Current inventory
+
+| Command | Keys | Scope | Repeat |
+| --- | --- | --- | --- |
+| Shortcut reference | `?` | Global | Ignore |
+| Item search | `Mod+K` | Global | Ignore |
+| Code editor | `Mod+I` | Global/editor bridge | Ignore |
+| Add item | `Mod+Alt+A` | Global | Ignore |
+| List/review switch | `Mod+E`, `Mod+Shift+E` | Global | Ignore |
+| Next review | `→`, `J` | Local | Allow |
+| Previous review | `←`, `K` | Local | Allow |
+| Review content | `Space` | Local | Ignore |
+| Exit review | `Escape` | Local | Ignore |
+| Hovered list item | `Shift` | Local | Ignore |

--- a/docs/space-shortcut-registry.md
+++ b/docs/space-shortcut-registry.md
@@ -22,7 +22,8 @@ Do not add another document or window `keydown` listener. Embedded editors that 
 - A command may opt into editable targets only for a narrow documented reason. The editor toggle is limited to the Space editor scope and its Monaco command bridges into the registry.
 - Repeat behaviour is explicit per command. Review next and previous allow key repeat; toggles and navigation commands do not.
 - A higher modal, sheet, or local scope wins before command priority. A disabled winner blocks a lower-scope command with the same keys.
-- The dispatcher respects `defaultPrevented` and calls `preventDefault()` only after an enabled command wins. It does not stop propagation.
+- The dispatcher respects `defaultPrevented` and calls `preventDefault()` only after an enabled command wins.
+- The Space `Mod+B` handler stops propagation after toggling because the shared `SidebarProvider` retains a window-level fallback for non-Space consumers. This prevents a second toggle without changing other sidebar users.
 - Mobile continues to use visible controls. The reference is available from the sidebar without requiring a hardware keyboard.
 
 ## Current inventory
@@ -31,6 +32,7 @@ Do not add another document or window `keydown` listener. Embedded editors that 
 | --- | --- | --- | --- |
 | Shortcut reference | `?` | Global | Ignore |
 | Item search | `Mod+K` | Global | Ignore |
+| Navigation sidebar | `Mod+B` | Global/shared-provider bridge | Ignore |
 | Code editor | `Mod+I` | Global/editor bridge | Ignore |
 | Add item | `Mod+Alt+A` | Global | Ignore |
 | List/review switch | `Mod+E`, `Mod+Shift+E` | Global | Ignore |

--- a/lib/space-editor-sheet.test.ts
+++ b/lib/space-editor-sheet.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  SPACE_EDITOR_HISTORY_KEY,
+  createEditorSheetHistoryState,
+  createEditorSheetRestoration,
+  ownsEditorSheetHistoryState,
+  resolveEditorSheetViewport,
+  type FocusTargetLike,
+  type ScrollRegionLike,
+} from './space-editor-sheet';
+
+class FakeRuntime {
+  private nextFrameId = 1;
+  private frames = new Map<number, () => void>();
+
+  requestAnimationFrame = (callback: () => void) => {
+    const id = this.nextFrameId++;
+    this.frames.set(id, callback);
+    return id;
+  };
+
+  cancelAnimationFrame = (id: number) => {
+    this.frames.delete(id);
+  };
+
+  flushFrames() {
+    const callbacks = [...this.frames.values()];
+    this.frames.clear();
+    for (const callback of callbacks) callback();
+  }
+
+  pendingFrameCount() {
+    return this.frames.size;
+  }
+}
+
+function focusTarget(isConnected = true) {
+  return {
+    isConnected,
+    focus: vi.fn(),
+  } satisfies FocusTargetLike;
+}
+
+function scrollRegion(left: number, top: number) {
+  return { scrollLeft: left, scrollTop: top } satisfies ScrollRegionLike;
+}
+
+describe('mobile Space editor sheet helpers', () => {
+  it('uses the visual viewport while the software keyboard is visible', () => {
+    expect(resolveEditorSheetViewport(844, { offsetTop: 24, height: 500 })).toEqual({
+      top: 24,
+      height: 500,
+      bottom: 524,
+    });
+  });
+
+  it('clamps delayed viewport values to the layout viewport', () => {
+    expect(resolveEditorSheetViewport(390, { offsetTop: 380, height: 240 })).toEqual({
+      top: 380,
+      height: 10,
+      bottom: 390,
+    });
+    expect(resolveEditorSheetViewport(390, null)).toEqual({
+      top: 0,
+      height: 390,
+      bottom: 390,
+    });
+  });
+
+  it('adds an owned same-page history marker without dropping router state', () => {
+    const state = createEditorSheetHistoryState({ __NA: true, index: 4 }, 'editor-1');
+
+    expect(state).toEqual({
+      __NA: true,
+      index: 4,
+      [SPACE_EDITOR_HISTORY_KEY]: 'editor-1',
+    });
+    expect(ownsEditorSheetHistoryState(state, 'editor-1')).toBe(true);
+    expect(ownsEditorSheetHistoryState(state, 'editor-2')).toBe(false);
+  });
+
+  it('restores captured scroll regions and the original focus target', () => {
+    const runtime = new FakeRuntime();
+    const restoration = createEditorSheetRestoration(runtime);
+    const target = focusTarget();
+    const first = scrollRegion(8, 120);
+    const second = scrollRegion(0, 44);
+
+    restoration.capture(target, [first, second]);
+    first.scrollLeft = 30;
+    first.scrollTop = 900;
+    second.scrollTop = 700;
+    restoration.restore();
+
+    expect(target.focus).not.toHaveBeenCalled();
+    runtime.flushFrames();
+
+    expect(first).toEqual({ scrollLeft: 8, scrollTop: 120 });
+    expect(second).toEqual({ scrollLeft: 0, scrollTop: 44 });
+    expect(target.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('uses the visible editor trigger when the original focus target disconnected', () => {
+    const runtime = new FakeRuntime();
+    const restoration = createEditorSheetRestoration(runtime);
+    const disconnected = focusTarget(false);
+    const fallback = focusTarget();
+
+    restoration.capture(disconnected, []);
+    restoration.restore(fallback);
+    runtime.flushFrames();
+
+    expect(disconnected.focus).not.toHaveBeenCalled();
+    expect(fallback.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('cancels stale restoration when the sheet reopens before the frame', () => {
+    const runtime = new FakeRuntime();
+    const restoration = createEditorSheetRestoration(runtime);
+    const firstTarget = focusTarget();
+    const secondTarget = focusTarget();
+    const region = scrollRegion(0, 100);
+
+    restoration.capture(firstTarget, [region]);
+    region.scrollTop = 400;
+    restoration.restore();
+    expect(runtime.pendingFrameCount()).toBe(1);
+
+    restoration.capture(secondTarget, [region]);
+    runtime.flushFrames();
+
+    expect(region.scrollTop).toBe(400);
+    expect(firstTarget.focus).not.toHaveBeenCalled();
+    expect(secondTarget.focus).not.toHaveBeenCalled();
+  });
+});

--- a/lib/space-editor-sheet.ts
+++ b/lib/space-editor-sheet.ts
@@ -1,0 +1,122 @@
+export const SPACE_EDITOR_HISTORY_KEY = '__spaceEditorSheet';
+
+export type VisualViewportSnapshot = {
+  height: number;
+  offsetTop: number;
+};
+
+export type EditorSheetViewport = {
+  top: number;
+  height: number;
+  bottom: number;
+};
+
+export function resolveEditorSheetViewport(
+  layoutHeight: number,
+  viewport?: VisualViewportSnapshot | null,
+): EditorSheetViewport {
+  const safeLayoutHeight = Math.max(0, layoutHeight);
+  if (!viewport) {
+    return { top: 0, height: safeLayoutHeight, bottom: safeLayoutHeight };
+  }
+
+  const top = Math.max(0, Math.min(viewport.offsetTop, safeLayoutHeight));
+  const height = Math.max(0, Math.min(viewport.height, safeLayoutHeight - top));
+  return { top, height, bottom: top + height };
+}
+
+export function createEditorSheetHistoryState(baseState: unknown, token: string) {
+  const base =
+    baseState && typeof baseState === 'object'
+      ? (baseState as Record<string, unknown>)
+      : {};
+  return { ...base, [SPACE_EDITOR_HISTORY_KEY]: token };
+}
+
+export function ownsEditorSheetHistoryState(state: unknown, token: string | null) {
+  if (!token || !state || typeof state !== 'object') return false;
+  return (state as Record<string, unknown>)[SPACE_EDITOR_HISTORY_KEY] === token;
+}
+
+export type FocusTargetLike = {
+  isConnected?: boolean;
+  focus: (options?: { preventScroll?: boolean }) => void;
+};
+
+export type ScrollRegionLike = {
+  scrollLeft: number;
+  scrollTop: number;
+};
+
+export type EditorSheetRestorationRuntime = {
+  requestAnimationFrame: (callback: () => void) => number;
+  cancelAnimationFrame: (id: number) => void;
+};
+
+export type EditorSheetRestoration = {
+  capture: (focusTarget: FocusTargetLike | null, regions: Iterable<ScrollRegionLike>) => void;
+  restore: (fallbackFocus?: FocusTargetLike | null) => void;
+  cancel: () => void;
+};
+
+export function createEditorSheetRestoration(
+  runtime: EditorSheetRestorationRuntime,
+): EditorSheetRestoration {
+  let generation = 0;
+  let frameId: number | null = null;
+  let focusTarget: FocusTargetLike | null = null;
+  let scrollSnapshots: Array<{
+    region: ScrollRegionLike;
+    left: number;
+    top: number;
+  }> = [];
+
+  const cancelFrame = () => {
+    if (frameId !== null) runtime.cancelAnimationFrame(frameId);
+    frameId = null;
+  };
+
+  const cancel = () => {
+    generation += 1;
+    cancelFrame();
+  };
+
+  const capture = (
+    nextFocusTarget: FocusTargetLike | null,
+    regions: Iterable<ScrollRegionLike>,
+  ) => {
+    cancel();
+    focusTarget = nextFocusTarget;
+    scrollSnapshots = Array.from(regions, (region) => ({
+      region,
+      left: region.scrollLeft,
+      top: region.scrollTop,
+    }));
+  };
+
+  const restore = (fallbackFocus: FocusTargetLike | null = null) => {
+    cancelFrame();
+    const activeGeneration = generation;
+    frameId = runtime.requestAnimationFrame(() => {
+      frameId = null;
+      if (activeGeneration !== generation) return;
+
+      for (const snapshot of scrollSnapshots) {
+        snapshot.region.scrollLeft = snapshot.left;
+        snapshot.region.scrollTop = snapshot.top;
+      }
+
+      const target = focusTarget?.isConnected === false ? fallbackFocus : focusTarget;
+      target?.focus({ preventScroll: true });
+    });
+  };
+
+  return { capture, restore, cancel };
+}
+
+export function createBrowserEditorSheetRestoration() {
+  return createEditorSheetRestoration({
+    requestAnimationFrame: (callback) => window.requestAnimationFrame(callback),
+    cancelAnimationFrame: (id) => window.cancelAnimationFrame(id),
+  });
+}

--- a/lib/space-shortcuts.test.ts
+++ b/lib/space-shortcuts.test.ts
@@ -64,6 +64,7 @@ describe('Space shortcut matching', () => {
       'help.open',
       'help.close',
       'search.toggle',
+      'sidebar.toggle',
       'editor.toggle',
       'navigation.add',
       'navigation.toggle-view',

--- a/lib/space-shortcuts.test.ts
+++ b/lib/space-shortcuts.test.ts
@@ -66,6 +66,7 @@ describe('Space shortcut matching', () => {
       'search.toggle',
       'sidebar.toggle',
       'editor.toggle',
+      'editor.close',
       'navigation.add',
       'navigation.toggle-view',
       'review.next',
@@ -179,6 +180,23 @@ describe('Space shortcut matching', () => {
     expect(resolution?.enabled).toBe(false);
   });
 
+  it('lets the mobile editor sheet own Escape while Monaco is focused', () => {
+    const commands = registrations({
+      'review.exit': { run: vi.fn() },
+      'editor.close': { run: vi.fn() },
+    });
+
+    const resolution = resolveSpaceShortcut(
+      keyboardEvent('Escape', {
+        target: fakeTarget({ editable: true, editor: true }),
+      }),
+      commands,
+    );
+
+    expect(resolution?.definition.id).toBe('editor.close');
+    expect(resolution?.definition.scope).toBe('sheet');
+  });
+
   it('respects events already owned by the browser or another widget', () => {
     const commands = registrations({ 'search.toggle': { run: vi.fn() } });
     expect(
@@ -206,6 +224,7 @@ describe('Space shortcut matching', () => {
       reference.find((entry) => entry.definition.id === 'navigation.add')?.unavailableReason,
     ).toBe('Admin access is required');
     expect(reference.some((entry) => entry.definition.id === 'help.close')).toBe(false);
+    expect(reference.some((entry) => entry.definition.id === 'editor.close')).toBe(false);
   });
 });
 

--- a/lib/space-shortcuts.test.ts
+++ b/lib/space-shortcuts.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SPACE_SHORTCUTS,
+  getSpaceShortcutReference,
+  installSpaceShortcutListener,
+  matchesSpaceShortcutBinding,
+  resolveSpaceShortcut,
+  type SpaceShortcutDefinition,
+  type SpaceShortcutId,
+  type SpaceShortcutRegistration,
+} from './space-shortcuts';
+
+type KeyboardOverrides = Partial<KeyboardEvent> & {
+  target?: EventTarget | null;
+};
+
+function keyboardEvent(key: string, overrides: KeyboardOverrides = {}) {
+  let prevented = false;
+  return {
+    key,
+    code: overrides.code ?? '',
+    ctrlKey: overrides.ctrlKey ?? false,
+    metaKey: overrides.metaKey ?? false,
+    altKey: overrides.altKey ?? false,
+    shiftKey: overrides.shiftKey ?? false,
+    repeat: overrides.repeat ?? false,
+    isComposing: overrides.isComposing ?? false,
+    keyCode: overrides.keyCode ?? 0,
+    target: overrides.target ?? null,
+    get defaultPrevented() {
+      return prevented || Boolean(overrides.defaultPrevented);
+    },
+    preventDefault: vi.fn(() => {
+      prevented = true;
+    }),
+    getModifierState: vi.fn(() => false),
+  } as unknown as KeyboardEvent;
+}
+
+function registrations(entries: Partial<Record<SpaceShortcutId, SpaceShortcutRegistration>>) {
+  return new Map(
+    Object.entries(entries) as [SpaceShortcutId, SpaceShortcutRegistration][],
+  );
+}
+
+function fakeTarget(options: { editable?: boolean; editor?: boolean } = {}) {
+  return {
+    tagName: options.editable ? 'INPUT' : 'DIV',
+    isContentEditable: false,
+    getAttribute: () => null,
+    closest: (selector: string) => {
+      if (options.editable && selector.includes('input')) return {};
+      if (options.editor && selector.includes('data-space-shortcut-scope="editor"')) return {};
+      return null;
+    },
+  } as unknown as EventTarget;
+}
+
+describe('Space shortcut matching', () => {
+  it('keeps stable unique registry IDs', () => {
+    const ids = SPACE_SHORTCUTS.map((shortcut) => shortcut.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual([
+      'help.open',
+      'help.close',
+      'search.toggle',
+      'editor.toggle',
+      'navigation.add',
+      'navigation.toggle-view',
+      'review.next',
+      'review.previous',
+      'review.toggle-content',
+      'review.exit',
+      'list.toggle-hovered',
+    ]);
+  });
+
+  it('matches exact modifiers and rejects extra or doubled Mod keys', () => {
+    const binding = SPACE_SHORTCUTS.find((shortcut) => shortcut.id === 'search.toggle')!.keys[0];
+
+    expect(matchesSpaceShortcutBinding(keyboardEvent('k', { ctrlKey: true }), binding)).toBe(true);
+    expect(matchesSpaceShortcutBinding(keyboardEvent('k', { metaKey: true }), binding)).toBe(true);
+    expect(
+      matchesSpaceShortcutBinding(
+        keyboardEvent('k', { ctrlKey: true, shiftKey: true }),
+        binding,
+      ),
+    ).toBe(false);
+    expect(
+      matchesSpaceShortcutBinding(
+        keyboardEvent('k', { ctrlKey: true, metaKey: true }),
+        binding,
+      ),
+    ).toBe(false);
+  });
+
+  it('uses code fallback without treating AltGraph as a command modifier', () => {
+    const binding = SPACE_SHORTCUTS.find(
+      (shortcut) => shortcut.id === 'navigation.add',
+    )!.keys[0];
+    const event = keyboardEvent('å', { code: 'KeyA', ctrlKey: true, altKey: true });
+    Object.defineProperty(event, 'getModifierState', {
+      value: (name: string) => name === 'AltGraph',
+    });
+
+    expect(matchesSpaceShortcutBinding(event, binding)).toBe(false);
+  });
+
+  it('ignores editable targets but permits the explicit editor integration', () => {
+    const commands = registrations({
+      'search.toggle': { run: vi.fn() },
+      'editor.toggle': { run: vi.fn() },
+    });
+
+    expect(
+      resolveSpaceShortcut(
+        keyboardEvent('k', { ctrlKey: true, target: fakeTarget({ editable: true }) }),
+        commands,
+      ),
+    ).toBeNull();
+
+    expect(
+      resolveSpaceShortcut(
+        keyboardEvent('i', {
+          ctrlKey: true,
+          target: fakeTarget({ editable: true, editor: true }),
+        }),
+        commands,
+      )?.definition.id,
+    ).toBe('editor.toggle');
+  });
+
+  it('ignores IME composition and keyCode 229', () => {
+    const commands = registrations({ 'review.next': { run: vi.fn() } });
+
+    expect(
+      resolveSpaceShortcut(keyboardEvent('j', { isComposing: true }), commands),
+    ).toBeNull();
+    expect(resolveSpaceShortcut(keyboardEvent('j', { keyCode: 229 }), commands)).toBeNull();
+  });
+
+  it('keeps repeated-key policy explicit', () => {
+    const commands = registrations({
+      'review.next': { run: vi.fn() },
+      'review.toggle-content': { run: vi.fn() },
+    });
+
+    expect(
+      resolveSpaceShortcut(keyboardEvent('j', { repeat: true }), commands)?.definition.id,
+    ).toBe('review.next');
+    expect(
+      resolveSpaceShortcut(keyboardEvent(' ', { code: 'Space', repeat: true }), commands),
+    ).toBeNull();
+  });
+
+  it('lets a disabled higher scope block a lower-priority handler', () => {
+    const definitions: readonly SpaceShortcutDefinition[] = [
+      {
+        ...SPACE_SHORTCUTS.find((shortcut) => shortcut.id === 'review.exit')!,
+        scope: 'local',
+      },
+      {
+        ...SPACE_SHORTCUTS.find((shortcut) => shortcut.id === 'help.close')!,
+        scope: 'modal',
+      },
+    ];
+    const commands = registrations({
+      'review.exit': { run: vi.fn(), enabled: true },
+      'help.close': {
+        run: vi.fn(),
+        enabled: false,
+        disabledReason: 'Modal is settling',
+      },
+    });
+
+    const resolution = resolveSpaceShortcut(keyboardEvent('Escape'), commands, definitions);
+    expect(resolution?.definition.id).toBe('help.close');
+    expect(resolution?.enabled).toBe(false);
+  });
+
+  it('respects events already owned by the browser or another widget', () => {
+    const commands = registrations({ 'search.toggle': { run: vi.fn() } });
+    expect(
+      resolveSpaceShortcut(
+        keyboardEvent('k', { ctrlKey: true, defaultPrevented: true }),
+        commands,
+      ),
+    ).toBeNull();
+  });
+
+  it('returns disabled reasons from the generated reference', () => {
+    const reference = getSpaceShortcutReference(
+      registrations({
+        'help.open': { run: vi.fn() },
+        'navigation.add': {
+          run: vi.fn(),
+          enabled: false,
+          disabledReason: 'Admin access is required',
+        },
+      }),
+    );
+
+    expect(reference.find((entry) => entry.definition.id === 'help.open')?.available).toBe(true);
+    expect(
+      reference.find((entry) => entry.definition.id === 'navigation.add')?.unavailableReason,
+    ).toBe('Admin access is required');
+    expect(reference.some((entry) => entry.definition.id === 'help.close')).toBe(false);
+  });
+});
+
+describe('Space shortcut listener lifecycle', () => {
+  it('dispatches through one listener and removes it during cleanup', () => {
+    let listener: ((event: KeyboardEvent) => void) | null = null;
+    const target = {
+      addEventListener: vi.fn((_type: 'keydown', next: (event: KeyboardEvent) => void) => {
+        listener = next;
+      }),
+      removeEventListener: vi.fn((_type: 'keydown', next: (event: KeyboardEvent) => void) => {
+        if (listener === next) listener = null;
+      }),
+    };
+    const run = vi.fn();
+    const cleanup = installSpaceShortcutListener(target, () =>
+      registrations({ 'search.toggle': { run } }),
+    );
+
+    const event = keyboardEvent('k', { ctrlKey: true });
+    expect(listener).not.toBeNull();
+    listener!(event);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(listener).toBeNull();
+    expect(target.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not prevent or dispatch a disabled command', () => {
+    let listener: ((event: KeyboardEvent) => void) | null = null;
+    const target = {
+      addEventListener: (_type: 'keydown', next: (event: KeyboardEvent) => void) => {
+        listener = next;
+      },
+      removeEventListener: () => undefined,
+    };
+    const run = vi.fn();
+    installSpaceShortcutListener(target, () =>
+      registrations({ 'navigation.add': { run, enabled: false } }),
+    );
+
+    const event = keyboardEvent('a', { ctrlKey: true, altKey: true });
+    listener!(event);
+    expect(run).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/lib/space-shortcuts.ts
+++ b/lib/space-shortcuts.ts
@@ -8,6 +8,7 @@ export type SpaceShortcutId =
   | 'search.toggle'
   | 'sidebar.toggle'
   | 'editor.toggle'
+  | 'editor.close'
   | 'navigation.add'
   | 'navigation.toggle-view'
   | 'review.next'
@@ -119,6 +120,17 @@ export const SPACE_SHORTCUTS: readonly SpaceShortcutDefinition[] = [
     priority: 80,
     repeat: 'ignore',
     editable: 'editor',
+  },
+  {
+    id: 'editor.close',
+    keys: [{ key: 'Escape', keyLabel: 'Esc' }],
+    scope: 'sheet',
+    category: 'Editor',
+    description: 'Close the mobile code editor',
+    priority: 1_000,
+    repeat: 'ignore',
+    editable: 'allow',
+    hiddenFromReference: true,
   },
   {
     id: 'navigation.add',

--- a/lib/space-shortcuts.ts
+++ b/lib/space-shortcuts.ts
@@ -249,9 +249,13 @@ export function matchesSpaceShortcutBinding(event: KeyboardEvent, binding: Space
   const expectedMod = binding.modifiers?.mod ?? false;
   const expectedAlt = binding.modifiers?.alt ?? false;
   const expectedShift = binding.modifiers?.shift ?? false;
-  const actualMod = event.metaKey || event.ctrlKey;
+  const pressedModKeys = Number(event.metaKey) + Number(event.ctrlKey);
 
-  if (actualMod !== expectedMod || event.altKey !== expectedAlt || event.shiftKey !== expectedShift) {
+  if (
+    (expectedMod ? pressedModKeys !== 1 : pressedModKeys !== 0) ||
+    event.altKey !== expectedAlt ||
+    event.shiftKey !== expectedShift
+  ) {
     return false;
   }
 
@@ -282,7 +286,11 @@ export function resolveSpaceShortcut(
   const candidates = definitions
     .map((definition, registryIndex) => {
       const registration = registrations.get(definition.id);
-      if (!registration || registration.active === false || !definitionMatchesEvent(definition, event)) {
+      if (
+        !registration ||
+        registration.active === false ||
+        !definitionMatchesEvent(definition, event)
+      ) {
         return null;
       }
 

--- a/lib/space-shortcuts.ts
+++ b/lib/space-shortcuts.ts
@@ -1,0 +1,381 @@
+export type SpaceShortcutScope = 'global' | 'local' | 'sheet' | 'modal';
+export type SpaceShortcutRepeatPolicy = 'allow' | 'ignore';
+export type SpaceShortcutEditablePolicy = 'ignore' | 'allow' | 'editor';
+
+export type SpaceShortcutId =
+  | 'help.open'
+  | 'help.close'
+  | 'search.toggle'
+  | 'editor.toggle'
+  | 'navigation.add'
+  | 'navigation.toggle-view'
+  | 'review.next'
+  | 'review.previous'
+  | 'review.toggle-content'
+  | 'review.exit'
+  | 'list.toggle-hovered';
+
+export type SpaceShortcutBinding = {
+  key: string;
+  code?: string;
+  keyLabel?: string;
+  modifiers?: {
+    mod?: boolean;
+    alt?: boolean;
+    shift?: boolean;
+  };
+};
+
+export type SpaceShortcutDefinition = {
+  id: SpaceShortcutId;
+  keys: readonly SpaceShortcutBinding[];
+  scope: SpaceShortcutScope;
+  category: 'General' | 'Navigation' | 'Review' | 'Editor' | 'List';
+  description: string;
+  priority: number;
+  repeat: SpaceShortcutRepeatPolicy;
+  editable: SpaceShortcutEditablePolicy;
+  composition?: 'allow' | 'ignore';
+  hiddenFromReference?: boolean;
+};
+
+export type SpaceShortcutRegistration = {
+  run: (event?: KeyboardEvent) => void;
+  active?: boolean;
+  enabled?: boolean;
+  disabledReason?: string;
+};
+
+export type SpaceShortcutRegistrations = ReadonlyMap<SpaceShortcutId, SpaceShortcutRegistration>;
+
+export type SpaceShortcutResolution = {
+  definition: SpaceShortcutDefinition;
+  registration: SpaceShortcutRegistration;
+  enabled: boolean;
+};
+
+export type SpaceShortcutReferenceEntry = {
+  definition: SpaceShortcutDefinition;
+  available: boolean;
+  unavailableReason?: string;
+};
+
+const SCOPE_PRIORITY: Record<SpaceShortcutScope, number> = {
+  global: 0,
+  local: 10_000,
+  sheet: 20_000,
+  modal: 30_000,
+};
+
+export const SPACE_SHORTCUTS: readonly SpaceShortcutDefinition[] = [
+  {
+    id: 'help.open',
+    keys: [{ key: '?', code: 'Slash', keyLabel: '?', modifiers: { shift: true } }],
+    scope: 'global',
+    category: 'General',
+    description: 'Open keyboard shortcut reference',
+    priority: 100,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'help.close',
+    keys: [{ key: 'Escape', keyLabel: 'Esc' }],
+    scope: 'modal',
+    category: 'General',
+    description: 'Close keyboard shortcut reference',
+    priority: 1_000,
+    repeat: 'ignore',
+    editable: 'allow',
+    hiddenFromReference: true,
+  },
+  {
+    id: 'search.toggle',
+    keys: [{ key: 'k', code: 'KeyK', keyLabel: 'K', modifiers: { mod: true } }],
+    scope: 'global',
+    category: 'General',
+    description: 'Open or close item search',
+    priority: 90,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'editor.toggle',
+    keys: [{ key: 'i', code: 'KeyI', keyLabel: 'I', modifiers: { mod: true } }],
+    scope: 'global',
+    category: 'Editor',
+    description: 'Open or close the code editor',
+    priority: 80,
+    repeat: 'ignore',
+    editable: 'editor',
+  },
+  {
+    id: 'navigation.add',
+    keys: [
+      {
+        key: 'a',
+        code: 'KeyA',
+        keyLabel: 'A',
+        modifiers: { mod: true, alt: true },
+      },
+    ],
+    scope: 'global',
+    category: 'Navigation',
+    description: 'Add a new item',
+    priority: 70,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'navigation.toggle-view',
+    keys: [
+      { key: 'e', code: 'KeyE', keyLabel: 'E', modifiers: { mod: true } },
+      {
+        key: 'e',
+        code: 'KeyE',
+        keyLabel: 'E',
+        modifiers: { mod: true, shift: true },
+      },
+    ],
+    scope: 'global',
+    category: 'Navigation',
+    description: 'Switch between list and review views',
+    priority: 70,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'review.next',
+    keys: [
+      { key: 'ArrowRight', keyLabel: '→' },
+      { key: 'j', code: 'KeyJ', keyLabel: 'J' },
+    ],
+    scope: 'local',
+    category: 'Review',
+    description: 'Move to the next review item',
+    priority: 90,
+    repeat: 'allow',
+    editable: 'ignore',
+  },
+  {
+    id: 'review.previous',
+    keys: [
+      { key: 'ArrowLeft', keyLabel: '←' },
+      { key: 'k', code: 'KeyK', keyLabel: 'K' },
+    ],
+    scope: 'local',
+    category: 'Review',
+    description: 'Move to the previous review item',
+    priority: 90,
+    repeat: 'allow',
+    editable: 'ignore',
+  },
+  {
+    id: 'review.toggle-content',
+    keys: [{ key: ' ', code: 'Space', keyLabel: 'Space' }],
+    scope: 'local',
+    category: 'Review',
+    description: 'Show or hide review content',
+    priority: 80,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'review.exit',
+    keys: [{ key: 'Escape', keyLabel: 'Esc' }],
+    scope: 'local',
+    category: 'Review',
+    description: 'Return to the item list',
+    priority: 100,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'list.toggle-hovered',
+    keys: [{ key: 'Shift', keyLabel: 'Shift', modifiers: { shift: true } }],
+    scope: 'local',
+    category: 'List',
+    description: 'Expand or collapse the hovered item',
+    priority: 80,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+] as const;
+
+function normaliseKey(key: string) {
+  return key.length === 1 ? key.toLowerCase() : key;
+}
+
+function getTargetLike(target: EventTarget | null) {
+  return target as
+    | (EventTarget & {
+        tagName?: string;
+        isContentEditable?: boolean;
+        getAttribute?: (name: string) => string | null;
+        closest?: (selector: string) => unknown;
+      })
+    | null;
+}
+
+export function isEditableShortcutTarget(target: EventTarget | null) {
+  const candidate = getTargetLike(target);
+  if (!candidate) return false;
+
+  const tagName = candidate.tagName?.toLowerCase();
+  if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') return true;
+  if (candidate.isContentEditable) return true;
+
+  const role = candidate.getAttribute?.('role');
+  if (role === 'textbox' || role === 'searchbox' || role === 'combobox') return true;
+
+  return Boolean(
+    candidate.closest?.(
+      'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="searchbox"], [role="combobox"], [data-space-shortcut-editable]',
+    ),
+  );
+}
+
+function editablePolicyAllows(definition: SpaceShortcutDefinition, target: EventTarget | null) {
+  if (!isEditableShortcutTarget(target)) return true;
+  if (definition.editable === 'allow') return true;
+  if (definition.editable === 'ignore') return false;
+
+  return Boolean(getTargetLike(target)?.closest?.('[data-space-shortcut-scope="editor"]'));
+}
+
+export function matchesSpaceShortcutBinding(event: KeyboardEvent, binding: SpaceShortcutBinding) {
+  if (event.getModifierState?.('AltGraph')) return false;
+
+  const expectedMod = binding.modifiers?.mod ?? false;
+  const expectedAlt = binding.modifiers?.alt ?? false;
+  const expectedShift = binding.modifiers?.shift ?? false;
+  const actualMod = event.metaKey || event.ctrlKey;
+
+  if (actualMod !== expectedMod || event.altKey !== expectedAlt || event.shiftKey !== expectedShift) {
+    return false;
+  }
+
+  const keyMatches = normaliseKey(event.key) === normaliseKey(binding.key);
+  const codeMatches = binding.code ? event.code === binding.code : false;
+  return keyMatches || codeMatches;
+}
+
+function definitionMatchesEvent(definition: SpaceShortcutDefinition, event: KeyboardEvent) {
+  if (event.repeat && definition.repeat === 'ignore') return false;
+  if (
+    definition.composition !== 'allow' &&
+    (event.isComposing || event.keyCode === 229)
+  ) {
+    return false;
+  }
+  if (!editablePolicyAllows(definition, event.target)) return false;
+  return definition.keys.some((binding) => matchesSpaceShortcutBinding(event, binding));
+}
+
+export function resolveSpaceShortcut(
+  event: KeyboardEvent,
+  registrations: SpaceShortcutRegistrations,
+  definitions: readonly SpaceShortcutDefinition[] = SPACE_SHORTCUTS,
+): SpaceShortcutResolution | null {
+  if (event.defaultPrevented) return null;
+
+  const candidates = definitions
+    .map((definition, registryIndex) => {
+      const registration = registrations.get(definition.id);
+      if (!registration || registration.active === false || !definitionMatchesEvent(definition, event)) {
+        return null;
+      }
+
+      return {
+        definition,
+        registration,
+        registryIndex,
+        rank: SCOPE_PRIORITY[definition.scope] + definition.priority,
+      };
+    })
+    .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
+    .sort((left, right) => right.rank - left.rank || left.registryIndex - right.registryIndex);
+
+  const winner = candidates[0];
+  if (!winner) return null;
+
+  return {
+    definition: winner.definition,
+    registration: winner.registration,
+    enabled: winner.registration.enabled !== false,
+  };
+}
+
+export type SpaceShortcutListenerTarget = {
+  addEventListener: (type: 'keydown', listener: (event: KeyboardEvent) => void) => void;
+  removeEventListener: (type: 'keydown', listener: (event: KeyboardEvent) => void) => void;
+};
+
+export function installSpaceShortcutListener(
+  target: SpaceShortcutListenerTarget,
+  getRegistrations: () => SpaceShortcutRegistrations,
+) {
+  const onKeyDown = (event: KeyboardEvent) => {
+    const resolution = resolveSpaceShortcut(event, getRegistrations());
+    if (!resolution || !resolution.enabled) return;
+
+    event.preventDefault();
+    resolution.registration.run(event);
+  };
+
+  target.addEventListener('keydown', onKeyDown);
+  return () => target.removeEventListener('keydown', onKeyDown);
+}
+
+export function getSpaceShortcutReference(
+  registrations: SpaceShortcutRegistrations,
+): SpaceShortcutReferenceEntry[] {
+  return SPACE_SHORTCUTS.filter((definition) => !definition.hiddenFromReference).map(
+    (definition) => {
+      const registration = registrations.get(definition.id);
+      const active = registration?.active !== false;
+      const enabled = registration?.enabled !== false;
+      const available = Boolean(registration && active && enabled);
+
+      return {
+        definition,
+        available,
+        unavailableReason: available
+          ? undefined
+          : registration?.disabledReason ?? 'Unavailable on this screen',
+      };
+    },
+  );
+}
+
+export function formatSpaceShortcutBinding(binding: SpaceShortcutBinding, isMac: boolean) {
+  const keyLabel = binding.keyLabel ?? binding.key;
+  if (binding.key === '?' || binding.key === 'Shift') {
+    return {
+      visual: keyLabel,
+      spoken: binding.key === '?' ? 'question mark' : 'Shift',
+    };
+  }
+
+  const visualParts: string[] = [];
+  const spokenParts: string[] = [];
+  if (binding.modifiers?.mod) {
+    visualParts.push(isMac ? '⌘' : 'Ctrl');
+    spokenParts.push(isMac ? 'Command' : 'Control');
+  }
+  if (binding.modifiers?.alt) {
+    visualParts.push(isMac ? '⌥' : 'Alt');
+    spokenParts.push(isMac ? 'Option' : 'Alt');
+  }
+  if (binding.modifiers?.shift) {
+    visualParts.push('Shift');
+    spokenParts.push('Shift');
+  }
+  visualParts.push(keyLabel);
+  spokenParts.push(keyLabel === 'Esc' ? 'Escape' : keyLabel);
+
+  return {
+    visual: visualParts.join(isMac ? '' : '+'),
+    spoken: spokenParts.join(' plus '),
+  };
+}

--- a/lib/space-shortcuts.ts
+++ b/lib/space-shortcuts.ts
@@ -6,6 +6,7 @@ export type SpaceShortcutId =
   | 'help.open'
   | 'help.close'
   | 'search.toggle'
+  | 'sidebar.toggle'
   | 'editor.toggle'
   | 'navigation.add'
   | 'navigation.toggle-view'
@@ -96,6 +97,16 @@ export const SPACE_SHORTCUTS: readonly SpaceShortcutDefinition[] = [
     category: 'General',
     description: 'Open or close item search',
     priority: 90,
+    repeat: 'ignore',
+    editable: 'ignore',
+  },
+  {
+    id: 'sidebar.toggle',
+    keys: [{ key: 'b', code: 'KeyB', keyLabel: 'B', modifiers: { mod: true } }],
+    scope: 'global',
+    category: 'General',
+    description: 'Open or close the navigation sidebar',
+    priority: 85,
     repeat: 'ignore',
     editable: 'ignore',
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,5 +24,8 @@ export default defineConfig({
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
+    env: {
+      SCRAPBOOK_E2E_SPACE_FIXTURE: '1',
+    },
   },
 });

--- a/tests/e2e/space-mobile-editor-sheet.spec.ts
+++ b/tests/e2e/space-mobile-editor-sheet.spec.ts
@@ -1,0 +1,268 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+type MobileScenario = {
+  name: string;
+  width: number;
+  height: number;
+  keyboardHeight: number;
+  keyboardOffsetTop: number;
+};
+
+const portrait: MobileScenario = {
+  name: 'portrait 390x844',
+  width: 390,
+  height: 844,
+  keyboardHeight: 500,
+  keyboardOffsetTop: 0,
+};
+
+const landscape: MobileScenario = {
+  name: 'reduced-height landscape 740x390',
+  width: 740,
+  height: 390,
+  keyboardHeight: 238,
+  keyboardOffsetTop: 18,
+};
+
+async function installSyntheticVisualViewport(page: Page, scenario: MobileScenario) {
+  await page.addInitScript(({ width, height }) => {
+    class TestVisualViewport extends EventTarget {
+      width = width;
+      height = height;
+      offsetTop = 0;
+      offsetLeft = 0;
+      pageTop = 0;
+      pageLeft = 0;
+      scale = 1;
+
+      setGeometry(nextHeight: number, nextOffsetTop: number) {
+        this.height = nextHeight;
+        this.offsetTop = nextOffsetTop;
+        this.dispatchEvent(new Event('resize'));
+        this.dispatchEvent(new Event('scroll'));
+      }
+    }
+
+    const viewport = new TestVisualViewport();
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: viewport,
+    });
+    (
+      window as Window & {
+        __setSpaceVisualViewport?: (nextHeight: number, nextOffsetTop: number) => void;
+      }
+    ).__setSpaceVisualViewport = (nextHeight, nextOffsetTop) =>
+      viewport.setGeometry(nextHeight, nextOffsetTop);
+  }, scenario);
+}
+
+async function setSyntheticVisualViewport(
+  page: Page,
+  height: number,
+  offsetTop: number,
+) {
+  await page.evaluate(
+    ({ nextHeight, nextOffsetTop }) => {
+      const setter = (
+        window as Window & {
+          __setSpaceVisualViewport?: (height: number, top: number) => void;
+        }
+      ).__setSpaceVisualViewport;
+      if (!setter) throw new Error('Missing synthetic Space visual viewport');
+      setter(nextHeight, nextOffsetTop);
+    },
+    { nextHeight: height, nextOffsetTop: offsetTop },
+  );
+}
+
+async function gotoMobile(page: Page, scenario: MobileScenario, path = '/space') {
+  await page.setViewportSize({ width: scenario.width, height: scenario.height });
+  await installSyntheticVisualViewport(page, scenario);
+  await page.goto(path);
+  await expect(page.getByRole('toolbar', { name: 'Space mobile actions' })).toBeVisible();
+  await expect(page.getByText('Shortcut Alpha')).toBeVisible();
+}
+
+async function openEditor(page: Page) {
+  const trigger = page.getByRole('button', { name: 'Open code editor' });
+  await trigger.click();
+  const dialog = page.getByRole('dialog', { name: 'Code editor' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('.monaco-editor')).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => page.evaluate(() => Boolean(history.state?.__spaceEditorSheet)))
+    .toBe(true);
+  return { trigger, dialog };
+}
+
+async function monacoInput(dialog: Locator) {
+  const input = dialog.locator('textarea.inputarea');
+  await expect(input).toBeVisible();
+  await input.click();
+  return input;
+}
+
+async function addScrollableSpace(page: Page) {
+  return page.evaluate(() => {
+    const region = document.querySelector<HTMLElement>('[data-space-scroll-region]');
+    if (!region) throw new Error('Missing Space scroll region');
+    const spacer = document.createElement('div');
+    spacer.setAttribute('data-space-test-spacer', 'true');
+    spacer.style.height = '1400px';
+    spacer.style.minHeight = '1400px';
+    spacer.style.flex = '0 0 1400px';
+    region.appendChild(spacer);
+    region.scrollTop = 240;
+    return region.scrollTop;
+  });
+}
+
+async function expectScroll(page: Page, expected: number) {
+  await expect
+    .poll(() =>
+      page.evaluate((top) => {
+        const region = document.querySelector<HTMLElement>('[data-space-scroll-region]');
+        return region ? Math.abs(region.scrollTop - top) : Number.POSITIVE_INFINITY;
+      }, expected),
+    )
+    .toBeLessThanOrEqual(2);
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth),
+    )
+    .toBeLessThanOrEqual(1);
+}
+
+test.describe('mobile Space actions', () => {
+  test.use({ hasTouch: true });
+
+  for (const scenario of [portrait, landscape]) {
+    test(`${scenario.name} exposes registry actions and natural scrolling`, async ({ page }) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await gotoMobile(page, scenario);
+
+      const toolbar = page.getByRole('toolbar', { name: 'Space mobile actions' });
+      await expect(toolbar.getByRole('button', { name: 'Search items' })).toBeVisible();
+      await expect(toolbar.getByRole('button', { name: 'Open review' })).toBeVisible();
+      await expect(toolbar.getByRole('button', { name: 'Open code editor' })).toBeVisible();
+      await expect(toolbar.getByRole('button', { name: 'Add item' })).toBeEnabled();
+
+      const reducedMotion = await toolbar.evaluate((element) => {
+        const style = getComputedStyle(element);
+        return { property: style.transitionProperty, duration: style.transitionDuration };
+      });
+      expect(
+        reducedMotion.property === 'none' ||
+          reducedMotion.duration.split(',').every((duration) => duration.trim() === '0s'),
+      ).toBe(true);
+
+      await toolbar.getByRole('button', { name: 'Search items' }).click();
+      const search = page.getByPlaceholder(/Search items/);
+      await expect(search).toBeFocused();
+      await search.fill('alpha');
+      await expect(search).toHaveValue('alpha');
+      await page.keyboard.press('Escape');
+      await expect(search).toBeHidden();
+
+      const scrollBefore = await addScrollableSpace(page);
+      const region = page.locator('[data-space-scroll-region]').first();
+      const box = await region.boundingBox();
+      expect(box).toBeTruthy();
+      await page.mouse.move(box!.x + box!.width / 2, Math.min(box!.y + 80, scenario.height - 120));
+      await page.mouse.wheel(0, 320);
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            document.querySelector<HTMLElement>('[data-space-scroll-region]')?.scrollTop ?? 0,
+          ),
+        )
+        .toBeGreaterThan(scrollBefore);
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+});
+
+test.describe('mobile Space editor sheet', () => {
+  test.use({ hasTouch: true });
+
+  for (const scenario of [portrait, landscape]) {
+    test(`${scenario.name} preserves review, Monaco selection, focus, scroll, and keyboard geometry`, async ({
+      page,
+    }) => {
+      await gotoMobile(page, scenario, '/space/review');
+      await page.keyboard.press('ArrowRight');
+      await expect(page.locator('[data-space-current-item]')).toContainText('Shortcut Beta');
+      await page.keyboard.press('Space');
+      await expect(page.locator('[data-space-review-content]')).toHaveAttribute(
+        'data-space-review-content',
+        'hidden',
+      );
+
+      const savedScroll = await addScrollableSpace(page);
+      const { trigger, dialog } = await openEditor(page);
+      const input = await monacoInput(dialog);
+      await page.keyboard.type('alpha');
+      await page.keyboard.press('Shift+ArrowLeft');
+
+      await setSyntheticVisualViewport(
+        page,
+        scenario.keyboardHeight,
+        scenario.keyboardOffsetTop,
+      );
+      await expect
+        .poll(() =>
+          dialog.evaluate((element) => {
+            const viewport = window.visualViewport;
+            const rect = element.getBoundingClientRect();
+            return {
+              top: Math.abs(rect.top - (viewport?.offsetTop ?? 0)),
+              bottom: Math.abs(rect.bottom - ((viewport?.offsetTop ?? 0) + (viewport?.height ?? 0))),
+            };
+          }),
+        )
+        .toEqual({ top: 0, bottom: 0 });
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden();
+      await expect(trigger).toBeFocused();
+      await expect(page).toHaveURL(/\/space\/review(?:\?|$)/);
+      await expect(page.locator('[data-space-current-item]')).toContainText('Shortcut Beta');
+      await expect(page.locator('[data-space-review-content]')).toHaveAttribute(
+        'data-space-review-content',
+        'hidden',
+      );
+      await expectScroll(page, savedScroll);
+
+      await setSyntheticVisualViewport(page, scenario.height, 0);
+      const reopened = await openEditor(page);
+      await monacoInput(reopened.dialog);
+      await page.keyboard.type('X');
+      await expect(reopened.dialog.locator('.view-lines')).toContainText('alphX');
+      await reopened.dialog.getByRole('button', { name: 'Close code editor' }).click();
+      await expect(reopened.dialog).toBeHidden();
+      await expect(reopened.trigger).toBeFocused();
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+
+  test('portrait browser back dismisses the sheet without losing the draft', async ({ page }) => {
+    await gotoMobile(page, portrait);
+    const { trigger, dialog } = await openEditor(page);
+    await monacoInput(dialog);
+    await page.keyboard.type('browser back draft');
+
+    await page.goBack();
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/\/space$/);
+    await expect(trigger).toBeFocused();
+
+    const reopened = await openEditor(page);
+    await expect(reopened.dialog.locator('.view-lines')).toContainText('browser back draft');
+    await reopened.dialog.getByRole('button', { name: 'Close code editor' }).click();
+    await expect(reopened.dialog).toBeHidden();
+  });
+});

--- a/tests/e2e/space-shortcuts.spec.ts
+++ b/tests/e2e/space-shortcuts.spec.ts
@@ -30,8 +30,8 @@ test.describe('Space shortcut registry', () => {
       'Move to the next review item',
     );
     await expect(help.locator('[data-space-shortcut-id="review.next"]')).toHaveAttribute(
-      'aria-disabled',
-      'true',
+      'data-available',
+      'false',
     );
 
     await page.keyboard.press('Escape');

--- a/tests/e2e/space-shortcuts.spec.ts
+++ b/tests/e2e/space-shortcuts.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test, type Page } from '@playwright/test';
 
 async function pressMod(page: Page, key: string) {
-  await page.keyboard.press(`Control+${key}`);
+  const modifier = await page.evaluate(() =>
+    /Mac|iPhone|iPad/i.test(navigator.platform) ? 'Meta' : 'Control',
+  );
+  await page.keyboard.press(`${modifier}+${key}`);
 }
 
 test.describe('Space shortcut registry', () => {

--- a/tests/e2e/space-shortcuts.spec.ts
+++ b/tests/e2e/space-shortcuts.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function pressMod(page: Page, key: string) {
+  await page.keyboard.press(`Control+${key}`);
+}
+
+test.describe('Space shortcut registry', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/space');
+    await expect(page.getByRole('button', { name: 'Toggle sidebar' })).toBeVisible();
+    await expect(page.getByText('Shortcut Alpha')).toBeVisible();
+  });
+
+  test('opens the generated reference and preserves typing', async ({ page }) => {
+    await page.keyboard.press('Shift+/');
+
+    const help = page.locator('[data-space-shortcut-help]');
+    await expect(help).toBeVisible();
+    await expect(help.getByRole('heading', { name: 'Space keyboard shortcuts' })).toBeVisible();
+    await expect(help.locator('[data-space-shortcut-id="search.toggle"]')).toContainText(
+      'Open or close item search',
+    );
+    await expect(help.locator('[data-space-shortcut-id="sidebar.toggle"]')).toContainText(
+      'Open or close the navigation sidebar',
+    );
+    await expect(help.locator('[data-space-shortcut-id="review.next"]')).toContainText(
+      'Move to the next review item',
+    );
+    await expect(help.locator('[data-space-shortcut-id="review.next"]')).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+
+    await page.keyboard.press('Escape');
+    await expect(help).toBeHidden();
+
+    await pressMod(page, 'K');
+    const search = page.getByPlaceholder(/Search items/);
+    await expect(search).toBeFocused();
+    await page.keyboard.type('j ? k');
+    await expect(search).toHaveValue('j ? k');
+    await expect(page).toHaveURL(/\/space$/);
+  });
+
+  test('dispatches sidebar, navigation, and review commands once', async ({ page }) => {
+    const sidebar = page.locator('[data-side="left"][data-state]').first();
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+
+    await pressMod(page, 'B');
+    await expect(sidebar).toHaveAttribute('data-state', 'collapsed');
+    await pressMod(page, 'B');
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+
+    await pressMod(page, 'E');
+    await expect(page).toHaveURL(/\/space\/review(?:\?|$)/);
+    await expect(page.getByRole('heading', { name: 'Shortcut Alpha' })).toBeVisible();
+    await expect(page.getByText('Alpha review content')).toBeVisible();
+
+    await page.keyboard.press('Space');
+    await expect(page.getByText('Alpha review content')).toBeHidden();
+
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByRole('heading', { name: 'Shortcut Beta' })).toBeVisible();
+    await expect(page.getByText('Beta review content')).toBeVisible();
+
+    await page.keyboard.press('k');
+    await expect(page.getByRole('heading', { name: 'Shortcut Alpha' })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page).toHaveURL(/\/space$/);
+  });
+
+  test('bridges the editor command and keeps the help surface usable on mobile', async ({ page }) => {
+    await pressMod(page, 'I');
+    const editor = page.locator('[data-space-shortcut-scope="editor"]');
+    await expect(editor).toBeVisible();
+    await expect(editor.locator('.monaco-editor')).toBeVisible({ timeout: 30_000 });
+
+    await pressMod(page, 'I');
+    await expect(editor).toBeHidden();
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.reload();
+    await page.getByRole('button', { name: 'Toggle sidebar' }).click();
+    await page.getByRole('button', { name: 'Keyboard shortcuts' }).click();
+
+    await expect(page.locator('[data-space-shortcut-help]')).toBeVisible();
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth))
+      .toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/e2e/space-shortcuts.spec.ts
+++ b/tests/e2e/space-shortcuts.spec.ts
@@ -15,6 +15,27 @@ async function waitForSpaceHydration(page: Page) {
   await expect(help).toBeHidden();
 }
 
+async function openMobileSidebar(page: Page) {
+  const toggle = page.getByRole('button', { name: 'Toggle sidebar' });
+  const referenceButton = page.getByRole('button', { name: 'Keyboard shortcuts' });
+
+  await expect
+    .poll(
+      async () => {
+        if (await referenceButton.isVisible()) return true;
+        await toggle.click();
+        try {
+          await referenceButton.waitFor({ state: 'visible', timeout: 1_500 });
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 15_000 },
+    )
+    .toBe(true);
+}
+
 test.describe('Space shortcut registry', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/space');
@@ -64,7 +85,7 @@ test.describe('Space shortcut registry', () => {
     await expect(sidebar).toHaveAttribute('data-state', 'expanded');
 
     await pressMod(page, 'E');
-    await expect(page).toHaveURL(/\/space\/review(?:\?|$)/);
+    await expect(page).toHaveURL(/\/space\/review(?:\?|$)/, { timeout: 15_000 });
     await expect(page.getByRole('heading', { name: 'Shortcut Alpha' })).toBeVisible();
     await expect(page.getByText('Alpha review content')).toBeVisible();
 
@@ -79,7 +100,7 @@ test.describe('Space shortcut registry', () => {
     await expect(page.getByRole('heading', { name: 'Shortcut Alpha' })).toBeVisible();
 
     await page.keyboard.press('Escape');
-    await expect(page).toHaveURL(/\/space$/);
+    await expect(page).toHaveURL(/\/space$/, { timeout: 15_000 });
   });
 
   test('bridges the editor command and keeps the help surface usable on mobile', async ({ page }) => {
@@ -93,7 +114,7 @@ test.describe('Space shortcut registry', () => {
 
     await page.setViewportSize({ width: 390, height: 844 });
     await page.reload();
-    await page.getByRole('button', { name: 'Toggle sidebar' }).click();
+    await openMobileSidebar(page);
     await page.getByRole('button', { name: 'Keyboard shortcuts' }).click();
 
     await expect(page.locator('[data-space-shortcut-help]')).toBeVisible();

--- a/tests/e2e/space-shortcuts.spec.ts
+++ b/tests/e2e/space-shortcuts.spec.ts
@@ -7,11 +7,20 @@ async function pressMod(page: Page, key: string) {
   await page.keyboard.press(`${modifier}+${key}`);
 }
 
+async function waitForSpaceHydration(page: Page) {
+  const help = page.locator('[data-space-shortcut-help]');
+  await page.getByRole('button', { name: 'Keyboard shortcuts' }).click();
+  await expect(help).toBeVisible();
+  await page.getByRole('button', { name: 'Close' }).click();
+  await expect(help).toBeHidden();
+}
+
 test.describe('Space shortcut registry', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/space');
     await expect(page.getByRole('button', { name: 'Toggle sidebar' })).toBeVisible();
     await expect(page.getByText('Shortcut Alpha')).toBeVisible();
+    await waitForSpaceHydration(page);
   });
 
   test('opens the generated reference and preserves typing', async ({ page }) => {


### PR DESCRIPTION
## Summary

- add a mobile bottom action rail for search, list/review switching, editor, and add-item actions;
- delegate every action through Agent 2's typed Space shortcut registry;
- add a hidden sheet-scope `editor.close` command for Escape without another global keyboard listener;
- keep one Monaco instance mounted after first open so unsaved code and selection survive sheet dismissal;
- present the editor as a visual-viewport-sized mobile dialog with safe-area padding, screen-reader labelling, reduced-motion handling, and desktop geometry unchanged;
- preserve current list/review state, focused trigger, and marked scroll regions across Escape, close-button, and browser-back dismissal;
- keep ordinary Space scrolling available after the sheet closes.

## Dependency

#410 is explicitly stable at `cd91c23c9e6e7b390a25e0eb108c0bf306b84396`, with CI run 351 green. This branch was created from current `main` at `ce6171abfa658533239607c344abb217fa373a72` and currently carries the stable registry merge until #422 lands. The branch will be rebased onto post-#410 `main` before handoff completion so registry-only files disappear from this PR's final diff.

## Registry integration

- mobile buttons call `executeShortcut(id)`;
- Monaco continues bridging `Mod+I` through `editor.toggle`;
- the editor registers `editor.toggle` and sheet-only `editor.close` through `useSpaceShortcut`;
- sheet scope outranks review-local Escape;
- no new document or window `keydown` listener.

## Deterministic coverage

Unit coverage covers:

- visual-viewport geometry and clamping;
- same-page history ownership;
- exact multi-region scroll restoration;
- original/fallback trigger focus;
- stale restoration cancellation;
- sheet Escape precedence while Monaco is focused.

Playwright covers Chromium and WebKit at:

- portrait: 390×844, synthetic keyboard viewport 500px;
- reduced-height landscape: 740×390, synthetic keyboard viewport 238px at 18px offset.

The scenarios cover registry-backed mobile actions, safe action access, reduced motion, natural scrolling, review/current-item preservation, hidden/revealed review state, Monaco draft and selection persistence, Escape, close-button, browser-back, focus restoration, viewport bounds, and horizontal overflow.

## Scope

No time-picker, homepage activity, navigation-progress, or material-system files are changed by #414.

Closes #414

Draft for CI, dependency rebase, and self-review. Do not merge yet.