### PR TITLE
fix: keep Site Atlas time copy production-accurate

### DIFF
--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -82,7 +82,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'time',
         href: '/time',
         label: 'Time',
-        description: 'Compare time zones and edit conversions directly.',
+        description: 'Compare local time with UTC and other time zones.',
         group: 'tools',
       },
       {


### PR DESCRIPTION
## Problem

The merged Site Atlas describes `/time` as supporting direct conversion editing, but that editor still lives only in draft PR #446. Global navigation therefore advertises a capability that current production does not provide.

## Fix

Replace the time-tool description with a durable statement that is true for both the current page and the proposed redesign:

> Compare local time with UTC and other time zones.

## Scope

One copy-only line in `lib/site-navigation.ts`.

Source parent: `343261b78c436a56685211ce15dabcc73f9e878d`  
Current base exercised by CI: `0b75cdc9418ef7924ade7c6633c69c0f6c6ce002`  
Head: `746e10b017b19e80f05005fd4d55e7fc737b48ba`

## Validation

CI run 527 (`30362573091`) passed on the current synthetic merge:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- screenshot and diagnostic artifact publication.

No time-page implementation, navigation behaviour, layout, route registry, or tests changed. Ready for review. Do not merge automatically.