### PR TITLE
Refine the homepage paper grid and Scraplet nook

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,20 @@
+.paperGrid {
+  --home-grid-rgb: 73 65 54;
+  --home-grid-alpha: 0.036;
+
+  background-image:
+    linear-gradient(rgb(var(--home-grid-rgb) / var(--home-grid-alpha)) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(var(--home-grid-rgb) / var(--home-grid-alpha)) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+:global(.dark) .paperGrid {
+  --home-grid-rgb: 229 220 235;
+  --home-grid-alpha: 0.044;
+}
+
+@media (forced-colors: active) {
+  .paperGrid {
+    display: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import ViewportPageShell from '@/components/viewport-page-shell';
 import { getGitHubHomeData } from '@/lib/github-home';
 import { ArrowUpRight } from 'lucide-react';
 import type { Metadata } from 'next';
+import styles from './page.module.css';
 
 export const metadata: Metadata = {
   title: 'Leo · GitHub activity',
@@ -28,12 +29,8 @@ export default async function Page() {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-30 dark:opacity-12"
-        style={{
-          backgroundImage:
-            'linear-gradient(rgba(30,30,34,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.04) 1px, transparent 1px)',
-          backgroundSize: '28px 28px',
-        }}
+        className={`${styles.paperGrid} pointer-events-none absolute inset-0`}
+        data-home-paper-grid
       />
 
       <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-start px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">

--- a/components/home/scrapbook-pet.module.css
+++ b/components/home/scrapbook-pet.module.css
@@ -1,0 +1,84 @@
+.pet {
+  isolation: isolate;
+  background:
+    linear-gradient(132deg, hsl(var(--card) / 0.9), hsl(var(--accent) / 0.46)),
+    hsl(var(--card));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.3),
+    0 4px 12px rgb(57 47 35 / 0.07);
+}
+
+.pet::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background-image: repeating-linear-gradient(
+    104deg,
+    transparent 0 17px,
+    rgb(76 61 45 / 0.026) 17px 18px
+  );
+  pointer-events: none;
+}
+
+.pet > * {
+  position: relative;
+  z-index: 1;
+}
+
+.figure {
+  isolation: isolate;
+}
+
+.figure::before {
+  content: '';
+  position: absolute;
+  inset: 0.32rem 0.12rem 0.18rem 0.18rem;
+  z-index: 0;
+  border: 1px solid hsl(var(--border) / 0.42);
+  border-radius: 48% 52% 44% 56%;
+  background: hsl(var(--primary) / 0.58);
+  box-shadow: 0 2px 5px rgb(57 47 35 / 0.08);
+  transform: rotate(-4deg);
+}
+
+.art {
+  position: relative;
+  z-index: 1;
+}
+
+:global(.dark) .pet {
+  background:
+    linear-gradient(132deg, hsl(var(--card) / 0.94), hsl(var(--accent) / 0.54)),
+    hsl(var(--card));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    0 5px 14px rgb(0 0 0 / 0.2);
+}
+
+:global(.dark) .pet::after {
+  background-image: repeating-linear-gradient(
+    104deg,
+    transparent 0 17px,
+    rgb(235 227 239 / 0.022) 17px 18px
+  );
+}
+
+:global(.dark) .figure::before {
+  border-color: hsl(var(--border) / 0.5);
+  background: hsl(var(--primary) / 0.5);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 0.22);
+}
+
+@media (forced-colors: active) {
+  .pet,
+  .figure::before {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+  }
+
+  .pet::after {
+    display: none;
+  }
+}

--- a/components/home/scrapbook-pet.module.css
+++ b/components/home/scrapbook-pet.module.css
@@ -21,12 +21,8 @@
   pointer-events: none;
 }
 
-.pet > * {
-  position: relative;
-  z-index: 1;
-}
-
 .figure {
+  z-index: 1;
   isolation: isolate;
 }
 

--- a/components/home/scrapbook-pet.tsx
+++ b/components/home/scrapbook-pet.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from 'framer-motion';
 import { useState } from 'react';
+import styles from './scrapbook-pet.module.css';
 
 const petMessages = [
   'Scraplet rustles happily.',
@@ -14,7 +15,10 @@ export function ScrapbookPet({ activity, updating }: { activity: number; updatin
   const reduceMotion = useReducedMotion();
   const [pets, setPets] = useState(0);
   const status = updating ? 'sniffing' : activity > 0 ? 'awake' : 'napping';
-  const message = pets === 0 ? 'Scraplet is keeping an eye on the activity feed.' : petMessages[(pets - 1) % petMessages.length];
+  const message =
+    pets === 0
+      ? 'Scraplet is keeping an eye on the activity feed.'
+      : petMessages[(pets - 1) % petMessages.length];
 
   return (
     <motion.button
@@ -25,7 +29,7 @@ export function ScrapbookPet({ activity, updating }: { activity: number; updatin
       title={`Pet Scraplet · ${status}`}
       whileTap={reduceMotion ? undefined : { scale: 0.96 }}
       onClick={() => setPets((count) => count + 1)}
-      className="group/pet relative grid min-h-[3.35rem] w-full grid-cols-[2.65rem_minmax(0,1fr)] items-center gap-1 overflow-hidden rounded-xl border border-border/65 bg-background/45 px-1.5 py-1 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.22)] transition-[background-color,border-color,box-shadow] duration-150 hover:border-border hover:bg-background/70 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_5px_14px_rgba(35,31,26,0.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_6px_16px_rgba(0,0,0,0.24)]"
+      className={`${styles.pet} group/pet relative grid min-h-[3.35rem] w-full grid-cols-[2.65rem_minmax(0,1fr)] items-center gap-1 overflow-hidden rounded-xl border border-border/65 px-1.5 py-1 text-left transition-[background-color,border-color,box-shadow] duration-150 hover:border-border hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_5px_14px_rgba(35,31,26,0.08)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),0_6px_16px_rgba(0,0,0,0.24)]`}
     >
       <motion.span
         key={pets}
@@ -36,10 +40,13 @@ export function ScrapbookPet({ activity, updating }: { activity: number; updatin
             : { y: [0, -4, 0], rotate: [0, -2, 2, 0] }
         }
         transition={{ duration: 0.38, ease: [0.2, 0.75, 0.2, 1] }}
-        className="relative block h-9 w-11"
+        className={`${styles.figure} relative block h-9 w-11`}
         aria-hidden="true"
       >
-        <svg viewBox="0 0 72 48" className="h-full w-full overflow-visible">
+        <svg
+          viewBox="0 0 72 48"
+          className={`${styles.art} h-full w-full overflow-visible`}
+        >
           <motion.path
             d="M23 28 5 20l12 15 10-1Z"
             className="fill-[#b7adbf] stroke-[#4d4852] dark:fill-[#696270] dark:stroke-[#ded8e3]"

--- a/components/home/scrapbook-pet.tsx
+++ b/components/home/scrapbook-pet.tsx
@@ -102,7 +102,7 @@ export function ScrapbookPet({ activity, updating }: { activity: number; updatin
         </svg>
       </motion.span>
 
-      <span className="min-w-0 leading-none">
+      <span className="relative z-[1] min-w-0 leading-none">
         <span className="block truncate font-mono text-[8px] font-semibold uppercase tracking-[0.12em] text-foreground">
           Scraplet
         </span>

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -153,7 +153,7 @@ test('keeps hover surfaces planted and lets the visitor pet Scraplet', async ({ 
   await expect(pet).toHaveAttribute('data-pets', '1');
 });
 
-test('keeps the paper grid legible and Scraplet cosy in both themes', async ({ page }) => {
+test('keeps the paper grid legible and Scraplet cosy in both themes', async ({ page }, testInfo) => {
   await page.setViewportSize({ width: 1280, height: 720 });
 
   for (const study of [
@@ -188,5 +188,16 @@ test('keeps the paper grid legible and Scraplet cosy in both themes', async ({ p
     expect(appearance.gridAlpha).toBeCloseTo(study.alpha, 3);
     expect(appearance.gridImage).not.toBe('none');
     expect(appearance.petImage).not.toBe('none');
+
+    await removeDevelopmentChrome(page);
+    const screenshotPath = path.join(
+      'test-results',
+      'homepage-density',
+      'themes',
+      testInfo.project.name,
+      `${study.theme}-1280x720.png`,
+    );
+    await mkdir(path.dirname(screenshotPath), { recursive: true });
+    await page.screenshot({ path: screenshotPath, animations: 'disabled' });
   }
 });

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -152,3 +152,41 @@ test('keeps hover surfaces planted and lets the visitor pet Scraplet', async ({ 
   await pet.click();
   await expect(pet).toHaveAttribute('data-pets', '1');
 });
+
+test('keeps the paper grid legible and Scraplet cosy in both themes', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  for (const study of [
+    { theme: 'light', alpha: 0.036 },
+    { theme: 'dark', alpha: 0.044 },
+  ] as const) {
+    await page.goto('/');
+    await page.evaluate((theme) => window.localStorage.setItem('theme', theme), study.theme);
+    await page.reload();
+
+    await expect(page.locator('html')).toHaveClass(new RegExp(study.theme));
+
+    const grid = page.locator('[data-home-paper-grid]');
+    const pet = page.locator('[data-scrapbook-pet]');
+    await expect(grid).toBeVisible();
+    await expect(pet).toBeVisible();
+
+    const appearance = await page.evaluate(() => {
+      const gridElement = document.querySelector<HTMLElement>('[data-home-paper-grid]');
+      const petElement = document.querySelector<HTMLElement>('[data-scrapbook-pet]');
+      if (!gridElement || !petElement) throw new Error('Missing paper homepage cue');
+
+      const gridStyle = getComputedStyle(gridElement);
+      const petStyle = getComputedStyle(petElement);
+      return {
+        gridAlpha: Number.parseFloat(gridStyle.getPropertyValue('--home-grid-alpha')),
+        gridImage: gridStyle.backgroundImage,
+        petImage: petStyle.backgroundImage,
+      };
+    });
+
+    expect(appearance.gridAlpha).toBeCloseTo(study.alpha, 3);
+    expect(appearance.gridImage).not.toBe('none');
+    expect(appearance.petImage).not.toBe('none');
+  }
+});


### PR DESCRIPTION
## Direction

Builds on the newer paperlike, cosy homepage direction rather than the retired material-instrument work.

## Changes

- keeps the existing 28px graph-paper rhythm;
- raises the grid rule to a restrained 3.6% warm-ink alpha in light mode and 4.4% pale-lilac alpha in dark mode;
- moves the grid recipe into a homepage CSS module so theme contrast is explicit and testable;
- gives Scraplet one soft paper-scrap backing and faint paper fibres inside the existing card;
- keeps Scraplet's dimensions, interaction, copy, motion, focus behaviour, and homepage footprint unchanged;
- hides decorative paper cues in forced-colour mode.

## Guardrail

This is intentionally a small pass. It does not spread Scraplet across the page, change layout, revive the steel/glass vocabulary, or add another palette.

## Visual review

- light mode: the rule is now legible across the open lower page while staying behind card borders and type;
- dark mode: the pale-lilac rule remains visible without turning into a luminous grid;
- Scraplet reads as a small cut-paper nook inside the existing metric rail, not a separate panel or mascot takeover;
- Chromium and WebKit agree closely at 1280×720.

## Validation

[CI run 455](https://github.com/teamleaderleo/scrapbook/actions/runs/30354328158) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- 135 passed and two intentional skips;
- one unmodified homepage wheel-scroll smoke test retried once after a transient null bounding box.

Homepage screenshot artifact: `sha256:c50bdf9f44600433d8736d92322f1dccc02be9fdeee537e5a6199383b39d4cfb`.
Playwright log: `sha256:c95e990451c373f8a3dbda124e416a2ac63a41882679e186fb976d26e243139f`.

## Self-review

A broad stacking selector initially risked overriding Scraplet's screen-reader-only live status. The final diff scopes stacking to the visible figure and label, preserving the accessible status span.

Kept as a draft for visual approval before merge.