### PR TITLE
Own and rebuild the production time page

### DIFF
--- a/app/time/page.tsx
+++ b/app/time/page.tsx
@@ -5,16 +5,25 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Time machine',
   description:
-    'Slide through the day and compare local time, UTC, Eastern, Pacific, and other time zones.',
+    'Choose a local time and compare UTC, Eastern, Pacific, and other time zones.',
   alternates: { canonical: '/time' },
 };
 
 export default function TimePage() {
   return (
     <ViewportPageShell
-      className="bg-background text-foreground"
-      contentClassName="min-h-[calc(100dvh-3rem)]"
+      className="relative bg-background text-foreground"
+      contentClassName="relative min-h-[calc(100dvh-3rem)] overflow-x-hidden text-inherit"
     >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-30 dark:opacity-12"
+        style={{
+          backgroundImage:
+            'linear-gradient(rgba(30,30,34,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.04) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+        }}
+      />
       <UTCTimeVisualizer />
     </ViewportPageShell>
   );

--- a/components/current-time-display.tsx
+++ b/components/current-time-display.tsx
@@ -1,38 +1,49 @@
+import { Minus, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { detectCurrentTimezoneDST } from '@/app/lib/dst-utils';
+import {
+  formatClockTime,
+  formatUtcOffset,
+  normalizeTimeOfDay,
+} from '@/lib/time-conversion';
 
 interface CurrentTimeDisplayProps {
-  onJumpToTime: (minutes: number) => void;
+  selectedMinutes: number;
+  onSelectedTimeChange: (minutes: number) => void;
 }
 
-export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayProps) {
+type ClockPart = 'hours' | 'minutes';
+
+function padClockPart(value: number) {
+  return String(value).padStart(2, '0');
+}
+
+function clampClockPart(value: number, maximum: number) {
+  return Math.min(maximum, Math.max(0, value));
+}
+
+export default function CurrentTimeDisplay({
+  selectedMinutes,
+  onSelectedTimeChange,
+}: CurrentTimeDisplayProps) {
+  const selected = normalizeTimeOfDay(selectedMinutes);
   const [currentTime, setCurrentTime] = useState(0);
   const [userTimezone, setUserTimezone] = useState('');
-  const [utcOffset, setUtcOffset] = useState('');
+  const [utcOffsetMinutes, setUtcOffsetMinutes] = useState(0);
   const [isDST, setIsDST] = useState(false);
+  const [editingPart, setEditingPart] = useState<ClockPart | null>(null);
+  const [hourDraft, setHourDraft] = useState(() => padClockPart(selected.hours));
+  const [minuteDraft, setMinuteDraft] = useState(() => padClockPart(selected.minutes));
 
   useEffect(() => {
     let interval: ReturnType<typeof setInterval> | undefined;
 
     const updateTime = () => {
       const now = new Date();
-      const minutesSinceMidnight = now.getHours() * 60 + now.getMinutes();
-      setCurrentTime(minutesSinceMidnight);
-
-      if (!userTimezone) {
-        setUserTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);
-
-        const offsetMinutes = -now.getTimezoneOffset();
-        const offsetHours = Math.floor(Math.abs(offsetMinutes) / 60);
-        const offsetMins = Math.abs(offsetMinutes) % 60;
-        const sign = offsetMinutes >= 0 ? '+' : '−';
-        setUtcOffset(
-          `UTC${sign}${String(offsetHours).padStart(2, '0')}:${String(offsetMins).padStart(2, '0')}`,
-        );
-
-        const dstInfo = detectCurrentTimezoneDST();
-        setIsDST(dstInfo.isDSTActive);
-      }
+      setCurrentTime(now.getHours() * 60 + now.getMinutes());
+      setUserTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+      setUtcOffsetMinutes(-now.getTimezoneOffset());
+      setIsDST(detectCurrentTimezoneDST().isDSTActive);
     };
 
     updateTime();
@@ -48,41 +59,213 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
       clearTimeout(initialTimeout);
       if (interval) clearInterval(interval);
     };
-  }, [userTimezone]);
+  }, []);
 
-  const formatTime = (minutes: number) => {
-    const hours = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+  useEffect(() => {
+    if (editingPart !== 'hours') setHourDraft(padClockPart(selected.hours));
+    if (editingPart !== 'minutes') setMinuteDraft(padClockPart(selected.minutes));
+  }, [editingPart, selected.hours, selected.minutes]);
+
+  const applyClockPart = (part: ClockPart, value: number) => {
+    const nextHours = part === 'hours' ? clampClockPart(value, 23) : selected.hours;
+    const nextMinutes = part === 'minutes' ? clampClockPart(value, 59) : selected.minutes;
+    onSelectedTimeChange(nextHours * 60 + nextMinutes);
   };
 
+  const commitDraft = (part: ClockPart) => {
+    const draft = part === 'hours' ? hourDraft : minuteDraft;
+    const fallback = part === 'hours' ? selected.hours : selected.minutes;
+    const maximum = part === 'hours' ? 23 : 59;
+    const parsed = draft === '' ? fallback : Number.parseInt(draft, 10);
+    const next = clampClockPart(Number.isFinite(parsed) ? parsed : fallback, maximum);
+
+    applyClockPart(part, next);
+    if (part === 'hours') setHourDraft(padClockPart(next));
+    else setMinuteDraft(padClockPart(next));
+  };
+
+  const handleDraftChange = (part: ClockPart, rawValue: string) => {
+    const nextDraft = rawValue.replace(/\D/g, '').slice(0, 2);
+    if (part === 'hours') setHourDraft(nextDraft);
+    else setMinuteDraft(nextDraft);
+
+    if (nextDraft === '') return;
+    const parsed = Number.parseInt(nextDraft, 10);
+    const maximum = part === 'hours' ? 23 : 59;
+    if (parsed <= maximum) applyClockPart(part, parsed);
+  };
+
+  const nudgeClockPart = (part: ClockPart, delta: number) => {
+    const current = part === 'hours' ? selected.hours : selected.minutes;
+    const modulus = part === 'hours' ? 24 : 60;
+    const next = (current + delta + modulus) % modulus;
+    applyClockPart(part, next);
+    if (part === 'hours') setHourDraft(padClockPart(next));
+    else setMinuteDraft(padClockPart(next));
+  };
+
+  const handlePartKeyDown = (
+    part: ClockPart,
+    event: React.KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      nudgeClockPart(part, event.key === 'ArrowUp' ? 1 : -1);
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.currentTarget.blur();
+    }
+  };
+
+  const shiftSelectedTime = (delta: number) => {
+    onSelectedTimeChange(normalizeTimeOfDay(selectedMinutes + delta).minutesSinceMidnight);
+  };
+
+  const selectedValue = formatClockTime(selected.hours, selected.minutes);
+
   return (
-    <div>
-      <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <h1 className="text-3xl font-semibold tracking-tight">Current time</h1>
-        <button
-          type="button"
-          onClick={() => onJumpToTime(currentTime)}
-          className="cursor-pointer rounded-xl border border-border/65 bg-background/42 px-2.5 py-1 font-mono text-3xl font-semibold tabular-nums shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_7px_18px_rgba(20,20,24,0.08)] backdrop-blur-xl transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_10px_22px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          title="Jump the scrubber to the current time"
+    <section
+      aria-labelledby="time-converter-heading"
+      className="grid min-w-0 gap-5 rounded-[1.25rem] border border-border/75 bg-card p-4 text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] sm:p-5 lg:grid-cols-[minmax(0,0.82fr)_minmax(24rem,1.18fr)] lg:items-center lg:p-6 dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)]"
+      data-time-editor
+    >
+      <div className="min-w-0">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+          Time converter
+        </p>
+        <h1
+          id="time-converter-heading"
+          className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl"
         >
-          {formatTime(currentTime)}
-        </button>
+          Choose the time you want to compare.
+        </h1>
+        <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground sm:text-base">
+          The selected local time drives every conversion on this page. The live clock is a reset,
+          not a competing readout.
+        </p>
       </div>
-      <p className="flex flex-wrap items-center gap-1.5 font-mono text-xs tabular-nums text-muted-foreground">
-        <span>{userTimezone || 'Local zone'}</span>
-        {utcOffset ? (
-          <>
-            <span aria-hidden="true">·</span>
-            <span>{utcOffset}</span>
-          </>
-        ) : null}
-        {isDST ? (
-          <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-sans text-[9px] font-semibold text-amber-700 dark:text-amber-400">
-            DST
+
+      <div
+        data-time-editor-surface
+        data-selected-local-time={selectedValue}
+        className="min-w-0 rounded-[1.15rem] border border-border/70 bg-background/60 p-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.24),0_12px_28px_rgba(20,20,24,0.08)] sm:p-4"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-medium text-foreground">Selected local time</p>
+          <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+            24 hour
           </span>
-        ) : null}
-      </p>
-    </div>
+        </div>
+
+        <div className="mt-3 grid min-w-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2 sm:gap-3">
+          <label className="grid min-w-0 gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">Hour</span>
+            <input
+              data-selected-hour
+              type="text"
+              inputMode="numeric"
+              autoComplete="off"
+              value={hourDraft}
+              onFocus={(event) => {
+                setEditingPart('hours');
+                event.currentTarget.select();
+              }}
+              onChange={(event) => handleDraftChange('hours', event.target.value)}
+              onBlur={() => {
+                commitDraft('hours');
+                setEditingPart(null);
+              }}
+              onKeyDown={(event) => handlePartKeyDown('hours', event)}
+              role="spinbutton"
+              aria-label="Selected hour"
+              aria-valuemin={0}
+              aria-valuemax={23}
+              aria-valuenow={selected.hours}
+              className="h-20 w-full min-w-0 rounded-2xl border border-border bg-card px-2 text-center font-mono text-[clamp(2.75rem,14vw,4.75rem)] font-semibold leading-none tabular-nums tracking-[-0.06em] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_8px_20px_rgba(20,20,24,0.08)] outline-none transition-[border-color,box-shadow,transform] focus:border-ring focus:ring-2 focus:ring-ring/30 sm:h-24"
+            />
+          </label>
+
+          <span
+            aria-hidden="true"
+            className="pb-2 font-mono text-[clamp(2.75rem,13vw,4.5rem)] font-semibold leading-none text-muted-foreground sm:pb-3"
+          >
+            :
+          </span>
+
+          <label className="grid min-w-0 gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground">Minute</span>
+            <input
+              data-selected-minute
+              type="text"
+              inputMode="numeric"
+              autoComplete="off"
+              value={minuteDraft}
+              onFocus={(event) => {
+                setEditingPart('minutes');
+                event.currentTarget.select();
+              }}
+              onChange={(event) => handleDraftChange('minutes', event.target.value)}
+              onBlur={() => {
+                commitDraft('minutes');
+                setEditingPart(null);
+              }}
+              onKeyDown={(event) => handlePartKeyDown('minutes', event)}
+              role="spinbutton"
+              aria-label="Selected minute"
+              aria-valuemin={0}
+              aria-valuemax={59}
+              aria-valuenow={selected.minutes}
+              className="h-20 w-full min-w-0 rounded-2xl border border-border bg-card px-2 text-center font-mono text-[clamp(2.75rem,14vw,4.75rem)] font-semibold leading-none tabular-nums tracking-[-0.06em] text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_8px_20px_rgba(20,20,24,0.08)] outline-none transition-[border-color,box-shadow,transform] focus:border-ring focus:ring-2 focus:ring-ring/30 sm:h-24"
+            />
+          </label>
+        </div>
+
+        <div className="mt-3 grid grid-cols-3 gap-2">
+          <button
+            type="button"
+            onClick={() => shiftSelectedTime(-15)}
+            className="flex min-h-11 items-center justify-center gap-1.5 rounded-xl border border-border/70 bg-card px-2 text-sm font-medium text-foreground transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Move selected time 15 minutes earlier"
+          >
+            <Minus className="h-4 w-4" aria-hidden="true" />
+            <span>15 min</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onSelectedTimeChange(currentTime)}
+            className="min-h-11 rounded-xl border border-border/70 bg-card px-2 text-sm font-medium text-foreground transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            title="Set the selected time to the current local time"
+          >
+            <span className="block text-[10px] text-muted-foreground">Use now</span>
+            <span className="font-mono text-sm font-semibold tabular-nums">
+              {formatClockTime(Math.floor(currentTime / 60), currentTime % 60)}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => shiftSelectedTime(15)}
+            className="flex min-h-11 items-center justify-center gap-1.5 rounded-xl border border-border/70 bg-card px-2 text-sm font-medium text-foreground transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Move selected time 15 minutes later"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            <span>15 min</span>
+          </button>
+        </div>
+
+        <p className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{userTimezone || 'Local zone'}</span>
+          <span aria-hidden="true">·</span>
+          <span className="font-mono tabular-nums">{formatUtcOffset(utcOffsetMinutes)}</span>
+          {isDST ? (
+            <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
+              DST
+            </span>
+          ) : null}
+        </p>
+      </div>
+    </section>
   );
 }

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -4,48 +4,90 @@ import { useEffect, useState } from 'react';
 import TimezoneSelector from './timezone-selector';
 import CurrentTimeDisplay from './current-time-display';
 import { isDSTActive } from '@/app/lib/dst-utils';
