### PR TITLE
feat: add the Generation 3 palette foundation

### DIFF
--- a/components/labs/agent-sigil-lab.tsx
+++ b/components/labs/agent-sigil-lab.tsx
@@ -4,6 +4,12 @@ import {
   createAgentIdentitySigilRecipe,
   type AgentIdentitySigilInput,
 } from '@/lib/agent-identity-sigils';
+import {
+  generation3PaletteCatalogue,
+  type Generation3PaletteFamily,
+  type Generation3PaletteRoles,
+  type Generation3PaletteVariant,
+} from '@/lib/agent-sigil-generation-3-palettes';
 import type { AgentSigilComplexity } from '@/lib/agent-sigils';
 
 const identities: Array<AgentIdentitySigilInput> = [
@@ -105,6 +111,15 @@ const complexityExamples: Array<{ label: string; value: AgentSigilComplexity }> 
   { label: 'Dense', value: 'dense' },
 ];
 
+const paletteSurfaces: Array<{
+  label: string;
+  key: 'light' | 'dark' | 'monochrome';
+}> = [
+  { label: 'Light', key: 'light' },
+  { label: 'Dark', key: 'dark' },
+  { label: 'Mono', key: 'monochrome' },
+];
+
 function IdentityCard({ identity }: { identity: AgentIdentitySigilInput }) {
   const recipe = createAgentIdentitySigilRecipe(identity);
 
@@ -126,6 +141,71 @@ function IdentityCard({ identity }: { identity: AgentIdentitySigilInput }) {
         <p className="mt-1 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground/75">
           g{recipe.generation} · {recipe.family} · {recipe.paletteName}
         </p>
+      </div>
+    </article>
+  );
+}
+
+function PaletteRoleStrip({
+  label,
+  roles,
+}: {
+  label: string;
+  roles: Generation3PaletteRoles;
+}) {
+  return (
+    <div
+      data-generation-3-palette-surface={label.toLowerCase()}
+      className="grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-2"
+    >
+      <span className="font-mono text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+        {label}
+      </span>
+      <div className="grid h-7 grid-cols-4 overflow-hidden rounded-lg border border-border/65 bg-background">
+        {Object.entries(roles).map(([role, colour]) => (
+          <span
+            key={role}
+            data-generation-3-palette-role={role}
+            title={`${role}: ${colour}`}
+            style={{ backgroundColor: colour }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Generation3PaletteCard({
+  family,
+  variant,
+}: {
+  family: Generation3PaletteFamily;
+  variant: Generation3PaletteVariant;
+}) {
+  return (
+    <article
+      data-generation-3-palette={variant.id}
+      data-generation-3-palette-family={family.id}
+      data-generation-3-palette-mode={family.mode}
+      className="min-w-0 rounded-[1rem] border border-border/65 bg-background p-3"
+    >
+      <div className="flex min-w-0 items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">{family.label}</h3>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">{variant.label}</p>
+        </div>
+        <span className="shrink-0 rounded-full border border-border/65 px-2 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+          {family.mode}
+        </span>
+      </div>
+      <div className="mt-3 grid gap-2">
+        {paletteSurfaces.map((surface) => (
+          <PaletteRoleStrip
+            key={surface.key}
+            label={surface.label}
+            roles={variant[surface.key]}
+          />
+        ))}
       </div>
     </article>
   );
@@ -174,6 +254,37 @@ export function AgentSigilLab() {
           {identities.map((identity) => (
             <IdentityCard key={`${identity.scope}:${identity.designation}`} identity={identity} />
           ))}
+        </div>
+      </section>
+
+      <section
+        data-generation-3-palette-shelf
+        className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 shadow-[0_18px_42px_rgba(28,26,24,0.08)] dark:shadow-[0_18px_42px_rgba(0,0,0,0.24)] sm:p-5"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Generation 3 palette foundation
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight">
+              Reviewed colour worlds before production geometry
+            </h2>
+          </div>
+          <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+            Ten stable families each contain two explicit variants across monotone, duotone, tri-colour, material, and luminous modes. Work-note edits never recolour the family.
+          </p>
+        </div>
+
+        <div className="mt-4 grid min-w-0 gap-2.5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+          {generation3PaletteCatalogue.flatMap((family) =>
+            family.variants.map((variant) => (
+              <Generation3PaletteCard
+                key={variant.id}
+                family={family}
+                variant={variant}
+              />
+            )),
+          )}
         </div>
       </section>
 

--- a/lib/agent-sigil-generation-3-palette-contrast.ts
+++ b/lib/agent-sigil-generation-3-palette-contrast.ts
@@ -1,0 +1,96 @@
+import type {
+  Generation3PaletteRole,
+  Generation3PaletteRoles,
+  Generation3PaletteVariant,
+} from './agent-sigil-generation-3-palettes';
+
+export const GENERATION_3_MIN_ROLE_CONTRAST = 1.5;
+
+const chromaticRoles: Exclude<Generation3PaletteRole, 'neutral'>[] = [
+  'dominant',
+  'support',
+  'highlight',
+];
+const surfaces: Array<'light' | 'dark' | 'monochrome'> = [
+  'light',
+  'dark',
+  'monochrome',
+];
+const hexColour = /^#[0-9a-f]{6}$/i;
+
+function channelToLinear(value: number) {
+  const channel = value / 255;
+  return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(colour: string) {
+  if (!hexColour.test(colour)) throw new Error(`Invalid Generation 3 palette colour: ${colour}`);
+  const red = Number.parseInt(colour.slice(1, 3), 16);
+  const green = Number.parseInt(colour.slice(3, 5), 16);
+  const blue = Number.parseInt(colour.slice(5, 7), 16);
+
+  return (
+    0.2126 * channelToLinear(red) +
+    0.7152 * channelToLinear(green) +
+    0.0722 * channelToLinear(blue)
+  );
+}
+
+export function generation3PaletteContrastRatio(first: string, second: string) {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+export type Generation3PaletteContrastFailure = {
+  paletteId: string;
+  surface: 'light' | 'dark' | 'monochrome';
+  role: Exclude<Generation3PaletteRole, 'neutral'>;
+  ratio: number;
+  minimum: number;
+};
+
+function surfaceFailures(
+  paletteId: string,
+  surface: Generation3PaletteContrastFailure['surface'],
+  roles: Generation3PaletteRoles,
+  minimum: number,
+) {
+  return chromaticRoles.flatMap((role): Generation3PaletteContrastFailure[] => {
+    const ratio = generation3PaletteContrastRatio(roles[role], roles.neutral);
+    return ratio + Number.EPSILON < minimum
+      ? [{ paletteId, surface, role, ratio, minimum }]
+      : [];
+  });
+}
+
+export function generation3PaletteContrastFailures(
+  palette: Generation3PaletteVariant,
+  minimum = GENERATION_3_MIN_ROLE_CONTRAST,
+) {
+  if (!Number.isFinite(minimum) || minimum < 1) {
+    throw new Error('Generation 3 palette contrast minimum must be a finite ratio of at least 1.');
+  }
+
+  return surfaces.flatMap((surface) =>
+    surfaceFailures(palette.id, surface, palette[surface], minimum),
+  );
+}
+
+export function assertGeneration3PaletteContrast(
+  palette: Generation3PaletteVariant,
+  minimum = GENERATION_3_MIN_ROLE_CONTRAST,
+) {
+  const failures = generation3PaletteContrastFailures(palette, minimum);
+  if (failures.length === 0) return;
+
+  const details = failures
+    .map(
+      (failure) =>
+        `${failure.surface}.${failure.role} ${failure.ratio.toFixed(2)}:1 < ${failure.minimum.toFixed(2)}:1`,
+    )
+    .join(', ');
+  throw new Error(`Generation 3 palette ${palette.id} fails the contrast floor: ${details}`);
+}

--- a/lib/agent-sigil-generation-3-palettes.test.ts
+++ b/lib/agent-sigil-generation-3-palettes.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertGeneration3PaletteContrast,
+  GENERATION_3_MIN_ROLE_CONTRAST,
+  generation3PaletteContrastFailures,
+  generation3PaletteContrastRatio,
+} from './agent-sigil-generation-3-palette-contrast';
+import {
+  createGeneration3PaletteRecipe,
+  generation3PaletteCatalogue,
+  generation3PaletteModes,
+  type Generation3PaletteRole,
+} from './agent-sigil-generation-3-palettes';
+
+const baseIdentity = {
+  scope: 'teamleaderleo/scrapbook',
+  designation: 'Testing review',
+};
+
+const roles: Generation3PaletteRole[] = ['dominant', 'support', 'highlight', 'neutral'];
+const hexColour = /^#[0-9a-f]{6}$/i;
+
+describe('Generation 3 palette foundation', () => {
+  it('repeats the exact palette recipe for the same identity and variant', () => {
+    expect(createGeneration3PaletteRecipe(baseIdentity)).toEqual(
+      createGeneration3PaletteRecipe(baseIdentity),
+    );
+  });
+
+  it('keeps description edits outside the palette seed', () => {
+    const original = {
+      ...baseIdentity,
+      description: 'Found three actionable test findings.',
+    };
+    const revised = {
+      ...baseIdentity,
+      description: 'Reviewed compatibility and release documentation.',
+    };
+
+    const first = createGeneration3PaletteRecipe({
+      scope: original.scope,
+      designation: original.designation,
+    });
+    const second = createGeneration3PaletteRecipe({
+      scope: revised.scope,
+      designation: revised.designation,
+    });
+
+    expect(second).toEqual(first);
+  });
+
+  it('supports every reviewed mode with at least two explicit families', () => {
+    for (const paletteMode of generation3PaletteModes) {
+      const families = generation3PaletteCatalogue.filter(
+        (family) => family.mode === paletteMode,
+      );
+      expect(families.length).toBeGreaterThanOrEqual(2);
+
+      const recipe = createGeneration3PaletteRecipe({ ...baseIdentity, paletteMode });
+      expect(recipe.mode).toBe(paletteMode);
+      expect(families.map((family) => family.id)).toContain(recipe.familyId);
+    }
+  });
+
+  it('stores two reviewed variants with bounded semantic roles in every family', () => {
+    expect(generation3PaletteCatalogue).toHaveLength(10);
+
+    for (const family of generation3PaletteCatalogue) {
+      expect(family.id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      expect(family.label.length).toBeGreaterThan(0);
+      expect(family.variants).toHaveLength(2);
+
+      for (const variant of family.variants) {
+        expect(variant.id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+        expect(variant.label.length).toBeGreaterThan(0);
+
+        for (const surface of [variant.light, variant.dark, variant.monochrome]) {
+          expect(Object.keys(surface).sort()).toEqual([...roles].sort());
+          for (const role of roles) expect(surface[role]).toMatch(hexColour);
+        }
+
+        expect(new Set(Object.values(variant.light)).size).toBe(roles.length);
+        expect(new Set(Object.values(variant.dark)).size).toBe(roles.length);
+      }
+    }
+  });
+
+  it('rejects catalogue colours that collapse into the neutral role', () => {
+    expect(GENERATION_3_MIN_ROLE_CONTRAST).toBe(1.5);
+    expect(generation3PaletteContrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 5);
+
+    for (const family of generation3PaletteCatalogue) {
+      for (const variant of family.variants) {
+        expect(generation3PaletteContrastFailures(variant)).toEqual([]);
+        expect(() => assertGeneration3PaletteContrast(variant)).not.toThrow();
+      }
+    }
+
+    const source = generation3PaletteCatalogue[0]!.variants[0]!;
+    const collapsed = {
+      ...source,
+      light: {
+        ...source.light,
+        dominant: source.light.neutral,
+      },
+    };
+    expect(generation3PaletteContrastFailures(collapsed)).toEqual([
+      expect.objectContaining({
+        paletteId: collapsed.id,
+        surface: 'light',
+        role: 'dominant',
+        ratio: 1,
+      }),
+    ]);
+    expect(() => assertGeneration3PaletteContrast(collapsed)).toThrow(/fails the contrast floor/i);
+  });
+
+  it('keeps the family stable while palette variants reroll inside it', () => {
+    const original = createGeneration3PaletteRecipe(baseIdentity);
+    const reroll = createGeneration3PaletteRecipe({ ...baseIdentity, paletteVariant: 1 });
+
+    expect(reroll.paletteVariant).toBe(1);
+    expect(reroll.familyId).toBe(original.familyId);
+    expect(reroll.variantId).not.toBe(original.variantId);
+    expect(reroll.fingerprint).not.toBe(original.fingerprint);
+    expect(reroll).toEqual(
+      createGeneration3PaletteRecipe({ ...baseIdentity, paletteVariant: 1 }),
+    );
+  });
+
+  it('produces a varied but bounded automatic population', () => {
+    const recipes = Array.from({ length: 80 }, (_, index) =>
+      createGeneration3PaletteRecipe({
+        scope: `owner/project-${index % 9}`,
+        designation: `Agent designation ${index}`,
+        paletteVariant: index % 4,
+      }),
+    );
+
+    expect(new Set(recipes.map((recipe) => recipe.familyId)).size).toBeGreaterThanOrEqual(7);
+    expect(new Set(recipes.map((recipe) => recipe.mode))).toEqual(
+      new Set(generation3PaletteModes),
+    );
+  });
+
+  it('rejects empty, unbounded, unsupported, or non-finite inputs', () => {
+    expect(() =>
+      createGeneration3PaletteRecipe({ scope: ' ', designation: 'Testing review' }),
+    ).toThrow(/scope must not be empty/i);
+    expect(() =>
+      createGeneration3PaletteRecipe({ scope: 'teamleaderleo/scrapbook', designation: ' ' }),
+    ).toThrow(/designation must not be empty/i);
+    expect(() =>
+      createGeneration3PaletteRecipe({
+        scope: 'teamleaderleo/scrapbook',
+        designation: 'x'.repeat(161),
+      }),
+    ).toThrow(/designation must contain at most 160/i);
+    expect(() =>
+      createGeneration3PaletteRecipe({
+        ...baseIdentity,
+        paletteVariant: Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow(/variant must be between/i);
+    expect(() =>
+      createGeneration3PaletteRecipe({
+        ...baseIdentity,
+        paletteMode: 'rainbow' as never,
+      }),
+    ).toThrow(/unsupported Generation 3 palette mode/i);
+  });
+});

--- a/lib/agent-sigil-generation-3-palettes.ts
+++ b/lib/agent-sigil-generation-3-palettes.ts
@@ -1,0 +1,396 @@
+export const generation3PaletteModes = [
+  'monotone',
+  'duotone',
+  'tri-colour',
+  'material',
+  'luminous',
+] as const;
+
+export type Generation3PaletteMode = (typeof generation3PaletteModes)[number];
+export type Generation3PaletteSelectionMode = Generation3PaletteMode | 'auto';
+export type Generation3PaletteRole = 'dominant' | 'support' | 'highlight' | 'neutral';
+
+export type Generation3PaletteRoles = Record<Generation3PaletteRole, string>;
+
+export type Generation3PaletteVariant = {
+  id: string;
+  label: string;
+  light: Generation3PaletteRoles;
+  dark: Generation3PaletteRoles;
+  monochrome: Generation3PaletteRoles;
+};
+
+export type Generation3PaletteFamily = {
+  id: string;
+  label: string;
+  mode: Generation3PaletteMode;
+  variants: readonly Generation3PaletteVariant[];
+};
+
+export type Generation3PaletteRecipe = {
+  version: 1;
+  familyId: string;
+  familyLabel: string;
+  mode: Generation3PaletteMode;
+  paletteVariant: number;
+  variantIndex: number;
+  variantId: string;
+  variantLabel: string;
+  fingerprint: string;
+  light: Generation3PaletteRoles;
+  dark: Generation3PaletteRoles;
+  monochrome: Generation3PaletteRoles;
+  identity: {
+    scope: string;
+    designation: string;
+  };
+};
+
+export type Generation3PaletteInput = {
+  /** Stable repository, product, or organisation identifier. */
+  scope: string;
+  /** Agent-chosen title or designation. */
+  designation: string;
+  /** Deliberate reproducible palette inside the stable family. */
+  paletteVariant?: number;
+  /** Limit deterministic family selection to one reviewed palette mode. */
+  paletteMode?: Generation3PaletteSelectionMode;
+};
+
+const MAX_SCOPE_LENGTH = 192;
+const MAX_DESIGNATION_LENGTH = 160;
+const MAX_PALETTE_VARIANT = 9_999;
+
+type RoleTuple = readonly [
+  dominant: string,
+  support: string,
+  highlight: string,
+  neutral: string,
+];
+
+type PaletteVariantDefinition = {
+  id: string;
+  label: string;
+  light: RoleTuple;
+  dark: RoleTuple;
+  monochrome: RoleTuple;
+};
+
+type PaletteFamilyDefinition = {
+  id: string;
+  label: string;
+  mode: Generation3PaletteMode;
+  variants: readonly PaletteVariantDefinition[];
+};
+
+function roles([dominant, support, highlight, neutral]: RoleTuple): Generation3PaletteRoles {
+  return { dominant, support, highlight, neutral };
+}
+
+const paletteFamilyDefinitions = [
+  {
+    id: 'indigo-frost',
+    label: 'Indigo / frost',
+    mode: 'monotone',
+    variants: [
+      {
+        id: 'indigo-frost-clear',
+        label: 'Clear indigo',
+        light: ['#4f46a5', '#766fc2', '#b9b9e8', '#292744'],
+        dark: ['#9189e8', '#6860bd', '#d8d7ff', '#222039'],
+        monochrome: ['#555555', '#858585', '#c7c7c7', '#252525'],
+      },
+      {
+        id: 'indigo-frost-muted',
+        label: 'Muted indigo',
+        light: ['#5b4f93', '#8279b1', '#c9c5e3', '#2c2940'],
+        dark: ['#9f95d8', '#7168a8', '#e2ddf6', '#242138'],
+        monochrome: ['#5d5d5d', '#8a8a8a', '#cccccc', '#272727'],
+      },
+    ],
+  },
+  {
+    id: 'ceramic-slate',
+    label: 'Ceramic / slate',
+    mode: 'monotone',
+    variants: [
+      {
+        id: 'ceramic-slate-stone',
+        label: 'Stone ceramic',
+        light: ['#65717a', '#8d989e', '#d7dcdd', '#30383d'],
+        dark: ['#aab4b8', '#7b878c', '#eef1f1', '#252c30'],
+        monochrome: ['#626262', '#949494', '#d1d1d1', '#292929'],
+      },
+      {
+        id: 'ceramic-slate-blue',
+        label: 'Blue ceramic',
+        light: ['#536f7c', '#829eaa', '#cedde2', '#29373d'],
+        dark: ['#8eabb5', '#65838f', '#dfedf0', '#222e33'],
+        monochrome: ['#5f5f5f', '#909090', '#cecece', '#282828'],
+      },
+    ],
+  },
+  {
+    id: 'ultramarine-silver',
+    label: 'Ultramarine / silver',
+    mode: 'duotone',
+    variants: [
+      {
+        id: 'ultramarine-silver-cobalt',
+        label: 'Cobalt silver',
+        light: ['#345ec4', '#72a4d6', '#c8d8e5', '#283244'],
+        dark: ['#6e91ea', '#77bad5', '#d9e7ef', '#20293b'],
+        monochrome: ['#4f4f4f', '#8b8b8b', '#c9c9c9', '#242424'],
+      },
+      {
+        id: 'ultramarine-silver-cyan',
+        label: 'Cyan steel',
+        light: ['#2f74a7', '#62a8c7', '#c4dce7', '#24343f'],
+        dark: ['#62a6d2', '#6bc1d4', '#d7edf2', '#1f2c34'],
+        monochrome: ['#545454', '#8d8d8d', '#cccccc', '#252525'],
+      },
+    ],
+  },
+  {
+    id: 'moss-citron',
+    label: 'Moss / citron',
+    mode: 'duotone',
+    variants: [
+      {
+        id: 'moss-citron-green',
+        label: 'Moss green',
+        light: ['#687536', '#a8af4d', '#d7dc84', '#303522'],
+        dark: ['#9eab58', '#c3ca65', '#e4e8a3', '#292e20'],
+        monochrome: ['#595959', '#8d8d8d', '#c8c8c8', '#282828'],
+      },
+      {
+        id: 'moss-citron-olive',
+        label: 'Olive citron',
+        light: ['#73713a', '#b1a94b', '#ddd37c', '#343222'],
+        dark: ['#aaa45a', '#ccc467', '#ece49a', '#2e2c20'],
+        monochrome: ['#5c5c5c', '#909090', '#cccccc', '#292929'],
+      },
+    ],
+  },
+  {
+    id: 'teal-pale-gold',
+    label: 'Teal / mint / pale gold',
+    mode: 'tri-colour',
+    variants: [
+      {
+        id: 'teal-pale-gold-mint',
+        label: 'Mint gold',
+        light: ['#278d8b', '#75bba9', '#dfbe68', '#243c3b'],
+        dark: ['#53b8b2', '#88cfba', '#efd485', '#203535'],
+        monochrome: ['#555555', '#8f8f8f', '#cfcfcf', '#252525'],
+      },
+      {
+        id: 'teal-pale-gold-brass',
+        label: 'Sea green brass',
+        light: ['#247d73', '#66ae91', '#d2ad61', '#243934'],
+        dark: ['#4fa99a', '#7cc4a4', '#e5ca7b', '#20322e'],
+        monochrome: ['#575757', '#8d8d8d', '#cbcbcb', '#272727'],
+      },
+    ],
+  },
+  {
+    id: 'coral-warm-cream',
+    label: 'Coral / rose / warm cream',
+    mode: 'tri-colour',
+    variants: [
+      {
+        id: 'coral-warm-cream-rose',
+        label: 'Coral rose',
+        light: ['#d25f5d', '#ad5d7e', '#ebcfa4', '#4b2c34'],
+        dark: ['#e77f78', '#cf7a9c', '#f4ddb8', '#3d2730'],
+        monochrome: ['#5b5b5b', '#8c8c8c', '#d0d0d0', '#292929'],
+      },
+      {
+        id: 'coral-warm-cream-apricot',
+        label: 'Rose apricot',
+        light: ['#c65d72', '#a35a88', '#e9c28f', '#482d36'],
+        dark: ['#dd7c8a', '#c0769c', '#f2d4aa', '#3a2930'],
+        monochrome: ['#5d5d5d', '#8b8b8b', '#cecece', '#282828'],
+      },
+    ],
+  },
+  {
+    id: 'cedar-amber-charcoal',
+    label: 'Cedar / amber / charcoal',
+    mode: 'material',
+    variants: [
+      {
+        id: 'cedar-amber-charcoal-clear',
+        label: 'Clear cedar',
+        light: ['#875537', '#c38845', '#e2b96f', '#342c27'],
+        dark: ['#b47a55', '#d2a05d', '#edcc8a', '#2d2724'],
+        monochrome: ['#5c5c5c', '#919191', '#cccccc', '#292929'],
+      },
+      {
+        id: 'cedar-amber-charcoal-walnut',
+        label: 'Walnut ochre',
+        light: ['#79533c', '#b27d45', '#d6ae6e', '#332b27'],
+        dark: ['#a67758', '#c7965e', '#e6c487', '#2c2724'],
+        monochrome: ['#5d5d5d', '#8f8f8f', '#cacaca', '#292929'],
+      },
+    ],
+  },
+  {
+    id: 'clay-oxblood-sand',
+    label: 'Clay / oxblood / sand',
+    mode: 'material',
+    variants: [
+      {
+        id: 'clay-oxblood-sand-earth',
+        label: 'Earth clay',
+        light: ['#a5604e', '#783b3f', '#d8b88c', '#402f2c'],
+        dark: ['#c47d68', '#a7585d', '#e6caa3', '#372a28'],
+        monochrome: ['#606060', '#858585', '#c9c9c9', '#292929'],
+      },
+      {
+        id: 'clay-oxblood-sand-terracotta',
+        label: 'Terracotta burgundy',
+        light: ['#a95f45', '#7e3f4b', '#d9ae82', '#402d2b'],
+        dark: ['#ca765d', '#a75464', '#e5c49b', '#372825'],
+        monochrome: ['#606060', '#888888', '#c8c8c8', '#292929'],
+      },
+    ],
+  },
+  {
+    id: 'graphite-electric-blue',
+    label: 'Graphite / electric blue',
+    mode: 'luminous',
+    variants: [
+      {
+        id: 'graphite-electric-blue-cobalt',
+        label: 'Electric cobalt',
+        light: ['#3f4653', '#647184', '#347ee8', '#20252c'],
+        dark: ['#7b879a', '#48566a', '#65a6ff', '#1d2229'],
+        monochrome: ['#5b5b5b', '#858585', '#c7c7c7', '#242424'],
+      },
+      {
+        id: 'graphite-electric-blue-cyan',
+        label: 'Electric cyan',
+        light: ['#414852', '#5e7485', '#2e9fd2', '#20262c'],
+        dark: ['#798998', '#456376', '#57c0eb', '#1b2228'],
+        monochrome: ['#5b5b5b', '#878787', '#c8c8c8', '#242424'],
+      },
+    ],
+  },
+  {
+    id: 'graphite-violet-beacon',
+    label: 'Graphite / violet beacon',
+    mode: 'luminous',
+    variants: [
+      {
+        id: 'graphite-violet-beacon-blue',
+        label: 'Violet blue',
+        light: ['#454451', '#6d6481', '#9b6de4', '#25232b'],
+        dark: ['#858190', '#5e5573', '#bd8cff', '#211f27'],
+        monochrome: ['#5d5d5d', '#898989', '#cbcbcb', '#252525'],
+      },
+      {
+        id: 'graphite-violet-beacon-magenta',
+        label: 'Violet magenta',
+        light: ['#49444f', '#745f7d', '#b25ad7', '#27232a'],
+        dark: ['#8c8190', '#684f70', '#d37af0', '#221e25'],
+        monochrome: ['#5e5e5e', '#8a8a8a', '#cccccc', '#252525'],
+      },
+    ],
+  },
+] as const satisfies readonly PaletteFamilyDefinition[];
+
+export const generation3PaletteCatalogue: readonly Generation3PaletteFamily[] =
+  paletteFamilyDefinitions.map((family) => ({
+    id: family.id,
+    label: family.label,
+    mode: family.mode,
+    variants: family.variants.map((variant) => ({
+      id: variant.id,
+      label: variant.label,
+      light: roles(variant.light),
+      dark: roles(variant.dark),
+      monochrome: roles(variant.monochrome),
+    })),
+  }));
+
+function normaliseIdentityField(value: string, label: string, maximum: number) {
+  const normalised = value.trim().replace(/\s+/g, ' ');
+  if (!normalised) throw new Error(`Generation 3 palette ${label} must not be empty.`);
+  if (normalised.length > maximum) {
+    throw new Error(`Generation 3 palette ${label} must contain at most ${maximum} characters.`);
+  }
+  return normalised;
+}
+
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function fingerprint(value: string) {
+  return hashString(value).toString(16).padStart(8, '0');
+}
+
+function normalisePaletteVariant(value: number | undefined) {
+  const paletteVariant = value ?? 0;
+  if (
+    !Number.isFinite(paletteVariant) ||
+    paletteVariant < 0 ||
+    paletteVariant > MAX_PALETTE_VARIANT
+  ) {
+    throw new Error(
+      `Generation 3 palette variant must be between 0 and ${MAX_PALETTE_VARIANT}.`,
+    );
+  }
+  return Math.floor(paletteVariant);
+}
+
+function isGeneration3PaletteMode(value: string): value is Generation3PaletteMode {
+  return generation3PaletteModes.includes(value as Generation3PaletteMode);
+}
+
+export function createGeneration3PaletteRecipe(
+  input: Generation3PaletteInput,
+): Generation3PaletteRecipe {
+  const scope = normaliseIdentityField(input.scope, 'scope', MAX_SCOPE_LENGTH);
+  const designation = normaliseIdentityField(
+    input.designation,
+    'designation',
+    MAX_DESIGNATION_LENGTH,
+  );
+  const paletteVariant = normalisePaletteVariant(input.paletteVariant);
+  const paletteMode = input.paletteMode ?? 'auto';
+  if (paletteMode !== 'auto' && !isGeneration3PaletteMode(paletteMode)) {
+    throw new Error(`Unsupported Generation 3 palette mode: ${paletteMode}`);
+  }
+
+  const candidates =
+    paletteMode === 'auto'
+      ? generation3PaletteCatalogue
+      : generation3PaletteCatalogue.filter((family) => family.mode === paletteMode);
+  const familySeed = `generation-3:palette-family:${paletteMode}:${scope}:${designation}`;
+  const family = candidates[hashString(familySeed) % candidates.length]!;
+  const variantIndex = paletteVariant % family.variants.length;
+  const variant = family.variants[variantIndex]!;
+
+  return {
+    version: 1,
+    familyId: family.id,
+    familyLabel: family.label,
+    mode: family.mode,
+    paletteVariant,
+    variantIndex,
+    variantId: variant.id,
+    variantLabel: variant.label,
+    fingerprint: fingerprint(`${familySeed}:${variant.id}:${paletteVariant}`),
+    light: { ...variant.light },
+    dark: { ...variant.dark },
+    monochrome: { ...variant.monochrome },
+    identity: { scope, designation },
+  };
+}

--- a/tests/e2e/sigil-lab.spec.ts
+++ b/tests/e2e/sigil-lab.spec.ts
@@ -36,6 +36,24 @@ test('sigil lab exposes layered generations and visual evidence', async ({ page 
     expect(fingerprints.every(Boolean)).toBe(true);
     expect(new Set(fingerprints).size).toBe(fingerprints.length);
 
+    const palettes = page.locator('[data-generation-3-palette]');
+    await expect(palettes).toHaveCount(20);
+    const paletteMetadata = await palettes.evaluateAll((elements) =>
+      elements.map((element) => ({
+        family: element.getAttribute('data-generation-3-palette-family'),
+        mode: element.getAttribute('data-generation-3-palette-mode'),
+      })),
+    );
+    expect(new Set(paletteMetadata.map((palette) => palette.family)).size).toBe(10);
+    for (const family of new Set(paletteMetadata.map((palette) => palette.family))) {
+      expect(paletteMetadata.filter((palette) => palette.family === family)).toHaveLength(2);
+    }
+    expect(new Set(paletteMetadata.map((palette) => palette.mode))).toEqual(
+      new Set(['monotone', 'duotone', 'tri-colour', 'material', 'luminous']),
+    );
+    await expect(page.locator('[data-generation-3-palette-surface]')).toHaveCount(60);
+    await expect(page.locator('[data-generation-3-palette-role]')).toHaveCount(240);
+
     const rerolls = page.locator('[data-sigil-reroll]');
     await expect(rerolls).toHaveCount(8);
     const rerollFingerprints = await rerolls.evaluateAll((elements) =>

--- a/tests/e2e/sigil-lab.spec.ts
+++ b/tests/e2e/sigil-lab.spec.ts
@@ -16,8 +16,10 @@ const variants = [
   { theme: 'dark' as const, width: 1366, height: 768 },
 ];
 
-test('sigil lab exposes layered generations and visual evidence', async ({ page }, testInfo) => {
-  for (const variant of variants) {
+for (const variant of variants) {
+  test(`sigil lab exposes layered generations in ${variant.theme} at ${variant.width}x${variant.height}`, async ({
+    page,
+  }, testInfo) => {
     await page.emulateMedia({ colorScheme: variant.theme });
     await page.setViewportSize({ width: variant.width, height: variant.height });
 
@@ -73,8 +75,8 @@ test('sigil lab exposes layered generations and visual evidence', async ({ page 
       ),
       fullPage: true,
     });
-  }
-});
+  });
+}
 
 test('repository, designation, and description seeds stay isolated', async ({ page }) => {
   await page.goto('/sigil-lab');


### PR DESCRIPTION
Advances #448 and the lab-only acceptance work in #443.

## Outcome

Add a deterministic, explicit colour foundation for Generation 3 without changing any production guestbook identity.

- define ten stable palette families across monotone, duotone, tri-colour, material, and luminous modes;
- provide two explicit reviewed variants inside every family;
- give every variant semantic dominant, support, highlight, and neutral roles;
- provide coordinated light, dark, and monochrome mappings from the same role system;
- select the family deterministically from `scope + designation`, then select a reviewed in-family palette with `paletteVariant`;
- use the proposed `paletteMode` and `paletteVariant` API names from #448;
- keep description text outside the palette API so wording changes cannot recolour an identity;
- enforce a reusable 1.5:1 minimum separation between every chromatic role and its neutral role on all three mappings;
- expose all twenty family variants as a palette-only shelf in `/sigil-lab`;
- add unit and Chromium/WebKit assertions for family stability, catalogue bounds, determinism, mode coverage, role completeness, contrast rejection, and responsive lab rendering.

## Current-main integration

This candidate is replayed directly onto the merged Kumiko experiment from #461. It keeps the separate construction-graph lab, all 41 Kumiko renders, graph/occupancy assertions, layer-isolation checks, small-size checks, and screenshots intact while adding the palette shelf and its assertions.

## Isolation boundary

This does **not**:

- add Generation 3 to `agentIdentitySigilGenerations`;
- change Generation 1 or Generation 2 recipes, fingerprints, SVG, palettes, or defaults;
- change guestbook entries, cards, sigil selections, or production gallery output;
- alter the merged Kumiko generator, renderer, population, or production boundary;
- switch any production identity to Generation 3.

## Exact scope

Base: `343261b78c436a56685211ce15dabcc73f9e878d`  
Head: `465e6cd6c286ff51c7e95f0c3be4b603814802e7`

Two commits and five files:

- `lib/agent-sigil-generation-3-palettes.ts`;
- `lib/agent-sigil-generation-3-palette-contrast.ts`;
- `lib/agent-sigil-generation-3-palettes.test.ts`;
- `components/labs/agent-sigil-lab.tsx`;
- `tests/e2e/sigil-lab.spec.ts`.

## Validation

Exact-head CI run 520 (`30361943296`) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- full Chromium and WebKit browser regressions;
- merged Kumiko graph, occupancy, layer-isolation, and size assertions;
- twenty palette cards, ten stable families, two variants per family, five modes, three surface mappings, contrast rejection, and no-horizontal-overflow assertions;
- light/dark mobile and desktop screenshot publication.

Screenshot artifact: `sha256:0bea2dad087b23476ddb211c9f088de6cb0a50af408958d7b60414c2af64baa4`.

Visual review confirms distinct mode populations, readable light/dark/monochrome roles, no palette collapse, and preserved Kumiko evidence. Ready for review. Do not merge automatically.