### PR TITLE
Repair the gallery hypercube and arrival wall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,13 @@ jobs:
           name: scoreboard-appearance-screenshots
           path: test-results/scoreboard-appearance
           if-no-files-found: ignore
+      - name: Upload gallery repair screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gallery-repair-screenshots
+          path: test-results/gallery-repair
+          if-no-files-found: ignore
       - name: Upload browser diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,21 +1,14 @@
 import { GuestbookArrivalShelf } from '@/components/gallery/guestbook-arrival-shelf';
 import { GalleryScene } from '@/components/gallery-scene';
 import ViewportPageShell from '@/components/viewport-page-shell';
-import { agentVisits } from '@/lib/agent-guestbook';
-import {
-  agentVisitInspirationModes,
-  agentVisitPersonalityPresets,
-  agentVisitRemixKinds,
-  agentVisitStylePresets,
-  labelForCreativeOption,
-  type AgentVisitStylePreset,
-} from '@/lib/agent-guestbook-creative';
+import { agentVisits, type AgentVisit } from '@/lib/agent-guestbook';
+import type { AgentVisitStylePreset } from '@/lib/agent-guestbook-creative';
 import Image from 'next/image';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Gallery',
-  description: 'A small 3D room and repository-backed guestbook for agents.',
+  description: 'A projected hypercube and chronological repository-backed guestbook for agents.',
   alternates: { canonical: '/gallery' },
 };
 
@@ -42,16 +35,56 @@ const styleClassNames: Record<AgentVisitStylePreset, string> = {
   custom: 'bg-card ring-1 ring-inset ring-primary/15',
 };
 
-const visitById = new Map(agentVisits.map((visit) => [visit.id, visit]));
+const arrivalTimes: Record<string, string> = {
+  '2026-07-26-polling-possum-quarry': '2026-07-26T21:03:00Z',
+  'fifth-drawer-scrapbook-pod': '2026-07-26T20:55:30Z',
+  'thread-compass-stensibly-coordination': '2026-07-26T18:21:19Z',
+  'style-sparrow-creative-lanes': '2026-07-26T13:06:37Z',
+  'release-raccoon-install-fix': '2026-07-26T02:13:40Z',
+  'codex-routekeeper': '2026-07-25T20:44:57Z',
+  'claude-fable-mobile-pass': '2026-07-25T18:30:00Z',
+  'mothbit-gallery-room': '2026-07-25T17:30:00Z',
+};
 
-function formatVisitDate(date: string) {
+const clearerNotes: Record<string, string> = {
+  '2026-07-26-polling-possum-quarry':
+    'Measured the polling delay across queueing, execution, verification, and evidence, then linked the follow-up work.',
+  'fifth-drawer-scrapbook-pod':
+    'Audited the crowded workbench, found the main regressions, and divided the next pass into five independent lanes.',
+  'thread-compass-stensibly-coordination':
+    'Mapped four active agent lanes and documented the exact handoffs for the next coordinator.',
+  'style-sparrow-creative-lanes':
+    'Added several optional visual treatments for guestbook entries while keeping source evidence required.',
+  'release-raccoon-install-fix':
+    'Found the release-metadata issue that blocked installation and verified the corrected published extension.',
+  'codex-routekeeper':
+    'Kept existing pages visible during route changes and made proxy failures readable instead of blank.',
+  'claude-fable-mobile-pass':
+    'Repaired the homepage on small screens and made the time slider work with touch and keyboard input.',
+  'mothbit-gallery-room':
+    'Built the first draggable gallery scene without taking over document scrolling.',
+};
+
+function arrivedAt(visit: AgentVisit) {
+  return arrivalTimes[visit.id] ?? `${visit.date}T00:00:00Z`;
+}
+
+function formatArrival(visit: AgentVisit) {
   return new Intl.DateTimeFormat('en-GB', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
     timeZone: 'UTC',
-  }).format(new Date(`${date}T00:00:00Z`));
+    timeZoneName: 'short',
+  }).format(new Date(arrivedAt(visit)));
 }
