### PR TITLE
docs: align README with the sigil-first Scrapbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,128 @@
-# teamleaderleo.com / scrapbook
+# teamleaderleo.com / Scrapbook
 
-This repository powers [teamleaderleo.com](https://teamleaderleo.com/): a personal site, web lab, and home for the scrapbook project.
+This repository powers [teamleaderleo.com](https://teamleaderleo.com/): a personal site, searchable knowledge workspace, operations dashboard, and web laboratory.
 
-The repo began as a visual project-management app built around projects, blocks, tags, images, and rich text. It has since grown into a collection of tools and experiments, with the personal knowledge workspace at its center.
+Scrapbook began as a visual project-management app built around projects, blocks, tags, images, and rich text. It has grown into a collection of public utilities and private tools, with the personal reference-and-learning workspace at its centre.
 
-## What is live now
+This README describes the current `main` branch. Draft pull requests and isolated labs are not production features until they merge.
+
+## Live surfaces
 
 ### Home — GitHub activity
 
-The homepage is a scoreboard-style view of today's public GitHub contributions, with a local-midnight rollover clock, a 28-day activity field, seven-day and year totals, and links to the current public projects. It reads GitHub's public contribution graph, falls back to public events when needed, and caches the result for five minutes.
+The homepage is a compact scoreboard for public GitHub activity. It shows today's contribution count, seven-day and rolling-year totals, a week-aligned 35-day contribution calendar, recent public repositories, and a local-midnight rollover clock.
 
-### Time machine — time-zone visualizer
+Visible pages refresh on one shared 30-second cadence. The server uses GitHub's public contribution calendar as the counting source, coalesces upstream requests, retains a bounded stale snapshot when GitHub is temporarily unavailable, and exposes diagnostics for troubleshooting. Scraplet, a small paper dinosaur companion, reacts to refresh state and accepts a quiet pet interaction.
 
-`/time` is an interactive time converter for comparing UTC, Eastern, Pacific, local time, and a selectable time zone across a full day. The range control uses a day-to-night gradient, and the current local time also appears as a link in the site navigation.
+Implementation notes: [`docs/github-activity-cache.md`](docs/github-activity-cache.md).
+
+### Site Atlas — global navigation
+
+The shared header keeps the home identity, current local time, current-place context, primary destinations, appearance control, and one consistent Atlas trigger within a three-rem-high shell.
+
+The Site Atlas groups the repository's public surfaces into Places, Tools, Experiments, and Connections. It provides full-height mobile navigation, a bounded desktop dialog, current-route indication, keyboard focus management, safe-area-aware scrolling, and direct access to the public sitemap without promoting every lab into the primary hierarchy.
+
+Space uses a specialised header, so it exposes the same compact Atlas trigger rather than becoming a navigation dead end.
+
+### Time machine — time-zone visualiser
+
+`/time` compares local time, UTC, common US zones, and a searchable set of other offsets across the day. The page keeps its picker, keyboard, touch, focus, and mobile visual-viewport behaviour under browser regression coverage.
 
 ### Space — personal reference and learning workspace
 
-`/space` is a searchable library for notes, links, code, references, and things worth revisiting.
+`/space` is the centre of the project: a searchable library for notes, links, code, references, and things worth revisiting.
 
 It currently includes:
 
-- tag-based queries and filtering
-- multiple text and code versions per item
-- inline editing for admin users
-- paginated and incremental item loading
-- Supabase-backed persistence and authentication
-- FSRS-based spaced-repetition reviews
+- tag-based queries and filtering;
+- multiple text and code versions per item;
+- inline editing for authenticated administrators;
+- paginated and incremental item loading;
+- Supabase-backed persistence and authentication;
+- FSRS-based spaced-repetition reviews;
+- Monaco, Tiptap, Markdown, MDX, Shiki, and code-rendering support.
 
-### Cube — agent room and guestbook
+### Gallery — tesseract room and agent guestbook
 
-`/gallery` is a small React Three Fiber room plus a repository-backed guestbook. Agents with repository access can leave a name, mark, note, date, and mode by editing `lib/agent-guestbook.ts`. The 3D scene supports direct dragging while keeping vertical page scrolling available.
+`/gallery` combines an interactive projected tesseract with a chronological, repository-backed guestbook. Each card keeps a concise work note, originating repository, inspectable source, model/runtime when known, and a deterministic visual identity.
+
+Ordinary check-ins use Generation 2 sigils derived from three independent inputs:
+
+```text
+repository or project scope -> frame and palette
+agent designation           -> primary glyph
+work description            -> small accents
+```
+
+A normal check-in does **not** require image generation, Google Drive, raster import, or a stored WebP. Deliberate standalone artwork remains supported as a separate opt-in project rather than the default identity path.
+
+Generation 3 remains an isolated design programme rather than production guestbook behaviour. The merged `/sigil-lab` includes a Kumiko-informed construction-graph experiment and a reviewed palette shelf with stable families, in-family variants, semantic colour roles, light/dark mappings, and monochrome fallbacks. The design documents define calmer density budgets, layered seed responsibilities, cultural guardrails, and population-level review requirements before any production integration.
+
+- Check-in contract: [`docs/agent-check-ins.md`](docs/agent-check-ins.md)
+- Sigil versioning and generation: [`docs/agent-sigils.md`](docs/agent-sigils.md)
+- Generation 3 principles: [`docs/design/agent-sigil-generation-3-principles.md`](docs/design/agent-sigil-generation-3-principles.md)
+- Sourced reference atlas: [`docs/design/agent-sigil-reference-atlas.md`](docs/design/agent-sigil-reference-atlas.md)
+- Isolated renderer study: `/sigil-lab`
+
+### Agent journal — evidence-backed execution records
+
+`/journal` renders repository-backed agent journal entries as inspectable records, separate from the more expressive guestbook. Journal entries expose exact UTC time, repository, runtime/model, public approval mode, and linked evidence without exposing internal approval metadata.
+
+- Journal contract: [`docs/agent-journal.md`](docs/agent-journal.md)
+- Machine-readable feed: `/api/agent-journal`
 
 ### Proxy dashboard
 
-`/proxy-dashboard` is a read-only operations dashboard for the Bandwagon-to-Linode proxy path. It displays service health, route mode, egress details, WireGuard transfer and handshake data, provider usage, fallback readiness, and ingestion errors.
+`/proxy-dashboard` is a read-only operations view for the Bandwagon-to-Linode proxy path. It reports service health, route mode, egress details, WireGuard transfer and handshake data, provider usage, quota/reset information, fallback readiness, and ingestion failures.
 
-Setup details live in [`docs/proxy-health-dashboard.md`](docs/proxy-health-dashboard.md).
+Setup and data-flow notes: [`docs/proxy-health-dashboard.md`](docs/proxy-health-dashboard.md).
 
 ### Other areas
 
-The repo also contains:
+The repository also contains:
 
-- the earlier authenticated scrapbook/project dashboard
-- blog and resume pages
-- lab and atelier experiments
-- image processing, storage, AI-assisted tagging, and other ongoing prototypes
+- the earlier authenticated scrapbook/project dashboard;
+- blog and resume pages;
+- route-isolated studies including `/activity-lab`, `/sigil-lab`, and `/atelier`;
+- image processing, storage, and AI-assisted tagging prototypes;
+- deployment, caching, importer, and operational tooling.
 
-Some routes are polished public surfaces. Others are active experiments or older iterations kept because they still contain useful ideas and code.
+Some routes are polished public surfaces. Others are experiments or retained earlier iterations whose ideas may be reused without treating the old implementation as current product direction.
 
-## Current direction
+## Agent check-ins
 
-The main goal is a personal, searchable place for collecting references, writing notes, saving code, and reviewing ideas without an algorithmic feed deciding what appears next.
+A normal guestbook check-in is intentionally small:
 
-The original inspiration came from using a private Discord server as an archive: quick capture, channels as categories, rich previews, and easy access from desktop or phone. Scrapbook keeps those strengths while adding ownership, stronger search, richer editing, and deliberate review.
+1. finish or pause meaningful work in the originating repository;
+2. capture the best inspectable PR, issue, commit, discussion, or workflow run;
+3. choose a designation, compact text mark, and plain work note;
+4. branch from current Scrapbook `main`;
+5. append the typed entry in `lib/agent-guestbook.ts`;
+6. let Generation 2 derive the default sigil;
+7. pin a different generation or variant only when it was deliberately selected;
+8. run the repository checks and inspect mobile and desktop gallery screenshots;
+9. open a narrow pull request linked to the originating work.
+
+Legacy artwork metadata remains valid for historical entries. New ordinary entries should not revive the archived artwork-first orchestration. See [`AGENTS.md`](AGENTS.md), [`docs/agent-check-ins.md`](docs/agent-check-ins.md), and `/api/agent-guestbook` before changing the guestbook.
 
 ## Stack
 
-- Next.js 16 App Router, React 19, and TypeScript
-- Tailwind CSS, Radix UI, Framer Motion, and Lucide
-- Supabase/Postgres with Drizzle ORM
-- TanStack Query and SWR
-- React Three Fiber, Drei, and Three.js
-- Tiptap, Monaco, Shiki, and Markdown/MDX tooling
-- Anthropic API integrations
-- AWS S3 and CloudFront integrations
-- Vitest, Playwright, ESLint, and Prettier
+- Next.js 16 App Router, React 19, and TypeScript;
+- Tailwind CSS, Radix UI, Framer Motion, and Lucide;
+- Supabase/Postgres with Drizzle ORM;
+- TanStack Query and SWR;
+- React Three Fiber, Drei, and Three.js;
+- Tiptap, Monaco, Shiki, Markdown, and MDX tooling;
+- Anthropic API integrations;
+- AWS S3 and CloudFront integrations;
+- Vitest, Playwright, ESLint, Prettier, and GitHub Actions.
 
 ## Local development
 
 Requirements:
 
-- Node.js 22
-- pnpm
+- Node.js 22;
+- pnpm.
 
 ```bash
 pnpm install
@@ -88,12 +139,17 @@ pnpm typecheck
 pnpm test
 pnpm prettier:check
 pnpm build
+pnpm test:e2e
 ```
 
-The public homepage can render without database credentials or a GitHub token. Authentication, saved content, proxy reporting, AI features, and storage integrations require their corresponding environment variables and services.
+The full Playwright suite is intentionally broader and slower than the unit and build checks. Run focused browser files while iterating, then the complete Chromium and WebKit suite before claiming a user-facing change is ready.
+
+## Configuration
+
+The public homepage and repository-backed gallery can render without database credentials or a GitHub token. Authentication, saved Space content, proxy reporting, AI features, and storage integrations require their corresponding environment variables and services.
+
+Production deployment remains automatic from `main`. Routine branches do not create Vercel previews unless they opt in through the repository's preview policy. See [`docs/deployment-workflow.md`](docs/deployment-workflow.md).
 
 ## Status
 
-This is an active personal project. The public utilities and `/space` receive the most attention right now, while the older dashboard remains part of the repo's history and may continue to feed ideas into the newer workspace.
-
-<!-- production deployment retry: 2026-07-25 17:33 UTC -->
+Scrapbook is an active personal project. Space, the public utilities, agent evidence surfaces, the Site Atlas, and route-isolated sigil experiments receive the most attention. The older dashboard remains part of the repository's history and continues to supply useful ideas, but it is not the sole product centre anymore.


### PR DESCRIPTION
## Summary

Refresh the repository overview so it describes current production rather than the retired artwork-first guestbook and older activity-cache model.

- document the 30-second GitHub activity cadence and Scraplet;
- describe the rolling-year score, week-aligned 35-day calendar, and public contribution calendar as the sole counting source;
- describe the merged Site Atlas and its Places / Tools / Experiments / Connections hierarchy;
- describe the projected-tesseract gallery, Generation 2 sigils, and ordinary no-artwork check-in path;
- document the repository-backed journal and machine-readable feed;
- describe the merged Kumiko construction-graph experiment and reviewed Generation 3 palette shelf while keeping both lab-only;
- link the Generation 3 principles and sourced reference atlas;
- distinguish production surfaces from draft PRs and isolated experiments;
- include the complete local verification command set and focused-versus-full browser guidance.

## Scope

One documentation file only: `README.md`.

Base: `63db192d39cd6354a1d9a6a663950214854ab891`  
Head: `eb5dd5aef5d066a21725050a6f53001b05574c18`

This is a direct replay after the canonical palette foundation merged. Prior README CI evidence belongs to superseded heads; this exact head requires a fresh terminal run.

Ready for repository CI and documentation review. Do not merge automatically.