+import {
+  convertLocalTimeToZone,
+  formatClockTime,
+  formatClockTime12Hour,
+  formatDayOffset,
+  formatUtcOffset,
+  normalizeTimeOfDay,
+  type NormalizedTimeOfDay,
+} from '@/lib/time-conversion';
 
 const DAY_GRADIENT =
   'linear-gradient(90deg, #151720 0%, #252938 9%, #493f55 18%, #715767 28%, #9f6f68 38%, #bd916c 46%, #c9a574 50%, #bd916c 56%, #9f6f68 64%, #715767 73%, #493f55 82%, #252938 91%, #151720 100%)';
 
-function formatOffset(offsetMinutes: number) {
-  if (offsetMinutes === 0) return 'UTC±00:00';
+const TIME_PRESETS = [
+  { label: 'Morning', minutes: 9 * 60 },
+  { label: 'Noon', minutes: 12 * 60 },
+  { label: 'Evening', minutes: 18 * 60 },
+  { label: 'Late', minutes: 22 * 60 },
+] as const;
 
-  const absoluteMinutes = Math.abs(offsetMinutes);
-  const hours = Math.floor(absoluteMinutes / 60);
-  const minutes = absoluteMinutes % 60;
-  return `UTC${offsetMinutes >= 0 ? '+' : '−'}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+function ComparisonCard({
+  label,
+  time,
+  offsetMinutes,
+  detail,
+}: {
+  label: string;
+  time: NormalizedTimeOfDay;
+  offsetMinutes: number;
+  detail?: string;
+}) {
+  return (
+    <div className="min-w-0 rounded-xl border border-border/65 bg-background/50 p-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)]">
+      <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1.5 font-mono text-3xl font-semibold tabular-nums tracking-[-0.035em]">
+        {formatClockTime(time.hours, time.minutes)}
+      </p>
+      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+        <span className="font-mono tabular-nums">
+          {formatClockTime12Hour(time.hours, time.minutes)}
+        </span>
+        <span aria-hidden="true"> · </span>
+        <span className="font-mono tabular-nums">{formatUtcOffset(offsetMinutes)}</span>
+      </p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {formatDayOffset(time.dayOffset)}
+        {detail ? ` · ${detail}` : ''}
+      </p>
+    </div>
+  );
 }
 
 export default function UTCTimeVisualizer() {
   const [localTime, setLocalTime] = useState(0);
   const [localOffsetMinutes, setLocalOffsetMinutes] = useState(0);
   const [useDST, setUseDST] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   useEffect(() => {
     const now = new Date();
     setLocalTime(now.getHours() * 60 + now.getMinutes());
     setLocalOffsetMinutes(-now.getTimezoneOffset());
     setUseDST(isDSTActive('us'));
+    setIsReady(true);
   }, []);
 
-  const localHours = Math.floor(localTime / 60);
-  const localMinutes = localTime % 60;
-  const easternOffset = useDST ? -4 : -5;
-  const pacificOffset = useDST ? -7 : -8;
-  const utcTotalMinutes = (localTime - localOffsetMinutes + 1440) % 1440;
-  const utcHours = Math.floor(utcTotalMinutes / 60);
-  const utcMinutes = utcTotalMinutes % 60;
+  const local = normalizeTimeOfDay(localTime);
+  const utc = convertLocalTimeToZone(localTime, localOffsetMinutes, 0);
+  const easternOffsetMinutes = (useDST ? -4 : -5) * 60;
+  const pacificOffsetMinutes = (useDST ? -7 : -8) * 60;
+  const eastern = convertLocalTimeToZone(
+    localTime,
+    localOffsetMinutes,
+    easternOffsetMinutes,
+  );
+  const pacific = convertLocalTimeToZone(
+    localTime,
+    localOffsetMinutes,
+    pacificOffsetMinutes,
+  );
 
-  const formatTime = (hours: number, minutes: number) =>
-    `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-
-  const formatTime12Hour = (hours: number, minutes: number) => {
-    const hours12 = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
-    return `${hours12}:${String(minutes).padStart(2, '0')}`;
-  };
-
-  const period = localHours >= 12 ? 'PM' : 'AM';
+  const localHours = local.hours;
   const timeOfDay =
     localHours < 6
       ? 'Night'
@@ -58,98 +100,105 @@ export default function UTCTimeVisualizer() {
             : 'Night';
 
   return (
-    <div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-6xl items-start px-4 py-4 sm:px-6 sm:py-8 lg:px-8">
-      <div className="w-full rounded-[1.5rem] border border-border/70 bg-card/92 p-4 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] backdrop-blur-xl dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
-        <CurrentTimeDisplay onJumpToTime={setLocalTime} />
+    <div
+      className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl items-start px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6"
+      data-time-converter-ready={isReady ? 'true' : 'false'}
+    >
+      <div className="flex w-full min-w-0 flex-col gap-4 sm:gap-5">
+        <CurrentTimeDisplay
+          selectedMinutes={localTime}
+          onSelectedTimeChange={setLocalTime}
+        />
 
-        <div className="mt-5 sm:mt-7">
-          <TimezoneSelector utcHours={utcHours} utcMinutes={utcMinutes} />
+        <TimezoneSelector utcTotalMinutes={localTime - localOffsetMinutes} />
+
+        <div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1.05fr)_minmax(22rem,0.95fr)]">
+          <section
+            aria-labelledby="time-scrubber-heading"
+            className="min-w-0 rounded-[1.25rem] border border-border/75 bg-card p-4 text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] sm:p-5 dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)]"
+          >
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+                  Scrub through the day
+                </p>
+                <h2 id="time-scrubber-heading" className="mt-1 text-xl font-semibold tracking-tight">
+                  Move every conversion together.
+                </h2>
+              </div>
+              <span className="text-sm font-medium text-muted-foreground">{timeOfDay}</span>
+            </div>
+
+            <input
+              id="time-of-day"
+              type="range"
+              min="0"
+              max="1439"
+              step="1"
+              value={localTime}
+              onChange={(event) => setLocalTime(Number.parseInt(event.target.value, 10))}
+              aria-label="Selected local time scrubber"
+              aria-valuetext={`${formatClockTime(local.hours, local.minutes)} ${timeOfDay}`}
+              className="time-day-slider mt-5 h-14 w-full cursor-pointer rounded-full"
+              style={{ background: DAY_GRADIENT }}
+            />
+            <div className="mt-2 flex justify-between font-mono text-[10px] tabular-nums text-muted-foreground">
+              <span>00:00</span>
+              <span>06:00</span>
+              <span>12:00</span>
+              <span>18:00</span>
+              <span>23:59</span>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2" aria-label="Time presets">
+              {TIME_PRESETS.map((preset) => (
+                <button
+                  key={preset.label}
+                  type="button"
+                  onClick={() => setLocalTime(preset.minutes)}
+                  className="rounded-lg border border-border/65 bg-background/50 px-3 py-2 text-sm font-medium text-muted-foreground transition-[background-color,color,transform] hover:-translate-y-px hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {preset.label}
+                  <span className="ml-1.5 font-mono text-xs tabular-nums">
+                    {formatClockTime(Math.floor(preset.minutes / 60), preset.minutes % 60)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section
+            aria-labelledby="time-comparisons-heading"
+            className="min-w-0 rounded-[1.25rem] border border-border/75 bg-card p-4 text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] sm:p-5 dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)]"
+          >
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              At a glance
+            </p>
+            <h2 id="time-comparisons-heading" className="mt-1 text-xl font-semibold tracking-tight">
+              Common reference zones
+            </h2>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <ComparisonCard
+                label="Local"
+                time={local}
+                offsetMinutes={localOffsetMinutes}
+                detail={timeOfDay}
+              />
+              <ComparisonCard label="UTC" time={utc} offsetMinutes={0} />
+              <ComparisonCard
+                label="Eastern"
+                time={eastern}
+                offsetMinutes={easternOffsetMinutes}
+              />
+              <ComparisonCard
+                label="Pacific"
+                time={pacific}
+                offsetMinutes={pacificOffsetMinutes}
+              />
+            </div>
+          </section>
         </div>
-
-        <div className="mt-6 sm:mt-7">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <label
-              htmlFor="time-of-day"
-              className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground"
-            >
-              Local time of day
-            </label>
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              {timeOfDay}
-            </span>
-          </div>
-          <input
-            id="time-of-day"
-            type="range"
-            min="0"
-            max="1439"
-            step="1"
-            value={localTime}
-            onChange={(event) => setLocalTime(Number.parseInt(event.target.value, 10))}
-            aria-label="Local time of day"
-            aria-valuetext={`${formatTime(localHours, localMinutes)} ${timeOfDay}`}
-            className="time-day-slider h-14 w-full cursor-pointer rounded-full"
-            style={{ background: DAY_GRADIENT }}
-          />
-          <div className="mt-2 flex justify-between font-mono text-[10px] tabular-nums text-muted-foreground">
-            <span>00:00</span>
-            <span>06:00</span>
-            <span>12:00</span>
-            <span>18:00</span>
-            <span>23:59</span>
-          </div>
-        </div>
-
-        <section
-          aria-label="Time comparisons"
-          className="mt-6 grid grid-cols-2 gap-3 sm:mt-7 sm:grid-cols-4"
-        >
-          <div className="col-span-2 rounded-xl border border-border/65 bg-background/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md sm:col-span-1">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              Local
-            </p>
-            <p className="mt-1 font-mono text-3xl font-semibold tabular-nums tracking-[-0.03em]">
-              {formatTime(localHours, localMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              {formatTime12Hour(localHours, localMinutes)} {period} ·{' '}
-              {formatOffset(localOffsetMinutes)}
-            </p>
-          </div>
-          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              UTC
-            </p>
-            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
-              {formatTime(utcHours, utcMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              UTC±00:00
-            </p>
-          </div>
-          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              Eastern
-            </p>
-            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
-              {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              {formatOffset(easternOffset * 60)}
-            </p>
-          </div>
-          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              Pacific
-            </p>
-            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
-              {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              {formatOffset(pacificOffset * 60)}
-            </p>
-          </div>
-        </section>
       </div>
     </div>
   );

--- a/components/timezone-selector.tsx
+++ b/components/timezone-selector.tsx
@@ -19,23 +19,23 @@ import {
   getAdjustedOffset,
   type TimezoneOption,
 } from '@/lib/timezone-options';
+import { formatDayOffset, normalizeTimeOfDay } from '@/lib/time-conversion';
 import {
   createBrowserViewportRestorationScheduler,
   type ViewportRestorationScheduler,
 } from '@/lib/visual-viewport-restoration';
 
 interface TimezoneSelectorProps {
-  utcHours: number;
-  utcMinutes: number;
+  utcTotalMinutes: number;
 }
 
-export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelectorProps) {
+export default function TimezoneSelector({ utcTotalMinutes }: TimezoneSelectorProps) {
   const [selectedZoneId, setSelectedZoneId] = useState(UTC_OPTION.id);
   const [previewZoneId, setPreviewZoneId] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState('');
   const [canApplyDST, setCanApplyDST] = useState(false);
-  const [resultMaxHeight, setResultMaxHeight] = useState(320);
+  const [resultMaxHeight, setResultMaxHeight] = useState(360);
   const rootRef = useRef<HTMLElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -51,22 +51,17 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
       : null;
   const displayOption = previewOption ?? selectedOption;
   const displayOffset = getAdjustedOffset(displayOption, canApplyDST);
-  const totalMinutes = utcHours * 60 + utcMinutes + displayOffset * 60;
-  const adjustedMinutes = ((totalMinutes % 1440) + 1440) % 1440;
-  const displayHours = Math.floor(adjustedMinutes / 60);
-  const displayMinutes = adjustedMinutes % 60;
+  const displayTime = normalizeTimeOfDay(utcTotalMinutes + displayOffset * 60);
   const isPreviewing = Boolean(previewOption && previewOption.id !== selectedOption.id);
 
   const measureAvailableResults = useCallback(() => {
     if (!isOpen || !listRef.current) return;
 
     const viewport = window.visualViewport;
-    const viewportBottom = viewport
-      ? viewport.offsetTop + viewport.height
-      : window.innerHeight;
+    const viewportBottom = viewport ? viewport.offsetTop + viewport.height : window.innerHeight;
     const listTop = listRef.current.getBoundingClientRect().top;
     const availableHeight = Math.floor(viewportBottom - listTop - 12);
-    setResultMaxHeight(Math.max(0, Math.min(360, availableHeight)));
+    setResultMaxHeight(Math.max(0, Math.min(420, availableHeight)));
   }, [isOpen]);
 
   const keepActiveOptionVisible = useCallback(() => {
@@ -177,37 +172,58 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
       ref={rootRef}
       data-timezone-instrument
       aria-label="Selected time zone"
-      className="scroll-mt-3 rounded-2xl border border-border/70 bg-card p-3 text-card-foreground shadow-[0_14px_34px_rgba(20,20,24,0.1)] sm:p-4 lg:grid lg:grid-cols-[minmax(0,0.9fr)_minmax(18rem,1.1fr)] lg:gap-4 dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)]"
+      className="scroll-mt-3 rounded-[1.25rem] border border-border/75 bg-card p-4 text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] sm:p-5 dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)]"
     >
       <div
         data-selected-time-readout
         aria-live={isOpen ? 'off' : 'polite'}
-        className="rounded-xl border border-border/70 bg-background p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.24),0_10px_24px_rgba(20,20,24,0.07)]"
+        className={`flex min-w-0 rounded-2xl border border-border/70 bg-background/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.24)] ${
+          isOpen
+            ? 'flex-row items-end justify-between gap-3 p-3 md:gap-4 md:p-4'
+            : 'flex-col gap-4 p-4 sm:flex-row sm:items-end sm:justify-between sm:p-5'
+        }`}
       >
-        <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-          {isPreviewing ? 'Preview time' : 'Selected time'}
-        </p>
-        <div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
-          <p className="font-mono text-5xl font-semibold tabular-nums tracking-[-0.05em] sm:text-6xl">
-            {formatTime(displayHours, displayMinutes)}
+        <div className="min-w-0">
+          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+            {isPreviewing ? 'Preview time' : 'Selected time'}
           </p>
-          <p className="pb-1 font-mono text-sm font-medium tabular-nums text-muted-foreground">
-            {displayOption.abbreviation}
-          </p>
+          <div className={`${isOpen ? 'mt-1' : 'mt-2'} flex flex-wrap items-end gap-x-3 gap-y-1`}>
+            <p
+              data-converted-time
+              className={`font-mono font-semibold tabular-nums tracking-[-0.05em] ${
+                isOpen ? 'text-3xl sm:text-4xl' : 'text-5xl sm:text-6xl'
+              }`}
+            >
+              {formatTime(displayTime.hours, displayTime.minutes)}
+            </p>
+            <p className="pb-1 font-mono text-sm font-medium tabular-nums text-muted-foreground">
+              {displayOption.abbreviation}
+            </p>
+          </div>
         </div>
-        <div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-xs tabular-nums text-muted-foreground">
-          <span className="font-semibold text-foreground">{displayOption.label}</span>
-          <span aria-hidden="true">·</span>
-          <span>{formatOffset(displayOffset)}</span>
-          {displayOption.dst ? (
-            <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-sans text-[9px] font-semibold text-amber-700 dark:text-amber-400">
-              DST
-            </span>
-          ) : null}
+
+        <div className={`min-w-0 text-right ${isOpen ? 'max-w-[48%]' : 'sm:max-w-[24rem]'}`}>
+          <p
+            className={`truncate font-medium text-foreground ${
+              isOpen ? 'text-sm sm:text-base' : 'text-base sm:text-lg'
+            }`}
+          >
+            {displayOption.label}
+          </p>
+          <p className="mt-1 flex flex-wrap items-center justify-end gap-1.5 text-xs text-muted-foreground">
+            <span className="font-mono tabular-nums">{formatOffset(displayOffset)}</span>
+            <span aria-hidden="true">·</span>
+            <span data-converted-day-offset>{formatDayOffset(displayTime.dayOffset)}</span>
+            {displayOption.dst ? (
+              <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-semibold text-amber-700 dark:text-amber-400">
+                DST
+              </span>
+            ) : null}
+          </p>
         </div>
       </div>
 
-      <div className="mt-3 min-w-0 lg:mt-0">
+      <div className={`${isOpen ? 'mt-2 md:mt-3' : 'mt-3'} min-w-0`}>
         <button
           ref={triggerRef}
           data-timezone-trigger
@@ -215,12 +231,25 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
           aria-expanded={isOpen}
           aria-controls="timezone-picker-results"
           onClick={() => (isOpen ? closePicker() : openPicker())}
-          className="flex min-h-11 w-full items-center gap-2 rounded-xl border border-border/70 bg-background px-3 text-left text-sm font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={`${
+            isOpen
+              ? 'flex h-0 min-h-0 overflow-hidden border-0 p-0 opacity-0 pointer-events-none md:h-auto md:min-h-16 md:border md:px-4 md:py-3 md:opacity-100 md:pointer-events-auto'
+              : 'flex min-h-16 border px-4 py-3'
+          } w-full min-w-0 items-center gap-3 rounded-2xl border-border/75 bg-background/55 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.24)] transition-[background-color,border-color,box-shadow] hover:border-border hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`}
         >
-          <Search className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
-          <span>{isOpen ? 'Hide zone search' : 'Search time zones'}</span>
-          <span className="ml-auto font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-            {isOpen ? 'Esc' : 'Open'}
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border/65 bg-card">
+            <Search className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-base font-medium text-foreground">
+              {isOpen ? 'Hide time zone search' : 'Choose a time zone'}
+            </span>
+            <span className="mt-0.5 block truncate text-sm text-muted-foreground">
+              Search by city, abbreviation, or UTC offset
+            </span>
+          </span>
+          <span className="shrink-0 rounded-lg border border-border/65 bg-card px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            {isOpen ? 'Esc' : 'Change'}
           </span>
         </button>
 
@@ -228,13 +257,13 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
           <div
             id="timezone-picker-results"
             data-timezone-picker
-            className="mt-2 overflow-hidden rounded-xl border border-border/70 bg-popover text-popover-foreground shadow-[0_18px_42px_rgba(20,20,24,0.18)]"
+            className="mt-0 overflow-hidden rounded-2xl border border-border/75 bg-popover text-popover-foreground shadow-[0_22px_52px_rgba(20,20,24,0.2)] md:mt-3"
           >
             <Command
               loop
               value={previewZoneId ?? undefined}
               onValueChange={setPreviewZoneId}
-              className="rounded-xl bg-popover"
+              className="rounded-2xl bg-popover [&_[cmdk-input-wrapper]]:px-4 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5"
               onKeyDown={(event) => {
                 if (event.key === 'Escape') {
                   event.preventDefault();
@@ -251,9 +280,9 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
                 ref={inputRef}
                 value={query}
                 onValueChange={setQuery}
-                placeholder="Type a city, zone, or UTC offset"
+                placeholder="Type a city, time zone, abbreviation, or UTC offset"
                 aria-label="Search time zones"
-                className="font-mono tabular-nums"
+                className="h-14 text-base"
               />
               <CommandList
                 ref={listRef}
@@ -262,7 +291,7 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
                 style={{ maxHeight: resultMaxHeight }}
               >
                 <CommandEmpty>No time zone found.</CommandEmpty>
-                <CommandGroup>
+                <CommandGroup className="p-2">
                   {TIMEZONE_OPTIONS.map((option) => {
                     const adjustedOffset = getAdjustedOffset(option, canApplyDST);
                     return (
@@ -276,23 +305,23 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
                           formatSearchOffset(adjustedOffset),
                         ]}
                         onSelect={() => selectZone(option)}
-                        className="min-h-11 items-center justify-between gap-3 px-3 py-2"
+                        className="min-h-14 items-center justify-between gap-4 rounded-xl px-3 py-3 sm:px-4"
                       >
                         <span className="min-w-0">
-                          <span className="block truncate text-sm">{option.label}</span>
-                          <span className="mt-0.5 block font-mono text-[10px] tabular-nums text-muted-foreground">
-                            {option.abbreviation}
-                            {option.dst ? ' · observes DST' : ''}
+                          <span className="block truncate text-base font-medium">{option.label}</span>
+                          <span className="mt-1 block text-xs text-muted-foreground">
+                            <span className="font-mono tabular-nums">{option.abbreviation}</span>
+                            {option.dst ? ' · observes daylight saving time' : ''}
                           </span>
                         </span>
-                        <span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+                        <span className="shrink-0 rounded-lg bg-muted/65 px-2 py-1 font-mono text-xs tabular-nums text-muted-foreground">
                           {formatOffset(adjustedOffset)}
                         </span>
                       </CommandItem>
                     );
                   })}
                 </CommandGroup>
-                <div className="border-t px-3 py-2 text-[11px] text-muted-foreground">
+                <div className="border-t px-4 py-3 text-xs leading-relaxed text-muted-foreground">
                   Offsets reflect the current daylight-saving period.
                 </div>
               </CommandList>

--- a/lib/time-conversion.test.ts
+++ b/lib/time-conversion.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertLocalTimeToZone,
+  formatClockTime12Hour,
+  formatDayOffset,
+  formatUtcOffset,
+  normalizeTimeOfDay,
+  parseTimeInput,
+} from './time-conversion';
+
+describe('time conversion helpers', () => {
+  it('normalizes previous and next-day values', () => {
+    expect(normalizeTimeOfDay(-30)).toEqual({
+      minutesSinceMidnight: 1410,
+      hours: 23,
+      minutes: 30,
+      dayOffset: -1,
+    });
+    expect(normalizeTimeOfDay(1470)).toEqual({
+      minutesSinceMidnight: 30,
+      hours: 0,
+      minutes: 30,
+      dayOffset: 1,
+    });
+  });
+
+  it('converts local time with whole and fractional offsets', () => {
+    expect(convertLocalTimeToZone(8 * 60, -7 * 60, 9 * 60)).toMatchObject({
+      hours: 0,
+      minutes: 0,
+      dayOffset: 1,
+    });
+    expect(convertLocalTimeToZone(9 * 60, -7 * 60, 5 * 60 + 30)).toMatchObject({
+      hours: 21,
+      minutes: 30,
+      dayOffset: 0,
+    });
+  });
+
+  it('formats clock, offset, and day labels', () => {
+    expect(formatClockTime12Hour(0, 5)).toBe('12:05 AM');
+    expect(formatClockTime12Hour(13, 45)).toBe('1:45 PM');
+    expect(formatUtcOffset(-210)).toBe('UTC−03:30');
+    expect(formatDayOffset(-1)).toBe('previous day');
+    expect(formatDayOffset(1)).toBe('next day');
+  });
+
+  it('parses valid time fields and rejects invalid values', () => {
+    expect(parseTimeInput('07:35')).toBe(455);
+    expect(parseTimeInput('24:00')).toBeNull();
+    expect(parseTimeInput('7:35')).toBeNull();
+  });
+});

--- a/lib/time-conversion.ts
+++ b/lib/time-conversion.ts
@@ -1,0 +1,65 @@
+export const MINUTES_PER_DAY = 24 * 60;
+
+export type NormalizedTimeOfDay = {
+  minutesSinceMidnight: number;
+  hours: number;
+  minutes: number;
+  dayOffset: number;
+};
+
+export function normalizeTimeOfDay(totalMinutes: number): NormalizedTimeOfDay {
+  const roundedMinutes = Math.round(totalMinutes);
+  const dayOffset = Math.floor(roundedMinutes / MINUTES_PER_DAY);
+  const minutesSinceMidnight =
+    ((roundedMinutes % MINUTES_PER_DAY) + MINUTES_PER_DAY) % MINUTES_PER_DAY;
+
+  return {
+    minutesSinceMidnight,
+    hours: Math.floor(minutesSinceMidnight / 60),
+    minutes: minutesSinceMidnight % 60,
+    dayOffset,
+  };
+}
+
+export function convertLocalTimeToZone(
+  localMinutes: number,
+  localOffsetMinutes: number,
+  targetOffsetMinutes: number,
+) {
+  return normalizeTimeOfDay(localMinutes - localOffsetMinutes + targetOffsetMinutes);
+}
+
+export function formatClockTime(hours: number, minutes: number) {
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+export function formatClockTime12Hour(hours: number, minutes: number) {
+  const hour = hours === 0 ? 12 : hours > 12 ? hours - 12 : hours;
+  return `${hour}:${String(minutes).padStart(2, '0')} ${hours >= 12 ? 'PM' : 'AM'}`;
+}
+
+export function formatUtcOffset(offsetMinutes: number) {
+  if (offsetMinutes === 0) return 'UTC±00:00';
+
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  const hours = Math.floor(absoluteMinutes / 60);
+  const minutes = absoluteMinutes % 60;
+  return `UTC${offsetMinutes >= 0 ? '+' : '−'}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+export function formatDayOffset(dayOffset: number) {
+  if (dayOffset === 0) return 'same day';
+  if (dayOffset === -1) return 'previous day';
+  if (dayOffset === 1) return 'next day';
+  return dayOffset < 0 ? `${Math.abs(dayOffset)} days earlier` : `${dayOffset} days later`;
+}
+
+export function parseTimeInput(value: string) {
+  const match = /^(\d{2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const hours = Number.parseInt(match[1], 10);
+  const minutes = Number.parseInt(match[2], 10);
+  if (hours > 23 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}

--- a/tests/e2e/time-converter-primary.spec.ts
+++ b/tests/e2e/time-converter-primary.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForTimeConverter(page: Page) {
+  await expect(page.locator('[data-time-converter-ready="true"]')).toBeVisible();
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      ),
+    )
+    .toBeLessThanOrEqual(0);
+}
+
+test.describe('owned time converter controls', () => {
+  test('keeps the custom clock editor, scrubber, presets, and cards synchronized', async ({
+    page,
+  }) => {
+    await page.goto('/time');
+    await waitForTimeConverter(page);
+
+    const hour = page.getByRole('spinbutton', { name: 'Selected hour' });
+    const minute = page.getByRole('spinbutton', { name: 'Selected minute' });
+    const surface = page.locator('[data-time-editor-surface]');
+    const scrubber = page.getByRole('slider', { name: 'Selected local time scrubber' });
+    const localCard = page.getByText('Local', { exact: true }).locator('..');
+
+    await hour.fill('14');
+    await minute.fill('30');
+    await page.getByRole('heading', { name: 'Choose the time you want to compare.' }).click();
+
+    await expect(hour).toHaveValue('14');
+    await expect(minute).toHaveValue('30');
+    await expect(surface).toHaveAttribute('data-selected-local-time', '14:30');
+    await expect(scrubber).toHaveValue(String(14 * 60 + 30));
+    await expect(localCard).toContainText('14:30');
+
+    await page.getByRole('button', { name: /Morning/ }).click();
+    await expect(hour).toHaveValue('09');
+    await expect(minute).toHaveValue('00');
+    await expect(scrubber).toHaveValue(String(9 * 60));
+    await expect(localCard).toContainText('09:00');
+
+    await minute.focus();
+    await minute.press('ArrowUp');
+    await expect(surface).toHaveAttribute('data-selected-local-time', '09:01');
+
+    await page.getByRole('button', { name: 'Move selected time 15 minutes later' }).click();
+    await expect(surface).toHaveAttribute('data-selected-local-time', '09:16');
+  });
+
+  test('keeps the clock editor physically substantial on a phone', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/time');
+    await waitForTimeConverter(page);
+
+    const surface = page.locator('[data-time-editor-surface]');
+    const hour = page.getByRole('spinbutton', { name: 'Selected hour' });
+    const minute = page.getByRole('spinbutton', { name: 'Selected minute' });
+
+    const [surfaceBox, hourBox, minuteBox] = await Promise.all([
+      surface.boundingBox(),
+      hour.boundingBox(),
+      minute.boundingBox(),
+    ]);
+
+    expect(surfaceBox).toBeTruthy();
+    expect(hourBox).toBeTruthy();
+    expect(minuteBox).toBeTruthy();
+    expect(surfaceBox!.width).toBeGreaterThanOrEqual(300);
+    expect(hourBox!.width).toBeGreaterThanOrEqual(108);
+    expect(minuteBox!.width).toBeGreaterThanOrEqual(108);
+    expect(hourBox!.height).toBeGreaterThanOrEqual(78);
+    expect(minuteBox!.height).toBeGreaterThanOrEqual(78);
+    expect(Math.abs(hourBox!.width - minuteBox!.width)).toBeLessThanOrEqual(1);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('renders the zone picker as a substantial full-width input surface', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 900 });
+    await page.goto('/time');
+    await waitForTimeConverter(page);
+
+    const trigger = page.locator('[data-timezone-trigger]');
+    const triggerBox = await trigger.boundingBox();
+    expect(triggerBox).toBeTruthy();
+    expect(triggerBox!.height).toBeGreaterThanOrEqual(62);
+
+    await trigger.click();
+
+    const picker = page.locator('[data-timezone-picker]');
+    const search = page.getByRole('combobox', { name: 'Search time zones' });
+    const firstOption = page.locator('[cmdk-item]').first();
+    await expect(picker).toBeVisible();
+    await expect(search).toBeFocused();
+    await expect(firstOption).toBeVisible();
+
+    const [pickerBox, searchBox, optionBox] = await Promise.all([
+      picker.boundingBox(),
+      search.boundingBox(),
+      firstOption.boundingBox(),
+    ]);
+    expect(pickerBox).toBeTruthy();
+    expect(searchBox).toBeTruthy();
+    expect(optionBox).toBeTruthy();
+    expect(pickerBox!.width).toBeGreaterThanOrEqual(triggerBox!.width - 2);
+    expect(searchBox!.height).toBeGreaterThanOrEqual(54);
+    expect(optionBox!.height).toBeGreaterThanOrEqual(54);
+  });
+});


### PR DESCRIPTION
## Production diagnosis

The deployed `/time` page was still narrow because the earlier substantial redesign in #437 remained an unmerged draft. Direct inspection of the current production deployment confirmed it was serving the old `main` implementation with a 44px zone trigger and no editable primary time field.

This replacement starts from current `main` at `bdd58863c53f92b18afb9ac9032da217928e09cd` and supersedes the now-closed #437.

## Fix

- replace the browser-native `type="time"` control with a fully owned clock editor built from two equal-width hour/minute fields;
- make the visible clock editor full-width, with 80px mobile and 96px larger-screen fields rather than browser-controlled intrinsic sizing;
- support direct numeric editing, ArrowUp/ArrowDown adjustment, clamping, zero-padding, ±15-minute movement, and a live “Use now” reset;
- make the selected time the single source of truth for the clock editor, scrubber, presets, local card, common-zone cards, and selected-zone conversion;
- enlarge the zone picker to a 64px full-width trigger, 56px search field, and 56px result rows;
- preserve the existing visual-viewport, focus, scroll-restoration, touch, Escape, and reduced-height mobile behaviour;
- align typography and card rhythm with the current homepage, reserving monospace for time values, offsets, and compact utility labels;
- show previous-day / same-day / next-day context across midnight;
- keep comparison cards full-width on phones.

## Validation

Final head: `c39464ae0fc23a643d58287307c83d08a1669be8`.

CI run 453 (`30353903099`) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- full Chromium/WebKit suite: **138 passed, 2 intentional skips**.

Two unrelated existing WebKit `material-system.spec.ts` homepage scoreboard screenshot assertions used their configured retry before passing. No time-page test was reported flaky or failed.

## Rendered geometry coverage

At the 390×844 mobile viewport, browser tests assert:

- editor surface width ≥ 300px;
- each hour/minute field width ≥ 108px;
- each field height ≥ 78px;
- hour and minute field widths differ by no more than 1px;
- no horizontal overflow.

Picker coverage asserts a ≥62px trigger, ≥54px search field and result rows, and a picker at least as wide as its trigger. Existing portrait and reduced-height landscape keyboard, focus, touch, Escape, scroll-restoration, and visual-viewport tests also passed in both engines.

## Deployment inspection

The Vercel project currently creates production deployments from `main` but did not create a preview deployment for this draft branch. Production therefore correctly remains on the old page until this PR is merged. The merge-ref itself was exercised by the full CI browser matrix above.

## Scope

Time page only. No homepage components, gallery/guestbook data, Space files, proxy files, navigation-progress files, or material-system files changed.

Draft and unmerged for visual review. Do not merge automatically.