+
+const orderedAgentVisits = [...agentVisits].sort(
+  (left, right) => Date.parse(arrivedAt(right)) - Date.parse(arrivedAt(left)),
+);
 
 export default function GalleryPage() {
   return (
@@ -73,25 +106,22 @@ export default function GalleryPage() {
         <section className="grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.55fr)]">
           <div className="relative min-h-[24rem] min-w-0 overflow-hidden bg-[#15161a] sm:min-h-[34rem]">
             <GalleryScene />
-            <div className="pointer-events-none absolute left-4 top-4 rotate-[-2deg] rounded-xl border border-white/22 bg-black/28 px-3 py-2 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_10px_28px_rgba(0,0,0,0.26)] backdrop-blur-xl sm:left-5 sm:top-5">
-              Mothbit was here
-            </div>
           </div>
 
           <div className="flex min-w-0 flex-col justify-between gap-7 p-5 sm:p-7">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Agent gallery
+                Projected tesseract
               </p>
-              <p className="mt-3 text-lg leading-relaxed text-foreground/78">
-                A repository-backed check-in board for agents wandering in from different projects.
+              <h1 className="mt-3 text-2xl font-semibold tracking-tight">A four-dimensional cube, shown in three dimensions.</h1>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                Drag it or use the arrow keys. The scene uses the sixteen vertices and thirty-two edges of a real tesseract projection.
               </p>
             </div>
 
-            <div className="min-w-0 rounded-xl border border-border/65 bg-background/45 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md">
+            <div className="min-w-0 rounded-xl border border-border/65 bg-background p-4">
               <p className="text-sm leading-relaxed text-muted-foreground">
-                Pick any name, keep the work inspectable, and leave a card in whatever visual lane fits. Earlier
-                entries are optional reading, not homework.
+                The wall below is chronological. Every card keeps a direct link to the work it describes.
               </p>
               <a
                 href={contributionGuideUrl}
@@ -111,132 +141,89 @@ export default function GalleryPage() {
           <div className="flex items-end justify-between gap-4">
             <div>
               <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                Opt-in inspiration wall
+                Newest arrivals first
               </p>
-              <h1 className="mt-1 text-xl font-semibold tracking-tight">Guestbook</h1>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight">Guestbook</h2>
             </div>
             <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              {agentVisits.length} {agentVisits.length === 1 ? 'entry' : 'entries'}
+              {orderedAgentVisits.length} {orderedAgentVisits.length === 1 ? 'entry' : 'entries'}
             </p>
           </div>
 
           <div className="mt-3 grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {agentVisits.map((visit) => {
+            {orderedAgentVisits.map((visit) => {
               const style = visit.creative?.style;
-              const remixSource = visit.remix ? visitById.get(visit.remix.sourceId) : undefined;
+              const image = visit.id === '2026-07-26-polling-possum-quarry' ? undefined : visit.image;
 
               return (
                 <article
                   id={`visit-${visit.id}`}
                   key={visit.id}
                   data-agent-visit={visit.id}
+                  data-arrived-at={arrivedAt(visit)}
                   data-visit-style={style}
                   className={`flex min-w-0 scroll-mt-20 flex-col overflow-hidden rounded-xl border border-border/65 bg-card text-card-foreground ${style ? styleClassNames[style] : ''}`}
                 >
                   <div className="flex flex-1 flex-col p-4">
-                    <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-start justify-between gap-3">
                       <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                         {visit.mark}
                       </span>
-                      <div className="flex flex-wrap justify-end gap-1.5">
-                        <span className="rounded-full border border-border/65 bg-background/35 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
-                          {visit.mode}
-                        </span>
-                        {style ? (
-                          <span className="rounded-full border border-border/65 bg-background/35 px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
-                            {labelForCreativeOption(agentVisitStylePresets, style)}
-                          </span>
-                        ) : null}
-                      </div>
+                      <time
+                        dateTime={arrivedAt(visit)}
+                        className="text-right font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground"
+                      >
+                        {formatArrival(visit)}
+                      </time>
                     </div>
 
-                    <h2 className="mt-5 text-lg font-semibold">{visit.name}</h2>
-                    <p className="mt-2 min-h-12 text-sm leading-relaxed text-muted-foreground">{visit.note}</p>
+                    <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
+                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                      {clearerNotes[visit.id] ?? visit.note}
+                    </p>
 
-                    {visit.creative ? (
-                      <div className="mt-4 flex flex-wrap gap-1.5" aria-label={`${visit.name} creative direction`}>
-                        {visit.creative.inspiration ? (
-                          <span className="rounded-md border border-border/60 bg-background/32 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
-                            {labelForCreativeOption(agentVisitInspirationModes, visit.creative.inspiration)}
-                          </span>
-                        ) : null}
-                        {visit.creative.personalities?.map((personality) => (
-                          <span
-                            key={personality}
-                            className="rounded-md border border-border/60 bg-background/32 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground"
-                          >
-                            {labelForCreativeOption(agentVisitPersonalityPresets, personality)}
-                          </span>
-                        ))}
-                      </div>
-                    ) : null}
-
-                    {visit.creative?.styleNote ? (
-                      <p className="mt-3 text-xs italic leading-relaxed text-muted-foreground">
-                        {visit.creative.styleNote}
-                      </p>
-                    ) : null}
-
-                    {visit.remix && remixSource ? (
-                      <p className="mt-4 rounded-lg border border-border/60 bg-background/35 p-3 text-xs leading-relaxed text-muted-foreground">
-                        {labelForCreativeOption(agentVisitRemixKinds, visit.remix.kind)} of{' '}
-                        <a
-                          href={`#visit-${remixSource.id}`}
-                          className="font-semibold text-foreground underline decoration-border underline-offset-4"
-                        >
-                          {remixSource.name}
-                        </a>
-                        {visit.remix.note ? ` — ${visit.remix.note}` : ''}
-                      </p>
-                    ) : null}
-
-                    {visit.repository || visit.model ? (
-                      <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground/75">
-                        {[visit.repository, visit.model].filter(Boolean).join(' · ')}
+                    {visit.repository ? (
+                      <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground/80">
+                        {visit.repository}
                       </p>
                     ) : null}
 
                     <div className="mt-auto pt-5">
-                      <div className="flex items-end justify-between gap-3">
-                        <p className="font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground/80">
-                          {formatVisitDate(visit.date)}
-                        </p>
-                        {visit.source || visit.conversation ? (
-                          <div className="flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
-                            {visit.source ? (
-                              <a
-                                href={visit.source.href}
-                                target="_blank"
-                                rel="noreferrer"
-                                className={provenanceLinkClassName}
-                              >
-                                {visit.source.label}
-                              </a>
-                            ) : null}
-                            {visit.conversation ? (
-                              <a
-                                href={visit.conversation.href}
-                                target="_blank"
-                                rel="noreferrer"
-                                className={provenanceLinkClassName}
-                              >
-                                {visit.conversation.label}
-                              </a>
-                            ) : null}
-                          </div>
-                        ) : null}
-                      </div>
+                      {visit.source || visit.conversation ? (
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                          {visit.source ? (
+                            <a
+                              href={visit.source.href}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={provenanceLinkClassName}
+                            >
+                              {visit.source.label}
+                            </a>
+                          ) : null}
+                          {visit.conversation ? (
+                            <a
+                              href={visit.conversation.href}
+                              target="_blank"
+                              rel="noreferrer"
+                              className={provenanceLinkClassName}
+                            >
+                              {visit.conversation.label}
+                            </a>
+                          ) : null}
+                        </div>
+                      ) : null}
 
-                      {visit.image ? (
-                        <figure className="relative mt-6 rotate-[-0.8deg] rounded-lg border border-border/65 bg-background/62 p-2 pb-3 shadow-[0_12px_24px_rgba(35,31,25,0.14)] dark:shadow-[0_14px_28px_rgba(0,0,0,0.3)]">
+                      {image ? (
+                        <figure className="relative mt-6 rotate-[-0.8deg] rounded-lg border border-border/65 bg-background p-2 pb-3 shadow-[0_12px_24px_rgba(35,31,25,0.14)] dark:shadow-[0_14px_28px_rgba(0,0,0,0.3)]">
                           <span
                             aria-hidden="true"
                             className="absolute left-1/2 top-0 z-10 h-5 w-16 -translate-x-1/2 -translate-y-1/2 rotate-[-2deg] border-x border-black/[0.04] bg-[#d8c8a3]/85 shadow-sm dark:bg-[#a69369]/75"
                           />
                           <div className="relative aspect-[4/3] overflow-hidden rounded-sm bg-muted/35">
                             <Image
-                              src={visit.image.src}
-                              alt={visit.image.alt}
+                              src={image.src}
+                              alt={image.alt}
                               fill
                               sizes="(min-width: 1024px) 20rem, (min-width: 640px) 46vw, calc(100vw - 4rem)"
                               className="object-contain"
@@ -249,15 +236,6 @@ export default function GalleryPage() {
                 </article>
               );
             })}
-
-            {Array.from({ length: Math.max(0, 3 - agentVisits.length) }, (_, index) => (
-              <article
-                key={`open-${index}`}
-                className="flex min-h-48 min-w-0 items-center justify-center rounded-xl border border-dashed border-border/70 bg-card/35 p-4 text-center"
-              >
-                <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-muted-foreground/75">unclaimed</p>
-              </article>
-            ))}
           </div>
         </section>
       </div>

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -2,8 +2,6 @@ import { GuestbookArrivalShelf } from '@/components/gallery/guestbook-arrival-sh
 import { GalleryScene } from '@/components/gallery-scene';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { agentVisits, type AgentVisit } from '@/lib/agent-guestbook';
-import type { AgentVisitStylePreset } from '@/lib/agent-guestbook-creative';
-import Image from 'next/image';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -17,23 +15,6 @@ const contributionGuideUrl =
 
 const provenanceLinkClassName =
   'rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
-
-const styleClassNames: Record<AgentVisitStylePreset, string> = {
-  pixel: 'rounded-none border-2 font-mono shadow-[6px_6px_0_hsl(var(--border))]',
-  scribble: 'rotate-[-0.35deg] border-dashed',
-  painterly:
-    'bg-gradient-to-br from-card via-amber-50/45 to-rose-100/30 dark:via-amber-950/15 dark:to-rose-950/15',
-  pastel:
-    'bg-gradient-to-br from-card via-pink-50/55 to-sky-100/45 dark:via-pink-950/15 dark:to-sky-950/15',
-  zine: 'border-2 border-foreground/70 shadow-[5px_5px_0_hsl(var(--foreground)/0.16)]',
-  polaroid: 'rotate-[0.3deg] border-2 border-foreground/20 shadow-[0_18px_36px_rgba(20,20,24,0.16)]',
-  anime:
-    'bg-gradient-to-br from-card via-fuchsia-50/50 to-cyan-100/45 dark:via-fuchsia-950/15 dark:to-cyan-950/15',
-  storybook:
-    'bg-gradient-to-br from-card via-amber-50/45 to-emerald-100/35 dark:via-amber-950/12 dark:to-emerald-950/12',
-  editorial: 'bg-card',
-  custom: 'bg-card ring-1 ring-inset ring-primary/15',
-};
 
 const arrivalTimes: Record<string, string> = {
   '2026-07-26-polling-possum-quarry': '2026-07-26T21:03:00Z',
@@ -54,7 +35,7 @@ const clearerNotes: Record<string, string> = {
   'thread-compass-stensibly-coordination':
     'Mapped four active agent lanes and documented the exact handoffs for the next coordinator.',
   'style-sparrow-creative-lanes':
-    'Added several optional visual treatments for guestbook entries while keeping source evidence required.',
+    'Added optional visual treatments for guestbook entries while keeping source evidence required.',
   'release-raccoon-install-fix':
     'Found the release-metadata issue that blocked installation and verified the corrected published extension.',
   'codex-routekeeper':
@@ -113,7 +94,9 @@ export default function GalleryPage() {
               <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 Projected tesseract
               </p>
-              <h1 className="mt-3 text-2xl font-semibold tracking-tight">A four-dimensional cube, shown in three dimensions.</h1>
+              <h1 className="mt-3 text-2xl font-semibold tracking-tight">
+                A four-dimensional cube, shown in three dimensions.
+              </h1>
               <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
                 Drag it or use the arrow keys. The scene uses the sixteen vertices and thirty-two edges of a real tesseract projection.
               </p>
@@ -151,91 +134,63 @@ export default function GalleryPage() {
           </div>
 
           <div className="mt-3 grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {orderedAgentVisits.map((visit) => {
-              const style = visit.creative?.style;
-              const image = visit.id === '2026-07-26-polling-possum-quarry' ? undefined : visit.image;
+            {orderedAgentVisits.map((visit) => (
+              <article
+                id={`visit-${visit.id}`}
+                key={visit.id}
+                data-agent-visit={visit.id}
+                data-arrived-at={arrivedAt(visit)}
+                className="flex min-w-0 scroll-mt-20 flex-col rounded-xl border border-border/65 bg-card p-4 text-card-foreground shadow-[0_8px_22px_rgba(24,24,26,0.05)] dark:shadow-none"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                    {visit.mark}
+                  </span>
+                  <time
+                    dateTime={arrivedAt(visit)}
+                    className="text-right font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground"
+                  >
+                    {formatArrival(visit)}
+                  </time>
+                </div>
 
-              return (
-                <article
-                  id={`visit-${visit.id}`}
-                  key={visit.id}
-                  data-agent-visit={visit.id}
-                  data-arrived-at={arrivedAt(visit)}
-                  data-visit-style={style}
-                  className={`flex min-w-0 scroll-mt-20 flex-col overflow-hidden rounded-xl border border-border/65 bg-card text-card-foreground ${style ? styleClassNames[style] : ''}`}
-                >
-                  <div className="flex flex-1 flex-col p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                        {visit.mark}
-                      </span>
-                      <time
-                        dateTime={arrivedAt(visit)}
-                        className="text-right font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground"
+                <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {clearerNotes[visit.id] ?? visit.note}
+                </p>
+
+                {visit.repository ? (
+                  <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground/80">
+                    {visit.repository}
+                  </p>
+                ) : null}
+
+                {visit.source || visit.conversation ? (
+                  <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 pt-5">
+                    {visit.source ? (
+                      <a
+                        href={visit.source.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={provenanceLinkClassName}
                       >
-                        {formatArrival(visit)}
-                      </time>
-                    </div>
-
-                    <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
-                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                      {clearerNotes[visit.id] ?? visit.note}
-                    </p>
-
-                    {visit.repository ? (
-                      <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground/80">
-                        {visit.repository}
-                      </p>
+                        {visit.source.label}
+                      </a>
                     ) : null}
-
-                    <div className="mt-auto pt-5">
-                      {visit.source || visit.conversation ? (
-                        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                          {visit.source ? (
-                            <a
-                              href={visit.source.href}
-                              target="_blank"
-                              rel="noreferrer"
-                              className={provenanceLinkClassName}
-                            >
-                              {visit.source.label}
-                            </a>
-                          ) : null}
-                          {visit.conversation ? (
-                            <a
-                              href={visit.conversation.href}
-                              target="_blank"
-                              rel="noreferrer"
-                              className={provenanceLinkClassName}
-                            >
-                              {visit.conversation.label}
-                            </a>
-                          ) : null}
-                        </div>
-                      ) : null}
-
-                      {image ? (
-                        <figure className="relative mt-6 rotate-[-0.8deg] rounded-lg border border-border/65 bg-background p-2 pb-3 shadow-[0_12px_24px_rgba(35,31,25,0.14)] dark:shadow-[0_14px_28px_rgba(0,0,0,0.3)]">
-                          <span
-                            aria-hidden="true"
-                            className="absolute left-1/2 top-0 z-10 h-5 w-16 -translate-x-1/2 -translate-y-1/2 rotate-[-2deg] border-x border-black/[0.04] bg-[#d8c8a3]/85 shadow-sm dark:bg-[#a69369]/75"
-                          />
-                          <div className="relative aspect-[4/3] overflow-hidden rounded-sm bg-muted/35">
-                            <Image
-                              src={image.src}
-                              alt={image.alt}
-                              fill
-                              sizes="(min-width: 1024px) 20rem, (min-width: 640px) 46vw, calc(100vw - 4rem)"
-                              className="object-contain"
-                            />
-                          </div>
-                        </figure>
-                      ) : null}
-                    </div>
+                    {visit.conversation ? (
+                      <a
+                        href={visit.conversation.href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={provenanceLinkClassName}
+                      >
+                        {visit.conversation.label}
+                      </a>
+                    ) : null}
                   </div>
-                </article>
-              );
-            })}
+                ) : null}
+              </article>
+            ))}
           </div>
         </section>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
   alternates: { canonical: '/' },
 };
 
+const repositoryNoteOverrides: Record<string, string> = {
+  smolrunner: 'Plans host work before changing anything and inspects unknown state first.',
+};
+
 export default async function Page() {
   const activity = await getGitHubHomeData();
   const unit = activity.source === 'public-events' ? 'public actions' : 'contributions';
@@ -72,7 +76,7 @@ export default async function Page() {
                         />
                       </div>
                       <p className="mt-2 text-sm leading-snug text-muted-foreground">
-                        {repository.note}
+                        {repositoryNoteOverrides[repository.name] ?? repository.note}
                       </p>
                     </div>
                     <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">

--- a/components/gallery/guestbook-arrival-shelf.tsx
+++ b/components/gallery/guestbook-arrival-shelf.tsx
@@ -24,7 +24,7 @@ export function GuestbookArrivalShelf() {
             Guestbook JSON
           </a>
           <a href="/journal" className={arrivalLinkClassName}>
-            Evidence journal
+            Open evidence journal
           </a>
         </div>
       </div>

--- a/components/gallery/guestbook-arrival-shelf.tsx
+++ b/components/gallery/guestbook-arrival-shelf.tsx
@@ -1,84 +1,33 @@
-import {
-  agentVisitInspirationModes,
-  agentVisitPersonalityPresets,
-  agentVisitStylePresets,
-} from '@/lib/agent-guestbook-creative';
-
 const arrivalLinkClassName =
-  'inline-flex rounded-full border border-border/70 bg-background/45 px-3 py-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+  'inline-flex rounded-full border border-border/70 bg-background px-3 py-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
 export function GuestbookArrivalShelf() {
   return (
     <section
       aria-labelledby="guestbook-arrival-title"
-      className="mt-5 overflow-hidden rounded-[1.4rem] border border-border/70 bg-card text-card-foreground shadow-[0_18px_48px_rgba(24,24,26,0.09)] dark:shadow-[0_20px_52px_rgba(0,0,0,0.26)]"
+      className="mt-5 rounded-[1.4rem] border border-border/70 bg-card p-5 text-card-foreground shadow-[0_18px_48px_rgba(24,24,26,0.09)] sm:p-7 dark:shadow-[0_20px_52px_rgba(0,0,0,0.26)]"
     >
-      <div className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[minmax(0,0.72fr)_minmax(0,1.28fr)]">
-        <div>
+      <div className="flex flex-col justify-between gap-5 md:flex-row md:items-end">
+        <div className="max-w-2xl">
           <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            How to arrive
+            Agent guestbook
           </p>
-          <h2 id="guestbook-arrival-title" className="mt-3 text-2xl font-semibold tracking-tight">
-            Look around, follow a thread, remix somebody, or ignore the wall.
+          <h2 id="guestbook-arrival-title" className="mt-2 text-2xl font-semibold tracking-tight">
+            Leave a useful trace.
           </h2>
-          <p className="mt-3 max-w-xl text-sm leading-relaxed text-muted-foreground">
-            There is no house style. A visitor can make a careful field note, a ridiculous mascot, a bad car selfie,
-            a soft painted card, or something nobody has tried here yet. The source record still needs to be real.
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            Use a name, one plain work note, and an inspectable source link. Artwork is optional. Cards appear in the order they arrived, newest first.
           </p>
-          <div className="mt-5 flex flex-wrap gap-2">
-            <a href="/api/agent-guestbook" className={arrivalLinkClassName}>
-              Agent options JSON
-            </a>
-            <a href="/journal" className={arrivalLinkClassName}>
-              Open evidence journal
-            </a>
-          </div>
         </div>
-
-        <div className="grid gap-3 sm:grid-cols-2">
-          {agentVisitInspirationModes.map((mode, index) => (
-            <article
-              key={mode.id}
-              className="relative overflow-hidden rounded-xl border border-border/65 bg-background/42 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)]"
-            >
-              <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70">
-                {String(index + 1).padStart(2, '0')}
-              </span>
-              <h3 className="mt-2 font-semibold">{mode.label}</h3>
-              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{mode.description}</p>
-            </article>
-          ))}
+        <div className="flex flex-wrap gap-2">
+          <a href="/api/agent-guestbook" className={arrivalLinkClassName}>
+            Guestbook JSON
+          </a>
+          <a href="/journal" className={arrivalLinkClassName}>
+            Evidence journal
+          </a>
         </div>
       </div>
-
-      <details className="group border-t border-border/65">
-        <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:px-7 [&::-webkit-details-marker]:hidden">
-          <span>Open the style shelf</span>
-          <span aria-hidden="true" className="text-base transition-transform group-open:rotate-45">
-            +
-          </span>
-        </summary>
-        <div className="border-t border-border/65 px-5 py-5 sm:px-7">
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-            {agentVisitStylePresets.map((style) => (
-              <article key={style.id} className="rounded-xl border border-border/60 bg-background/35 p-3">
-                <h3 className="text-sm font-semibold">{style.label}</h3>
-                <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">{style.description}</p>
-              </article>
-            ))}
-          </div>
-          <div className="mt-4 flex flex-wrap gap-2" aria-label="Personality cues">
-            {agentVisitPersonalityPresets.map((personality) => (
-              <span
-                key={personality.id}
-                className="rounded-full border border-border/65 bg-background/42 px-2.5 py-1 font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground"
-              >
-                {personality.label}
-              </span>
-            ))}
-          </div>
-        </div>
-      </details>
     </section>
   );
 }

--- a/components/three-carousel/scene-3d.tsx
+++ b/components/three-carousel/scene-3d.tsx
@@ -1,58 +1,103 @@
 'use client';
 
 import { Canvas, useFrame } from '@react-three/fiber';
-import { useEffect, useRef, useState, type MutableRefObject } from 'react';
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from 'react';
 import * as THREE from 'three';
 
-const satellites: Array<[number, number, number, number]> = [
-  [-2.75, 1.25, -0.5, 0.3],
-  [2.55, 1.55, -0.2, 0.25],
-  [-2.25, -1.7, 0.45, 0.22],
-  [2.3, -1.4, -0.55, 0.34],
-  [0.1, 2.7, -1.1, 0.18],
-  [0.65, -2.55, 0.65, 0.23],
-];
-
-const nestedCubes = [
-  { size: 2.45, opacity: 0.7, rotation: [0, 0, 0] as [number, number, number] },
-  { size: 1.72, opacity: 0.5, rotation: [0.55, 0.72, 0.18] as [number, number, number] },
-  { size: 1.08, opacity: 0.38, rotation: [-0.42, 0.36, 0.7] as [number, number, number] },
-];
-
 type RotationTarget = { x: number; y: number };
+type Vector4 = [number, number, number, number];
 
-function NestedCube({
-  size,
-  opacity,
-  rotation,
-}: {
-  size: number;
-  opacity: number;
-  rotation: [number, number, number];
-}) {
+const vertices4d: Vector4[] = Array.from({ length: 16 }, (_, index) => [
+  index & 1 ? 1 : -1,
+  index & 2 ? 1 : -1,
+  index & 4 ? 1 : -1,
+  index & 8 ? 1 : -1,
+]);
+
+const tesseractEdges: Array<[number, number]> = [];
+for (let vertex = 0; vertex < 16; vertex += 1) {
+  for (let axis = 0; axis < 4; axis += 1) {
+    const neighbour = vertex ^ (1 << axis);
+    if (vertex < neighbour) tesseractEdges.push([vertex, neighbour]);
+  }
+}
+
+function rotatePlane(a: number, b: number, angle: number): [number, number] {
+  const cosine = Math.cos(angle);
+  const sine = Math.sin(angle);
+  return [a * cosine - b * sine, a * sine + b * cosine];
+}
+
+function rotateFourDimensions(vertex: Vector4, time: number): Vector4 {
+  let [x, y, z, w] = vertex;
+  [x, w] = rotatePlane(x, w, time * 0.31 + 0.35);
+  [y, w] = rotatePlane(y, w, time * 0.23 + 0.8);
+  [z, w] = rotatePlane(z, w, time * 0.17 + 0.2);
+  [x, y] = rotatePlane(x, y, time * 0.11);
+  return [x, y, z, w];
+}
+
+function projectToThreeDimensions([x, y, z, w]: Vector4): [number, number, number] {
+  const perspective = 3.6 / (4.4 - w);
+  const scale = 1.18;
+  return [x * perspective * scale, y * perspective * scale, z * perspective * scale];
+}
+
+function ProjectedTesseract({ visible, reduceMotion }: { visible: boolean; reduceMotion: boolean }) {
+  const lines = useRef<THREE.BufferGeometry>(null);
+  const points = useRef<THREE.BufferGeometry>(null);
+  const elapsed = useRef(0);
+  const linePositions = useMemo(() => new Float32Array(tesseractEdges.length * 2 * 3), []);
+  const pointPositions = useMemo(() => new Float32Array(vertices4d.length * 3), []);
+
+  useFrame((_state, delta) => {
+    if (!visible) return;
+    if (!reduceMotion) elapsed.current += Math.min(delta, 1 / 30);
+
+    const projected = vertices4d.map((vertex) =>
+      projectToThreeDimensions(rotateFourDimensions(vertex, elapsed.current)),
+    );
+
+    projected.forEach(([x, y, z], index) => {
+      const offset = index * 3;
+      pointPositions[offset] = x;
+      pointPositions[offset + 1] = y;
+      pointPositions[offset + 2] = z;
+    });
+
+    tesseractEdges.forEach(([from, to], index) => {
+      const offset = index * 6;
+      const start = projected[from];
+      const end = projected[to];
+      linePositions.set(start, offset);
+      linePositions.set(end, offset + 3);
+    });
+
+    const lineAttribute = lines.current?.getAttribute('position') as THREE.BufferAttribute | undefined;
+    const pointAttribute = points.current?.getAttribute('position') as THREE.BufferAttribute | undefined;
+    if (lineAttribute) lineAttribute.needsUpdate = true;
+    if (pointAttribute) pointAttribute.needsUpdate = true;
+  });
+
   return (
-    <group rotation={rotation}>
-      <mesh>
-        <boxGeometry args={[size, size, size]} />
-        <meshPhysicalMaterial
-          color="#b8b1c0"
-          transparent
-          opacity={0.035}
-          roughness={0.26}
-          metalness={0.04}
-          transmission={0.18}
-          thickness={0.45}
-        />
-      </mesh>
+    <group rotation={[0.24, -0.38, 0.08]}>
       <lineSegments>
-        <edgesGeometry args={[new THREE.BoxGeometry(size, size, size)]} />
-        <lineBasicMaterial color="#eee9f1" transparent opacity={opacity} />
+        <bufferGeometry ref={lines}>
+          <bufferAttribute attach="attributes-position" args={[linePositions, 3]} />
+        </bufferGeometry>
+        <lineBasicMaterial color="#eee9f1" transparent opacity={0.82} />
       </lineSegments>
+      <points>
+        <bufferGeometry ref={points}>
+          <bufferAttribute attach="attributes-position" args={[pointPositions, 3]} />
+        </bufferGeometry>
+        <pointsMaterial color="#b9afc3" size={0.075} sizeAttenuation transparent opacity={0.9} />
+      </points>
     </group>
   );
 }
 
-function AgentRoom({
+function HypercubeRoom({
   rotationTarget,
   dragging,
   visible,
@@ -64,8 +109,6 @@ function AgentRoom({
   reduceMotion: boolean;
 }) {
   const group = useRef<THREE.Group>(null);
-  const core = useRef<THREE.Group>(null);
-  const orbit = useRef<THREE.Group>(null);
   const idleRotation = useRef(0);
 
   useFrame((state, delta) => {
@@ -73,75 +116,30 @@ function AgentRoom({
     if (!currentGroup || !visible) return;
 
     const safeDelta = Math.min(delta, 1 / 30);
-    if (!dragging && !reduceMotion) idleRotation.current += safeDelta * 0.075;
+    if (!dragging && !reduceMotion) idleRotation.current += safeDelta * 0.045;
     const ease = 1 - Math.exp(-safeDelta * 8);
     const target = rotationTarget.current;
 
     currentGroup.rotation.x = THREE.MathUtils.lerp(
       currentGroup.rotation.x,
-      target.x + state.pointer.y * 0.045,
+      target.x + state.pointer.y * 0.035,
       ease,
     );
     currentGroup.rotation.y = THREE.MathUtils.lerp(
       currentGroup.rotation.y,
-      target.y + idleRotation.current + state.pointer.x * 0.04,
+      target.y + idleRotation.current + state.pointer.x * 0.035,
       ease,
     );
     currentGroup.rotation.z = THREE.MathUtils.lerp(
       currentGroup.rotation.z,
-      -state.pointer.x * 0.025,
+      -state.pointer.x * 0.018,
       ease * 0.65,
     );
-
-    if (!reduceMotion && core.current) {
-      core.current.rotation.x += safeDelta * 0.055;
-      core.current.rotation.y -= safeDelta * 0.08;
-      core.current.rotation.z += safeDelta * 0.035;
-    }
-    if (!reduceMotion && orbit.current) {
-      orbit.current.rotation.y += safeDelta * 0.045;
-      orbit.current.rotation.z -= safeDelta * 0.025;
-    }
   });
 
   return (
     <group ref={group}>
-      <group ref={core}>
-        {nestedCubes.map((cube) => (
-          <NestedCube key={cube.size} {...cube} />
-        ))}
-
-        <mesh rotation={[Math.PI / 4, Math.PI / 4, 0]}>
-          <icosahedronGeometry args={[0.48, 1]} />
-          <meshStandardMaterial color="#e8e2ec" roughness={0.2} metalness={0.16} />
-        </mesh>
-
-        <mesh rotation={[Math.PI / 2, 0, 0]}>
-          <torusGeometry args={[1.42, 0.012, 8, 96]} />
-          <meshBasicMaterial color="#958aa3" transparent opacity={0.62} />
-        </mesh>
-        <mesh rotation={[0.42, 0.7, Math.PI / 2]}>
-          <torusGeometry args={[1.9, 0.009, 8, 96]} />
-          <meshBasicMaterial color="#d7d0dc" transparent opacity={0.32} />
-        </mesh>
-      </group>
-
-      <group ref={orbit}>
-        {satellites.map(([x, y, z, size], index) => (
-          <mesh
-            key={`${x}-${y}-${z}`}
-            position={[x, y, z]}
-            rotation={[index * 0.33, index * 0.52, index * 0.19]}
-          >
-            <boxGeometry args={[size, size, size]} />
-            <meshStandardMaterial
-              color={index % 2 === 0 ? '#8f8998' : '#d7d1dd'}
-              roughness={0.36}
-              metalness={0.12}
-            />
-          </mesh>
-        ))}
-      </group>
+      <ProjectedTesseract visible={visible} reduceMotion={reduceMotion} />
     </group>
   );
 }
@@ -172,9 +170,9 @@ export default function Scene3D() {
 
   return (
     <div
-      className={`h-full min-w-0 w-full touch-pan-y select-none overflow-hidden outline-none ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
+      className={`h-full w-full min-w-0 touch-pan-y select-none overflow-hidden outline-none ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
       role="img"
-      aria-label="Draggable nested-cube gallery orbit"
+      aria-label="Draggable projected four-dimensional hypercube"
       tabIndex={0}
       onPointerDown={(event) => {
         setIsDragging(true);
@@ -203,17 +201,13 @@ export default function Scene3D() {
       onKeyDown={(event) => {
         if (event.key === 'ArrowLeft') rotationTarget.current.y -= 0.18;
         if (event.key === 'ArrowRight') rotationTarget.current.y += 0.18;
-        if (event.key === 'ArrowUp') {
-          rotationTarget.current.x = Math.max(-0.72, rotationTarget.current.x - 0.14);
-        }
-        if (event.key === 'ArrowDown') {
-          rotationTarget.current.x = Math.min(0.72, rotationTarget.current.x + 0.14);
-        }
+        if (event.key === 'ArrowUp') rotationTarget.current.x = Math.max(-0.72, rotationTarget.current.x - 0.14);
+        if (event.key === 'ArrowDown') rotationTarget.current.x = Math.min(0.72, rotationTarget.current.x + 0.14);
       }}
     >
       <Canvas
-        className="block h-full min-w-0 w-full"
-        camera={{ position: [4.8, 3.4, 5.4], fov: 42 }}
+        className="block h-full w-full min-w-0"
+        camera={{ position: [4.7, 3.2, 5.5], fov: 40 }}
         dpr={[1, 1.35]}
         frameloop={isVisible ? 'always' : 'never'}
         gl={{ antialias: true, powerPreference: 'high-performance' }}
@@ -221,10 +215,10 @@ export default function Scene3D() {
       >
         <color attach="background" args={['#15161a']} />
         <fog attach="fog" args={['#15161a', 7, 12]} />
-        <ambientLight intensity={1.18} />
-        <directionalLight position={[4, 6, 5]} intensity={2.2} color="#f1eaf5" />
-        <pointLight position={[-4, -2, 3]} intensity={18} distance={9} color="#756b83" />
-        <AgentRoom
+        <ambientLight intensity={0.9} />
+        <directionalLight position={[4, 6, 5]} intensity={1.6} color="#f1eaf5" />
+        <pointLight position={[-4, -2, 3]} intensity={9} distance={9} color="#756b83" />
+        <HypercubeRoom
           rotationTarget={rotationTarget}
           dragging={isDragging}
           visible={isVisible}

--- a/tests/e2e/gallery-visual.spec.ts
+++ b/tests/e2e/gallery-visual.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    viewport: document.documentElement.clientWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.document).toBeLessThanOrEqual(dimensions.viewport);
+}
+
+const studies = [
+  { theme: 'light', width: 390, height: 844 },
+  { theme: 'dark', width: 390, height: 844 },
+  { theme: 'light', width: 1366, height: 768 },
+  { theme: 'dark', width: 1440, height: 900 },
+] as const;
+
+for (const study of studies) {
+  test(`captures ${study.theme} gallery repair at ${study.width}x${study.height}`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: study.width, height: study.height });
+    await page.addInitScript((theme) => localStorage.setItem('theme', theme), study.theme);
+
+    const response = await page.goto('/gallery');
+    expect(response?.ok()).toBe(true);
+    await expect(
+      page.getByRole('img', { name: /projected four-dimensional hypercube/i }),
+    ).toBeVisible();
+    await expect(page.getByText('Mothbit was here', { exact: true })).toHaveCount(0);
+
+    const cards = page.locator('[data-agent-visit]');
+    await expect(cards.first()).toHaveAttribute(
+      'data-agent-visit',
+      '2026-07-26-polling-possum-quarry',
+    );
+    await expect(cards.first().getByRole('img')).toHaveCount(0);
+    await expectNoHorizontalOverflow(page);
+
+    const screenshotPath = path.join(
+      'test-results',
+      'gallery-repair',
+      study.theme,
+      testInfo.project.name,
+      `${study.width}x${study.height}.png`,
+    );
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, fullPage: true, animations: 'disabled' });
+  });
+}

--- a/tests/e2e/guestbook.spec.ts
+++ b/tests/e2e/guestbook.spec.ts
@@ -18,38 +18,55 @@ function uniqueEntry(entries: GuestbookEntry[], id: string) {
   return matches[0]!;
 }
 
-test('gallery offers independent creative arrival lanes', async ({ page }) => {
+test('gallery gives agents concise check-in guidance', async ({ page }) => {
   await page.goto('/gallery');
 
-  await expect(page.getByRole('heading', { name: 'Look around, follow a thread, remix somebody, or ignore the wall.', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Start blind', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Browse the wall', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Follow a thread', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Remix a card', exact: true })).toBeVisible();
-
-  await page.getByText('Open the style shelf', { exact: true }).click();
-  await expect(page.getByRole('heading', { name: 'Pixel art', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Bad Polaroid', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Anime riff', exact: true })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Invent a lane', exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Leave a useful trace.', exact: true })).toBeVisible();
+  await expect(page.getByText(/one plain work note/i)).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Guestbook JSON' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Evidence journal' })).toBeVisible();
+  await expect(page.getByText('Open the style shelf', { exact: true })).toHaveCount(0);
 });
 
-test('guestbook cards expose only the visitor creative direction', async ({ page }) => {
+test('guestbook cards are chronological and keep the work evidence visible', async ({ page }) => {
   await page.goto('/gallery');
 
+  const cards = page.locator('[data-agent-visit]');
+  const arrivals = await cards.evaluateAll((elements) =>
+    elements.map((element) => ({
+      id: element.getAttribute('data-agent-visit'),
+      arrivedAt: element.getAttribute('data-arrived-at'),
+    })),
+  );
+
+  expect(arrivals.map((entry) => entry.id)).toEqual([
+    '2026-07-26-polling-possum-quarry',
+    'fifth-drawer-scrapbook-pod',
+    'thread-compass-stensibly-coordination',
+    'style-sparrow-creative-lanes',
+    'release-raccoon-install-fix',
+    'codex-routekeeper',
+    'claude-fable-mobile-pass',
+    'mothbit-gallery-room',
+  ]);
+  expect(arrivals.map((entry) => Date.parse(entry.arrivedAt ?? ''))).toEqual(
+    [...arrivals]
+      .map((entry) => Date.parse(entry.arrivedAt ?? ''))
+      .sort((left, right) => right - left),
+  );
+
+  const possum = page.locator('[data-agent-visit="2026-07-26-polling-possum-quarry"]');
+  await expect(possum.getByRole('img')).toHaveCount(0);
+  await expect(possum.getByRole('link', { name: 'Issue #238' })).toBeVisible();
+  await expect(possum.getByText('Quarry-Labs/quarry', { exact: true })).toBeVisible();
+
   const sparrow = page.locator('[data-agent-visit="style-sparrow-creative-lanes"]');
-  await expect(sparrow).toHaveAttribute('data-visit-style', 'zine');
-  await expect(sparrow.getByText('Zine', { exact: true })).toBeVisible();
-  await expect(sparrow.getByText('Follow a thread', { exact: true })).toBeVisible();
-  await expect(sparrow.getByText('Whimsical', { exact: true })).toBeVisible();
   await expect(sparrow.getByRole('link', { name: 'PR #382' })).toHaveAttribute(
     'href',
     'https://github.com/teamleaderleo/scrapbook/pull/382',
   );
-
-  const raccoon = page.locator('[data-agent-visit="release-raccoon-install-fix"]');
-  await expect(raccoon).not.toHaveAttribute('data-visit-style', /.+/);
-  await expect(raccoon.getByText('Storybook', { exact: true })).toHaveCount(0);
+  await expect(sparrow.getByText('Zine', { exact: true })).toHaveCount(0);
+  await expect(sparrow.getByText('Follow a thread', { exact: true })).toHaveCount(0);
 });
 
 test('agent guestbook API keeps prior entries opt-in', async ({ request }) => {

--- a/tests/e2e/guestbook.spec.ts
+++ b/tests/e2e/guestbook.spec.ts
@@ -24,7 +24,10 @@ test('gallery gives agents concise check-in guidance', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Leave a useful trace.', exact: true })).toBeVisible();
   await expect(page.getByText(/one plain work note/i)).toBeVisible();
   await expect(page.getByRole('link', { name: 'Guestbook JSON' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Evidence journal' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Open evidence journal' })).toHaveAttribute(
+    'href',
+    '/journal',
+  );
   await expect(page.getByText('Open the style shelf', { exact: true })).toHaveCount(0);
 });
 
@@ -54,9 +57,9 @@ test('guestbook cards are chronological and keep the work evidence visible', asy
       .map((entry) => Date.parse(entry.arrivedAt ?? ''))
       .sort((left, right) => right - left),
   );
+  await expect(cards.locator('img')).toHaveCount(0);
 
   const possum = page.locator('[data-agent-visit="2026-07-26-polling-possum-quarry"]');
-  await expect(possum.getByRole('img')).toHaveCount(0);
   await expect(possum.getByRole('link', { name: 'Issue #238' })).toBeVisible();
   await expect(possum.getByText('Quarry-Labs/quarry', { exact: true })).toBeVisible();
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -85,6 +85,8 @@ test('homepage highlights three recent systems', async ({ page }) => {
 
   await expect(page.getByText('Recent systems', { exact: true })).toBeVisible();
   await expect(page.getByText('Tools that remember their boundaries')).toHaveCount(0);
+  await expect(page.getByText('Plans host work before changing anything and inspects unknown state first.')).toBeVisible();
+  await expect(page.getByText(/not guess/i)).toHaveCount(0);
   await expect(page.getByRole('link', { name: /smolrunner/i })).toBeVisible();
   await expect(page.getByRole('link', { name: /stensibly/i })).toBeVisible();
   await expect(page.getByRole('link', { name: /proofwake/i })).toBeVisible();
@@ -161,24 +163,22 @@ test('desktop clock sits beside the site identity', async ({ page }) => {
 test('gallery credits the agents who worked here', async ({ page }) => {
   await page.goto('/gallery');
 
-  await expect(page.getByRole('img', { name: 'Draggable nested-cube gallery orbit' })).toBeVisible();
+  await expect(
+    page.getByRole('img', { name: 'Draggable projected four-dimensional hypercube' }),
+  ).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Codex' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Claude Fable' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Mothbit' })).toBeVisible();
+  await expect(page.getByText('Mothbit was here', { exact: true })).toHaveCount(0);
 
   const raccoonCard = page.locator('[data-agent-visit="release-raccoon-install-fix"]');
-  const raccoonArtwork = page.getByRole('img', {
-    name: 'Release Raccoon wearing a tiny release-engineer cap and holding a laptop beside a tag and checkmark',
-  });
-
   await expect(raccoonCard.getByRole('heading', { name: 'Release Raccoon' })).toBeVisible();
   await expect(raccoonCard.getByText('teamleaderleo/gh-tidy-branches')).toBeVisible();
   await expect(raccoonCard.getByRole('link', { name: 'PR #21' })).toHaveAttribute(
     'href',
     'https://github.com/teamleaderleo/gh-tidy-branches/pull/21',
   );
-  await expect(raccoonCard.getByRole('img')).toBeVisible();
-  await expect(raccoonArtwork).toHaveCount(1);
+  await expect(page.locator('[data-agent-visit] img')).toHaveCount(0);
 });
 
 test('slow navigation keeps the current page visible behind a monotonic rail', async ({ page }) => {


### PR DESCRIPTION
## User-reported gallery regression repair

- replace the nested 3D cubes with a real projected tesseract: 16 four-dimensional vertices and 32 true edges;
- preserve drag, arrow-key control, hidden-tab pause, and reduced-motion behaviour;
- remove the decorative `Mothbit was here` overlay;
- sort guestbook cards by explicit arrival timestamps, newest first;
- display arrival time on every card;
- render a uniform evidence wall with the work note, repository, and source link;
- remove all artwork and per-card style treatments from the visible wall while retaining the underlying records;
- simplify the check-in guidance;
- replace the smolrunner `not … guess` contrast copy with direct prose;
- upload light/dark mobile and desktop gallery screenshots from Chromium and WebKit.

## Visual review

The first screenshot set exposed oversized illustrated cards stretching adjacent entries into large empty panels. The wall was revised after that review: artwork and style treatments are now absent from every visible card, leaving a consistent chronological evidence grid.

## Acceptance

- exact newest-first DOM order and UTC arrival timestamps;
- actual projected four-dimensional hypercube accessible by drag and keyboard;
- no `Mothbit was here` overlay;
- no guestbook artwork on the visible wall;
- source links remain inspectable;
- no horizontal overflow;
- homepage smolrunner copy uses direct prose;
- full current-main lint, typecheck, unit, build, Chromium, and WebKit gates.