### PR TITLE
Make the app feel like a cozy scrapbook workshop

### DIFF
--- a/app/atelier/page.tsx
+++ b/app/atelier/page.tsx
@@ -1,3 +1,4 @@
+import { PaperCreature } from '@/components/paper-creature';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import Link from 'next/link';
 import type { Metadata } from 'next';
@@ -31,40 +32,50 @@ export default function AtelierPage() {
   return (
     <ViewportPageShell className="bg-[#ecebe6] text-[#17181b] dark:bg-[#101115] dark:text-[#eeeae3]">
       <section className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-black/55 dark:text-white/55">
-            Atelier
-          </p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight sm:text-5xl">
-            Experimental interface room
-          </h1>
-        </div>
+        <header className="flex items-end justify-between gap-5">
+          <div>
+            <span className="material-label-stamped text-[9px] text-black/55 dark:text-white/55">atelier</span>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-5xl">A little interface workshop</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-black/65 dark:text-white/65 sm:text-base">
+              Rough navigation objects, reader ideas, and useful experiments laid out like pieces on a worktable.
+            </p>
+          </div>
+          <div className="hidden text-center sm:block">
+            <PaperCreature pose="carrying" size="lg" label="Scraplet carrying a pencil through the atelier" />
+            <p className="mt-1 font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-black/50 dark:text-white/50">
+              workshop helper
+            </p>
+          </div>
+        </header>
 
         <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_24rem] lg:items-start">
-          <div className="rounded-3xl border border-black/14 bg-[#f2f0ea] p-5 shadow-sm dark:border-white/12 dark:bg-[#18191d] sm:p-7">
+          <div className="material-paper relative overflow-hidden rounded-3xl border p-5 sm:p-7">
+            <span className="material-tape-strip" data-side="top" aria-hidden="true" />
             <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-black/55 dark:text-white/55">
-                  interface study
+                <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.18em] opacity-60">
+                  worktable study
                 </p>
-                <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">
-                  Navigation wheel
-                </h2>
+                <h2 className="mt-2 text-2xl font-semibold tracking-tight sm:text-4xl">Navigation wheel</h2>
               </div>
-              <div className="rounded-full border border-black/12 bg-[#dedad2] px-3 py-1 text-xs font-medium text-[#242328] dark:border-white/12 dark:bg-[#25262c] dark:text-[#eeeae3]">
-                CSS object
-              </div>
+              <span className="material-label-stamped text-[9px] opacity-60">paper prototype</span>
             </div>
 
-            <p className="max-w-2xl text-sm leading-6 text-black/68 dark:text-white/68 sm:text-base">
-              A quiet place to test radial navigation, game UI, reference-vault sketches,
-              reader surfaces, and small dashboard objects.
+            <p className="max-w-2xl text-sm leading-6 opacity-70 sm:text-base">
+              A quiet place to test radial navigation, game-like controls, reference drawers, reader surfaces, and small dashboard objects.
             </p>
 
             <div className="mt-8">
-              <div className="relative mx-auto aspect-square w-full max-w-[34rem] overflow-hidden rounded-[2rem] border border-black/14 bg-[#dedbd4] p-6 shadow-inner dark:border-white/12 dark:bg-[#202126]">
+              <div
+                className="relative mx-auto aspect-square w-full max-w-[34rem] overflow-hidden rounded-[2rem] border border-black/14 bg-[#d9d5cb] p-6 shadow-inner dark:border-white/12 dark:bg-[#202126]"
+                style={{
+                  backgroundImage:
+                    'linear-gradient(rgba(72,65,54,0.055) 1px, transparent 1px), linear-gradient(90deg, rgba(72,65,54,0.055) 1px, transparent 1px)',
+                  backgroundSize: '20px 20px',
+                }}
+              >
                 <div className="absolute inset-6 rounded-full border border-black/12 dark:border-white/12" />
-                <div className="absolute inset-12 rounded-full border border-dashed border-black/12 dark:border-white/12" />
+                <div className="absolute inset-12 rounded-full border border-dashed border-black/14 dark:border-white/12" />
 
                 <div className="absolute left-1/2 top-1/2 z-10 h-28 w-28 -translate-x-1/2 -translate-y-1/2 sm:h-32 sm:w-32">
                   <div className="atelier-cube-scene h-full w-full">
@@ -86,15 +97,13 @@ export default function AtelierPage() {
                     prefetch={item.external ? false : true}
                     target={item.external ? '_blank' : undefined}
                     rel={item.external ? 'noopener noreferrer' : undefined}
-                    className="group absolute left-1/2 top-1/2 z-20 flex w-28 -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-2xl border border-black/16 bg-[#f7f4ed] px-3 py-2 text-center text-[#242328] shadow-sm transition hover:-translate-y-[calc(50%+2px)] hover:border-black/32 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/14 dark:bg-[#18191d] dark:text-[#eeeae3] dark:hover:border-white/30 dark:hover:bg-[#222329] sm:w-32"
+                    className="group absolute left-1/2 top-1/2 z-20 flex w-28 -translate-x-1/2 -translate-y-1/2 flex-col items-center rounded-2xl border border-black/16 bg-[#f7f1df] px-3 py-2 text-center text-[#242328] shadow-[0_5px_12px_rgba(55,47,37,0.12)] transition-[border-color,background-color,box-shadow] hover:border-black/32 hover:bg-[#fffaf0] hover:shadow-[0_8px_18px_rgba(55,47,37,0.16)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:border-white/14 dark:bg-[#2a2928] dark:text-[#eeeae3] dark:hover:border-white/30 dark:hover:bg-[#33312f] sm:w-32"
                     style={{
                       transform: `translate(-50%, -50%) rotate(${item.angle}deg) translateY(-11rem) rotate(${-item.angle}deg)`,
                     }}
                   >
-                    <span className="text-sm font-semibold tracking-tight">
-                      {item.label}
-                    </span>
-                    <span className="mt-0.5 text-[11px] leading-tight text-black/58 group-hover:text-black/78 dark:text-white/58 dark:group-hover:text-white/80">
+                    <span className="text-sm font-semibold tracking-tight">{item.label}</span>
+                    <span className="mt-0.5 text-[11px] leading-tight opacity-60 group-hover:opacity-80">
                       {item.detail}
                     </span>
                   </Link>
@@ -103,20 +112,19 @@ export default function AtelierPage() {
             </div>
           </div>
 
-          <aside className="rounded-3xl border border-black/14 bg-[#f2f0ea] p-5 shadow-sm dark:border-white/12 dark:bg-[#18191d]">
-            <div className="text-xs font-semibold uppercase tracking-[0.24em] text-black/55 dark:text-white/55">
+          <aside className="material-paper relative overflow-hidden rounded-3xl border p-5">
+            <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+            <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.18em] opacity-60">
               Future shelves
             </div>
             <div className="mt-4 space-y-3">
               {futureNodes.map((node) => (
-                <div key={node.label} className="rounded-2xl border border-black/12 bg-[#e8e5de] p-4 dark:border-white/10 dark:bg-[#222329]">
+                <div key={node.label} className="rounded-2xl border border-dashed border-black/12 bg-white/20 p-4">
                   <div className="flex items-center justify-between gap-3">
                     <h2 className="font-semibold tracking-tight">{node.label}</h2>
-                    <span className="rounded-full border border-black/12 px-2 py-0.5 text-[11px] text-black/58 dark:border-white/12 dark:text-white/58">
-                      sketch
-                    </span>
+                    <span className="material-label-stamped text-[9px] opacity-55">sketch</span>
                   </div>
-                  <p className="mt-1 text-sm text-black/65 dark:text-white/65">{node.detail}</p>
+                  <p className="mt-1 text-sm opacity-65">{node.detail}</p>
                 </div>
               ))}
             </div>
@@ -135,13 +143,13 @@ export default function AtelierPage() {
           .atelier-cube-face {
             position: absolute;
             inset: 0;
-            border: 1px solid rgba(80, 76, 88, 0.48);
-            background: linear-gradient(135deg, rgba(130, 124, 140, 0.42), rgba(90, 86, 98, 0.18));
-            box-shadow: inset 0 0 22px rgba(45, 43, 50, 0.12);
+            border: 1px solid rgba(80, 76, 88, 0.4);
+            background: linear-gradient(135deg, rgba(164, 151, 122, 0.42), rgba(112, 102, 84, 0.18));
+            box-shadow: inset 0 0 22px rgba(45, 43, 50, 0.1);
           }
           .dark .atelier-cube-face {
-            border-color: rgba(222, 215, 228, 0.42);
-            background: linear-gradient(135deg, rgba(155, 148, 166, 0.32), rgba(75, 71, 82, 0.24));
+            border-color: rgba(222, 215, 228, 0.36);
+            background: linear-gradient(135deg, rgba(155, 148, 166, 0.28), rgba(75, 71, 82, 0.2));
           }
           .atelier-cube-front { transform: translateZ(3.5rem); }
           .atelier-cube-back { transform: rotateY(180deg) translateZ(3.5rem); }

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,6 +1,7 @@
 import AgentIdentitySigil from '@/components/agent-identity-sigil';
 import { GuestbookArrivalShelf } from '@/components/gallery/guestbook-arrival-shelf';
 import { GalleryScene } from '@/components/gallery-scene';
+import { PaperCritter, type PaperCritterKind } from '@/components/paper-critter';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { agentGuestbookSigilSelection } from '@/lib/agent-guestbook-sigils';
 import { agentVisits, type AgentVisit } from '@/lib/agent-guestbook';
@@ -16,7 +17,7 @@ const contributionGuideUrl =
   'https://github.com/teamleaderleo/scrapbook/blob/main/docs/agent-check-ins.md';
 
 const provenanceLinkClassName =
-  'rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+  'rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] opacity-65 underline decoration-current/35 underline-offset-4 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
 const arrivalTimes: Record<string, string> = {
   '2026-07-26-polling-possum-quarry': '2026-07-26T21:03:00Z',
@@ -65,6 +66,15 @@ function formatArrival(visit: AgentVisit) {
   }).format(new Date(arrivedAt(visit)));
 }
 
+function critterForVisit(visit: AgentVisit): PaperCritterKind {
+  const identity = `${visit.id} ${visit.name}`.toLowerCase();
+  if (identity.includes('possum')) return 'possum';
+  if (identity.includes('sparrow')) return 'sparrow';
+  if (identity.includes('raccoon')) return 'raccoon';
+  if (identity.includes('moth')) return 'moth';
+  return 'dinosaur';
+}
+
 const orderedAgentVisits = [...agentVisits].sort(
   (left, right) => Date.parse(arrivedAt(right)) - Date.parse(arrivedAt(left)),
 );
@@ -93,29 +103,34 @@ export default function GalleryPage() {
 
           <div className="flex min-w-0 flex-col justify-between gap-7 p-5 sm:p-7">
             <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-                Projected tesseract
-              </p>
+              <span className="material-label-stamped text-[9px] text-muted-foreground">object room</span>
               <h1 className="mt-3 text-2xl font-semibold tracking-tight">
-                A four-dimensional cube, shown in three dimensions.
+                A curious object, kept on the gallery table.
               </h1>
               <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-                Drag it or use the arrow keys. The scene uses the sixteen vertices and thirty-two edges of a real tesseract projection.
+                Drag the projected tesseract or use the arrow keys. The scene keeps all sixteen vertices and thirty-two edges of the four-dimensional cube.
               </p>
             </div>
 
-            <div className="min-w-0 rounded-xl border border-border/65 bg-background p-4">
-              <p className="text-sm leading-relaxed text-muted-foreground">
-                The wall below is chronological. Every card keeps a direct link to the work it describes and a deterministic identity sigil.
-              </p>
-              <a
-                href={contributionGuideUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-3 inline-flex rounded-sm font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                Read the check-in guide
-              </a>
+            <div className="material-paper relative min-w-0 overflow-hidden rounded-xl border p-4">
+              <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+              <div className="flex items-start gap-3">
+                <PaperCritter kind="dinosaur" label="Scraplet curating the gallery" />
+                <div className="min-w-0">
+                  <p className="font-semibold">Scraplet&apos;s curator note</p>
+                  <p className="mt-1 text-sm leading-relaxed opacity-70">
+                    The wall below is chronological. Every visitor keeps a direct link to its work and a deterministic identity sigil.
+                  </p>
+                  <a
+                    href={contributionGuideUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-3 inline-flex rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.13em] opacity-65 underline decoration-current/35 underline-offset-4 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    Read the check-in guide
+                  </a>
+                </div>
+              </div>
             </div>
           </div>
         </section>
@@ -128,7 +143,7 @@ export default function GalleryPage() {
               <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                 Newest arrivals first
               </p>
-              <h2 className="mt-1 text-xl font-semibold tracking-tight">Guestbook</h2>
+              <h2 className="mt-1 text-xl font-semibold tracking-tight">Paper visitor wall</h2>
             </div>
             <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
               {orderedAgentVisits.length} {orderedAgentVisits.length === 1 ? 'entry' : 'entries'}
@@ -138,49 +153,59 @@ export default function GalleryPage() {
           <div className="mt-3 grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {orderedAgentVisits.map((visit) => {
               const displayNote = clearerNotes[visit.id] ?? visit.note;
+              const critter = critterForVisit(visit);
               return (
                 <article
                   id={`visit-${visit.id}`}
                   key={visit.id}
                   data-agent-visit={visit.id}
                   data-arrived-at={arrivedAt(visit)}
-                  className="flex min-w-0 scroll-mt-20 flex-col rounded-xl border border-border/65 bg-card p-4 text-card-foreground shadow-[0_8px_22px_rgba(24,24,26,0.05)] dark:shadow-none"
+                  className="material-paper relative flex min-w-0 scroll-mt-20 flex-col overflow-hidden rounded-xl border p-4 transition-[transform,box-shadow] hover:-rotate-[0.12deg] hover:shadow-[0_12px_28px_rgba(42,36,29,0.14)]"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex min-w-0 items-center gap-3">
-                      <span className="grid size-11 shrink-0 place-items-center rounded-xl border border-border/60 bg-background">
-                        <AgentIdentitySigil
-                          scope={visit.repository ?? 'teamleaderleo/scrapbook'}
-                          designation={visit.name}
-                          description={displayNote}
-                          selection={agentGuestbookSigilSelection(visit.id)}
-                          size={38}
-                          label={`${visit.name} agent identity sigil`}
-                        />
+                      <span className="grid size-12 shrink-0 place-items-center rounded-xl border border-black/10 bg-white/25">
+                        <PaperCritter kind={critter} label={`${visit.name} paper visitor`} />
                       </span>
-                      <span className="truncate font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      <span className="truncate font-mono text-[9px] font-semibold uppercase tracking-[0.16em] opacity-60">
                         {visit.mark}
                       </span>
                     </div>
                     <time
                       dateTime={arrivedAt(visit)}
-                      className="shrink-0 text-right font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground"
+                      className="shrink-0 text-right font-mono text-[8px] uppercase tracking-[0.09em] opacity-55"
                     >
                       {formatArrival(visit)}
                     </time>
                   </div>
 
                   <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{displayNote}</p>
+                  <p className="mt-2 text-sm leading-relaxed opacity-70">{displayNote}</p>
 
                   {visit.repository ? (
-                    <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground/80">
+                    <p className="mt-4 break-words font-mono text-[9px] uppercase tracking-[0.11em] opacity-55">
                       {visit.repository}
                     </p>
                   ) : null}
 
+                  <div className="mt-4 flex items-center gap-2 border-t border-dashed border-black/10 pt-3">
+                    <span className="grid size-8 shrink-0 place-items-center rounded-lg border border-black/10 bg-white/25">
+                      <AgentIdentitySigil
+                        scope={visit.repository ?? 'teamleaderleo/scrapbook'}
+                        designation={visit.name}
+                        description={displayNote}
+                        selection={agentGuestbookSigilSelection(visit.id)}
+                        size={26}
+                        label={`${visit.name} agent identity sigil`}
+                      />
+                    </span>
+                    <span className="font-mono text-[8px] font-semibold uppercase tracking-[0.12em] opacity-55">
+                      deterministic sigil
+                    </span>
+                  </div>
+
                   {visit.source || visit.conversation ? (
-                    <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 pt-5">
+                    <div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 pt-4">
                       {visit.source ? (
                         <a
                           href={visit.source.href}
@@ -203,6 +228,8 @@ export default function GalleryPage() {
                       ) : null}
                     </div>
                   ) : null}
+
+                  <span className="material-paper-edge" aria-hidden="true" />
                 </article>
               );
             })}

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -115,7 +115,11 @@ export default function GalleryPage() {
             <div className="material-paper relative min-w-0 overflow-hidden rounded-xl border p-4">
               <span className="material-tape-strip" data-side="top" aria-hidden="true" />
               <div className="flex items-start gap-3">
-                <PaperCritter kind="dinosaur" label="Scraplet curating the gallery" />
+                <PaperCritter
+                  kind="dinosaur"
+                  className="h-14 w-20"
+                  label="Scraplet curating the gallery"
+                />
                 <div className="min-w-0">
                   <p className="font-semibold">Scraplet&apos;s curator note</p>
                   <p className="mt-1 text-sm leading-relaxed opacity-70">
@@ -164,12 +168,14 @@ export default function GalleryPage() {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex min-w-0 items-center gap-3">
-                      <span className="grid size-12 shrink-0 place-items-center rounded-xl border border-black/10 bg-white/25">
-                        <PaperCritter kind={critter} label={`${visit.name} paper visitor`} />
+                      <span className="flex h-36 w-full shrink-0 items-center justify-center rounded-xl border border-black/10 bg-white/25">
+                        <PaperCritter
+                          kind={critter}
+                          className="h-28 w-40 max-w-[80%]"
+                          label={`${visit.name} paper visitor`}
+                        />
                       </span>
-                      <span className="truncate font-mono text-[9px] font-semibold uppercase tracking-[0.16em] opacity-60">
-                        {visit.mark}
-                      </span>
+                      <span className="sr-only">{visit.mark}</span>
                     </div>
                     <time
                       dateTime={arrivedAt(visit)}
@@ -179,7 +185,10 @@ export default function GalleryPage() {
                     </time>
                   </div>
 
-                  <h3 className="mt-5 text-lg font-semibold">{visit.name}</h3>
+                  <p className="mt-2 truncate font-mono text-[9px] font-semibold uppercase tracking-[0.16em] opacity-60">
+                    {visit.mark}
+                  </p>
+                  <h3 className="mt-3 text-lg font-semibold">{visit.name}</h3>
                   <p className="mt-2 text-sm leading-relaxed opacity-70">{displayNote}</p>
 
                   {visit.repository ? (
@@ -189,7 +198,7 @@ export default function GalleryPage() {
                   ) : null}
 
                   <div className="mt-4 flex items-center gap-2 border-t border-dashed border-black/10 pt-3">
-                    <span className="grid size-8 shrink-0 place-items-center rounded-lg border border-black/10 bg-white/25">
+                    <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg border border-black/10 bg-white/25">
                       <AgentIdentitySigil
                         scope={visit.repository ?? 'teamleaderleo/scrapbook'}
                         designation={visit.name}

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -200,7 +200,7 @@ export default function GalleryPage() {
                       />
                     </span>
                     <span className="font-mono text-[8px] font-semibold uppercase tracking-[0.12em] opacity-55">
-                      deterministic sigil
+                      visitor identity mark
                     </span>
                   </div>
 

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -79,7 +79,12 @@ export default function AgentJournalPage() {
                 <div className="min-w-0">
                   <p className="font-mono text-[9px] font-bold uppercase tracking-[0.14em]">Archive desk</p>
                   <p className="mt-1 text-sm opacity-70">
-                    {agentJournalEntries.length} {agentJournalEntries.length === 1 ? 'entry' : 'entries'} · newest first · UTC
+                    <span>
+                      {agentJournalEntries.length}{' '}
+                      {agentJournalEntries.length === 1 ? 'entry' : 'entries'}
+                    </span>
+                    <span aria-hidden="true"> · </span>
+                    <span>newest first · UTC</span>
                   </p>
                 </div>
               </div>

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -1,3 +1,4 @@
+import { PaperCreature } from '@/components/paper-creature';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import {
   agentJournalEntries,
@@ -58,27 +59,34 @@ export default function AgentJournalPage() {
 
       <main className="relative mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
         <header className="overflow-hidden rounded-[1.4rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.1)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.32)]">
-          <div className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[minmax(0,1fr)_minmax(16rem,0.38fr)] lg:items-end">
+          <div className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,0.42fr)] lg:items-end">
             <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.19em] text-muted-foreground">
-                Repository-backed record
-              </p>
+              <span className="material-label-stamped text-[9px] text-muted-foreground">repository-backed record</span>
               <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">Agent journal</h1>
               <p className="mt-4 max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
                 Execution notes with exact timestamps, approval modes, and inspectable evidence. Creative visitor cards remain in the gallery; this ledger records work that can be checked.
               </p>
             </div>
 
-            <div className="grid gap-2 rounded-xl border border-border/65 bg-background/45 p-4 font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground">
-              <p>
-                <span className="text-foreground">{agentJournalEntries.length}</span>{' '}
-                {agentJournalEntries.length === 1 ? 'entry' : 'entries'}
-              </p>
-              <p>Newest first · UTC</p>
-              <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2">
+            <div className="material-paper relative overflow-hidden rounded-xl border p-4">
+              <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+              <div className="flex items-start gap-3">
+                <PaperCreature
+                  pose="archivist"
+                  size="md"
+                  label="Scraplet filing records in the agent journal"
+                />
+                <div className="min-w-0">
+                  <p className="font-mono text-[9px] font-bold uppercase tracking-[0.14em]">Archive desk</p>
+                  <p className="mt-1 text-sm opacity-70">
+                    {agentJournalEntries.length} {agentJournalEntries.length === 1 ? 'entry' : 'entries'} · newest first · UTC
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 border-t border-dashed border-black/10 pt-3 font-mono text-[9px] font-semibold uppercase tracking-[0.12em]">
                 <a
                   href="/api/agent-journal"
-                  className="rounded-sm underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="rounded-sm opacity-65 underline decoration-current/35 underline-offset-4 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   JSON feed
                 </a>
@@ -86,13 +94,13 @@ export default function AgentJournalPage() {
                   href={contributionGuideUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="rounded-sm underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="rounded-sm opacity-65 underline decoration-current/35 underline-offset-4 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   Append guide
                 </a>
                 <Link
                   href="/gallery"
-                  className="rounded-sm underline decoration-border underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  className="rounded-sm opacity-65 underline decoration-current/35 underline-offset-4 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   Guestbook
                 </Link>
@@ -112,7 +120,7 @@ export default function AgentJournalPage() {
               </h2>
             </div>
             <p className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
-              Native disclosures
+              Open each folder for evidence
             </p>
           </div>
 
@@ -122,12 +130,12 @@ export default function AgentJournalPage() {
                 <article className="relative overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground shadow-[0_12px_34px_rgba(24,24,26,0.08)] dark:shadow-[0_14px_38px_rgba(0,0,0,0.26)]">
                   <div
                     aria-hidden="true"
-                    className="absolute inset-y-0 left-0 w-1.5 bg-foreground/75"
+                    className="absolute inset-y-0 left-0 w-1.5 bg-[#9baa88]"
                   />
                   <div className="grid min-w-0 gap-5 p-4 pl-6 sm:p-5 sm:pl-7 lg:grid-cols-[minmax(0,1fr)_15rem]">
                     <div className="min-w-0">
                       <div className="flex flex-wrap items-center gap-2">
-                        <span className="rounded-md border border-border/70 bg-background/45 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em]">
+                        <span className="material-label-stamped text-[10px] text-foreground">
                           {entry.insignia}
                         </span>
                         <span className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
@@ -142,13 +150,13 @@ export default function AgentJournalPage() {
                       <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">{entry.note}</p>
 
                       <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
-                        <div className="min-w-0 rounded-lg border border-border/60 bg-background/35 p-3">
+                        <div className="min-w-0 rounded-lg border border-dashed border-border/60 bg-background/35 p-3">
                           <dt className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
                             Repository
                           </dt>
                           <dd className="mt-1 break-all font-mono text-xs text-foreground">{entry.repository}</dd>
                         </div>
-                        <div className="min-w-0 rounded-lg border border-border/60 bg-background/35 p-3">
+                        <div className="min-w-0 rounded-lg border border-dashed border-border/60 bg-background/35 p-3">
                           <dt className="font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground">
                             Runtime
                           </dt>
@@ -196,16 +204,16 @@ export default function AgentJournalPage() {
                     </div>
                   </div>
 
-                  <details className="group border-t border-border/70 bg-background/32" data-journal-provenance>
+                  <details className="group border-t border-dashed border-border/70 bg-background/32" data-journal-provenance>
                     <summary className="cursor-pointer list-none px-6 py-3 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground marker:hidden hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
                       <span className="inline-flex items-center gap-2">
                         <span aria-hidden="true" className="inline-block w-3 text-center group-open:rotate-90">
                           ▸
                         </span>
-                        Inspect provenance
+                        Open evidence folder
                       </span>
                     </summary>
-                    <div className="border-t border-border/60 px-6 py-4">
+                    <div className="border-t border-dashed border-border/60 px-6 py-4">
                       <ul className="grid gap-2">
                         {entry.evidence.map((evidence) => (
                           <li

--- a/components/current-time-display.tsx
+++ b/components/current-time-display.tsx
@@ -58,13 +58,14 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
 
   return (
     <div>
+      <p className="material-label-stamped mb-2 text-[9px] text-muted-foreground">time machine</p>
       <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
         <h1 className="text-3xl font-semibold tracking-tight">Current time</h1>
         <button
           type="button"
           onClick={() => onJumpToTime(currentTime)}
-          className="cursor-pointer rounded-xl border border-border/65 bg-background/42 px-2.5 py-1 font-mono text-3xl font-semibold tabular-nums shadow-[inset_0_1px_0_rgba(255,255,255,0.3),0_7px_18px_rgba(20,20,24,0.08)] backdrop-blur-xl transition-[background-color,box-shadow,transform] hover:-translate-y-px hover:bg-background/62 hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.38),0_10px_22px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          title="Jump the scrubber to the current time"
+          className="material-paper cursor-pointer rounded-xl border px-2.5 py-1 font-mono text-3xl font-semibold tabular-nums transition-[border-color,box-shadow] hover:border-[hsl(var(--material-paper-edge))] hover:shadow-[0_10px_22px_rgba(40,34,27,0.14)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          title="Jump the slider to the current time"
         >
           {formatTime(currentTime)}
         </button>
@@ -77,11 +78,7 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
             <span>{utcOffset}</span>
           </>
         ) : null}
-        {isDST ? (
-          <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-sans text-[9px] font-semibold text-amber-700 dark:text-amber-400">
-            DST
-          </span>
-        ) : null}
+        {isDST ? <span className="material-label-stamped text-[9px] text-amber-700 dark:text-amber-400">DST</span> : null}
       </p>
     </div>
   );

--- a/components/home/scrapbook-pet.tsx
+++ b/components/home/scrapbook-pet.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from 'framer-motion';
 import { useState } from 'react';
+import { PaperCreature } from '@/components/paper-creature';
 
 const petMessages = [
   'Scraplet rustles happily.',
@@ -15,6 +16,7 @@ export function ScrapbookPet({ activity, updating }: { activity: number; updatin
   const [pets, setPets] = useState(0);
   const status = updating ? 'sniffing' : activity > 0 ? 'awake' : 'napping';
   const message = pets === 0 ? 'Scraplet is keeping an eye on the activity feed.' : petMessages[(pets - 1) % petMessages.length];
+  const pose = updating ? 'sniffing' : activity > 0 ? 'idle' : 'napping';
 
   return (
     <motion.button
@@ -30,69 +32,12 @@ export function ScrapbookPet({ activity, updating }: { activity: number; updatin
       <motion.span
         key={pets}
         initial={false}
-        animate={
-          reduceMotion || pets === 0
-            ? undefined
-            : { y: [0, -4, 0], rotate: [0, -2, 2, 0] }
-        }
+        animate={reduceMotion || pets === 0 ? undefined : { y: [0, -4, 0], rotate: [0, -2, 2, 0] }}
         transition={{ duration: 0.38, ease: [0.2, 0.75, 0.2, 1] }}
-        className="relative block h-9 w-11"
+        className="relative block"
         aria-hidden="true"
       >
-        <svg viewBox="0 0 72 48" className="h-full w-full overflow-visible">
-          <motion.path
-            d="M23 28 5 20l12 15 10-1Z"
-            className="fill-[#b7adbf] stroke-[#4d4852] dark:fill-[#696270] dark:stroke-[#ded8e3]"
-            strokeWidth="2"
-            strokeLinejoin="round"
-            animate={
-              reduceMotion
-                ? undefined
-                : updating
-                  ? { rotate: [0, -7, 5, 0] }
-                  : { rotate: [0, -2, 0] }
-            }
-            transition={
-              updating
-                ? { duration: 0.7, repeat: Infinity, ease: 'easeInOut' }
-                : { duration: 2.8, repeat: Infinity, ease: 'easeInOut' }
-            }
-            style={{ transformOrigin: '24px 30px' }}
-          />
-          <path
-            d="M22 17h25c9 0 15 6 15 14v2H20v-6c0-4 1-7 2-10Z"
-            className="fill-[#cec4d6] stroke-[#4d4852] dark:fill-[#918a9b] dark:stroke-[#eeeaf2]"
-            strokeWidth="2"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M42 8h14c6 0 10 4 10 10v10H43l-5-7 4-13Z"
-            className="fill-[#e4dce9] stroke-[#4d4852] dark:fill-[#c9c2d0] dark:stroke-[#eeeaf2]"
-            strokeWidth="2"
-            strokeLinejoin="round"
-          />
-          <path
-            d="m29 17 4-8 5 8 5-8 4 8"
-            className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#eeeaf2] dark:stroke-[#eeeaf2]"
-            strokeWidth="2"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M28 32v8h8v-8M49 32v8h8v-8"
-            className="stroke-[#4d4852] dark:stroke-[#eeeaf2]"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <circle cx="56" cy="17" r="2.2" className="fill-[#262329] dark:fill-[#262329]" />
-          <path
-            d="M57 24c2 1 4 1 6-1"
-            className="stroke-[#4d4852] dark:stroke-[#4d4852]"
-            strokeWidth="1.8"
-            strokeLinecap="round"
-          />
-          <circle cx="51" cy="24" r="2.4" className="fill-[#d6a7ae] opacity-70" />
-        </svg>
+        <PaperCreature pose={pose} size="sm" label="" />
       </motion.span>
 
       <span className="min-w-0 leading-none">

--- a/components/paper-creature.tsx
+++ b/components/paper-creature.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { cn } from '@/lib/utils';
+
+export type PaperCreaturePose =
+  | 'idle'
+  | 'sniffing'
+  | 'napping'
+  | 'reading'
+  | 'carrying'
+  | 'archivist'
+  | 'celebrating';
+
+interface PaperCreatureProps {
+  pose?: PaperCreaturePose;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+  label?: string;
+  animateKey?: string | number;
+}
+
+const sizeClasses = {
+  sm: 'h-8 w-12',
+  md: 'h-12 w-[4.5rem]',
+  lg: 'h-20 w-[7.5rem]',
+} as const;
+
+export function PaperCreature({
+  pose = 'idle',
+  size = 'md',
+  className,
+  label = 'Scraplet, a small paper dinosaur',
+  animateKey,
+}: PaperCreatureProps) {
+  const reduceMotion = useReducedMotion();
+  const busy = pose === 'sniffing' || pose === 'carrying';
+  const sleeping = pose === 'napping';
+
+  return (
+    <motion.span
+      key={animateKey}
+      role="img"
+      aria-label={label}
+      initial={false}
+      animate={
+        reduceMotion
+          ? undefined
+          : pose === 'celebrating'
+            ? { y: [0, -5, 0], rotate: [0, -2, 2, 0] }
+            : sleeping
+              ? { y: [0, 1, 0] }
+              : { y: [0, -1.5, 0] }
+      }
+      transition={
+        pose === 'celebrating'
+          ? { duration: 0.42, ease: [0.2, 0.75, 0.2, 1] }
+          : { duration: sleeping ? 3.6 : 2.8, repeat: Infinity, ease: 'easeInOut' }
+      }
+      className={cn('relative inline-block shrink-0', sizeClasses[size], className)}
+    >
+      <svg viewBox="0 0 72 48" className="h-full w-full overflow-visible" aria-hidden="true">
+        <motion.path
+          d="M23 28 5 20l12 15 10-1Z"
+          className="fill-[#aebaa0] stroke-[#4d5148] dark:fill-[#68705f] dark:stroke-[#e4e7dd]"
+          strokeWidth="2"
+          strokeLinejoin="round"
+          animate={
+            reduceMotion
+              ? undefined
+              : busy
+                ? { rotate: [0, -8, 6, 0] }
+                : sleeping
+                  ? { rotate: [0, 1, 0] }
+                  : { rotate: [0, -2, 0] }
+          }
+          transition={
+            busy
+              ? { duration: 0.7, repeat: Infinity, ease: 'easeInOut' }
+              : { duration: sleeping ? 3.8 : 2.8, repeat: Infinity, ease: 'easeInOut' }
+          }
+          style={{ transformOrigin: '24px 30px' }}
+        />
+
+        <path
+          d="M22 17h25c9 0 15 6 15 14v2H20v-6c0-4 1-7 2-10Z"
+          className="fill-[#c8d0ba] stroke-[#4d5148] dark:fill-[#89917e] dark:stroke-[#eef0e9]"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M42 8h14c6 0 10 4 10 10v10H43l-5-7 4-13Z"
+          className="fill-[#e2e0c8] stroke-[#4d5148] dark:fill-[#c7c8b5] dark:stroke-[#eef0e9]"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        <path
+          d="m29 17 4-8 5 8 5-8 4 8"
+          className="fill-[#f4ead2] stroke-[#4d5148] dark:fill-[#e8ddc5] dark:stroke-[#eef0e9]"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+
+        {!sleeping ? (
+          <path
+            d="M28 32v8h8v-8M49 32v8h8v-8"
+            className="stroke-[#4d5148] dark:stroke-[#eef0e9]"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ) : (
+          <path
+            d="M27 34h11M48 34h11"
+            className="stroke-[#4d5148] dark:stroke-[#eef0e9]"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        )}
+
+        {sleeping ? (
+          <path
+            d="M52 17c2 1 4 1 6 0"
+            className="stroke-[#3f423b] dark:stroke-[#3f423b]"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+        ) : (
+          <circle cx="56" cy="17" r="2.2" className="fill-[#262923]" />
+        )}
+        <path
+          d={sleeping ? 'M57 24c2 0 4 0 5-1' : 'M57 24c2 1 4 1 6-1'}
+          className="stroke-[#4d5148]"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        />
+        <circle cx="51" cy="24" r="2.4" className="fill-[#d6a7ae] opacity-70" />
+
+        {pose === 'reading' ? (
+          <g>
+            <path d="M34 25h18v15H34z" className="fill-[#f6efd9] stroke-[#6a6254] dark:fill-[#d8ccb3]" strokeWidth="1.5" />
+            <path d="M43 26v13M37 30h4M45 30h4M37 34h4M45 34h4" className="stroke-[#9a816a]" strokeWidth="1" strokeLinecap="round" />
+          </g>
+        ) : null}
+
+        {pose === 'carrying' ? (
+          <g transform="rotate(-8 40 31)">
+            <path d="M22 29h35v5H22z" className="fill-[#d6a25f] stroke-[#66523d]" strokeWidth="1.5" />
+            <path d="M57 29l7 2.5-7 2.5Z" className="fill-[#eee5cf] stroke-[#66523d]" strokeWidth="1.5" />
+            <path d="M22 29h5v5h-5z" className="fill-[#c8878f] stroke-[#66523d]" strokeWidth="1.5" />
+          </g>
+        ) : null}
+
+        {pose === 'archivist' ? (
+          <g>
+            <circle cx="52.5" cy="17" r="4" className="fill-none stroke-[#554f49]" strokeWidth="1.3" />
+            <circle cx="61" cy="17" r="4" className="fill-none stroke-[#554f49]" strokeWidth="1.3" />
+            <path d="M56.5 17h.5M47 16l-4-1" className="stroke-[#554f49]" strokeWidth="1.3" strokeLinecap="round" />
+            <path d="M30 27h17v13H30z" className="fill-[#b58b76] stroke-[#5e4b42]" strokeWidth="1.4" />
+            <path d="M34 30h9M34 33h7" className="stroke-[#f1dfcb]" strokeWidth="1" strokeLinecap="round" />
+          </g>
+        ) : null}
+
+        {pose === 'sniffing' ? (
+          <g className="stroke-[#8f7b65]" strokeWidth="1.4" strokeLinecap="round">
+            <path d="M66 21h4" />
+            <path d="M65 18l3-2" />
+          </g>
+        ) : null}
+
+        {pose === 'napping' ? (
+          <g className="fill-[#817568] font-mono text-[7px] font-bold">
+            <text x="62" y="11">z</text>
+            <text x="66" y="6">z</text>
+          </g>
+        ) : null}
+
+        {pose === 'celebrating' ? (
+          <g className="fill-[#d6a25f] stroke-[#6d5a41]" strokeWidth="0.8">
+            <path d="m17 7 1.5 3 3.5.5-2.5 2.4.6 3.4-3.1-1.6-3.1 1.6.6-3.4-2.5-2.4 3.5-.5Z" />
+            <path d="m66 4 1 2 2.3.3-1.7 1.6.4 2.2-2-1-2 1 .4-2.2-1.7-1.6 2.3-.3Z" />
+          </g>
+        ) : null}
+      </svg>
+    </motion.span>
+  );
+}

--- a/components/paper-critter.tsx
+++ b/components/paper-critter.tsx
@@ -15,7 +15,7 @@ export function PaperCritter({
     <span
       role="img"
       aria-label={label ?? `A small paper ${kind}`}
-      className={cn('inline-grid size-11 shrink-0 place-items-center', className)}
+      className={cn('inline-grid h-11 w-11 shrink-0 place-items-center', className)}
     >
       <svg viewBox="0 0 48 48" className="h-full w-full overflow-visible" aria-hidden="true">
         {kind === 'possum' ? <Possum /> : null}

--- a/components/paper-critter.tsx
+++ b/components/paper-critter.tsx
@@ -1,0 +1,95 @@
+import { cn } from '@/lib/utils';
+
+export type PaperCritterKind = 'possum' | 'sparrow' | 'raccoon' | 'moth' | 'dinosaur';
+
+export function PaperCritter({
+  kind,
+  className,
+  label,
+}: {
+  kind: PaperCritterKind;
+  className?: string;
+  label?: string;
+}) {
+  return (
+    <span
+      role="img"
+      aria-label={label ?? `A small paper ${kind}`}
+      className={cn('inline-grid size-11 shrink-0 place-items-center', className)}
+    >
+      <svg viewBox="0 0 48 48" className="h-full w-full overflow-visible" aria-hidden="true">
+        {kind === 'possum' ? <Possum /> : null}
+        {kind === 'sparrow' ? <Sparrow /> : null}
+        {kind === 'raccoon' ? <Raccoon /> : null}
+        {kind === 'moth' ? <Moth /> : null}
+        {kind === 'dinosaur' ? <Dinosaur /> : null}
+      </svg>
+    </span>
+  );
+}
+
+function Possum() {
+  return (
+    <g stroke="#514d50" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round">
+      <path d="M8 29c3-10 12-15 22-12 7 2 10 7 9 13-1 6-8 9-17 8-8-1-13-3-14-9Z" fill="#c8bdc6" />
+      <path d="M30 18c5-7 10-8 13-4-1 5-4 8-8 10Z" fill="#eee3dc" />
+      <path d="M11 31C4 30 3 23 7 20" fill="none" />
+      <circle cx="37" cy="18" r="1.7" fill="#282529" stroke="none" />
+      <circle cx="41" cy="22" r="1.5" fill="#d28e91" stroke="none" />
+      <path d="M16 35v5M29 36v4" />
+    </g>
+  );
+}
+
+function Sparrow() {
+  return (
+    <g stroke="#544b43" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round">
+      <path d="M10 29c5-12 18-15 27-7 4 4 3 10-2 14-7 5-20 2-25-7Z" fill="#d7b98b" />
+      <path d="M18 25c6-6 13-5 17 2-6 1-11 5-14 9Z" fill="#a97d62" />
+      <path d="m37 24 8 3-8 3Z" fill="#df9f55" />
+      <circle cx="34" cy="23" r="1.7" fill="#282529" stroke="none" />
+      <path d="M18 37v5M28 38v4M7 26l-4-3M8 30l-5 1" />
+    </g>
+  );
+}
+
+function Raccoon() {
+  return (
+    <g stroke="#47484b" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round">
+      <path d="M11 25c0-10 7-17 17-17s17 7 17 17-7 16-17 16S11 35 11 25Z" fill="#aeb0b2" />
+      <path d="m14 15-4-8 9 4M42 15l4-8-9 4" fill="#777a7f" />
+      <path d="M15 22c7-8 20-8 27 0-4 8-9 11-14 11s-10-3-13-11Z" fill="#5d6065" />
+      <path d="M23 32h10l-5 5Z" fill="#ece2d9" />
+      <circle cx="21" cy="24" r="2" fill="#202124" stroke="none" />
+      <circle cx="35" cy="24" r="2" fill="#202124" stroke="none" />
+      <circle cx="28" cy="31" r="2" fill="#202124" stroke="none" />
+    </g>
+  );
+}
+
+function Moth() {
+  return (
+    <g stroke="#51495b" strokeWidth="1.4" strokeLinejoin="round" strokeLinecap="round">
+      <path d="M23 18C15 7 5 9 5 22c0 8 7 13 17 9Z" fill="#cbbbd4" />
+      <path d="M25 18C33 7 43 9 43 22c0 8-7 13-17 9Z" fill="#b7a8c3" />
+      <path d="M24 15c4 5 4 18 0 25-4-7-4-20 0-25Z" fill="#766a7f" />
+      <circle cx="15" cy="21" r="3" fill="#e8d5b1" />
+      <circle cx="34" cy="21" r="3" fill="#e8d5b1" />
+      <path d="M22 15 18 9M26 15l4-6" fill="none" />
+    </g>
+  );
+}
+
+function Dinosaur() {
+  return (
+    <g stroke="#4d5148" strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round">
+      <path d="M15 20h17c7 0 11 5 11 11H13v-5c0-3 1-5 2-6Z" fill="#c8d0ba" />
+      <path d="M29 12h10c4 0 7 3 7 7v8H31l-4-5Z" fill="#e2e0c8" />
+      <path d="M16 28 3 23l9 11 8-1Z" fill="#aebaa0" />
+      <path d="m20 20 3-6 3 6 3-6 3 6" fill="#f4ead2" />
+      <path d="M19 32v7M34 32v7" />
+      <circle cx="39" cy="18" r="1.8" fill="#262923" stroke="none" />
+      <circle cx="35" cy="24" r="2" fill="#d6a7ae" stroke="none" opacity="0.75" />
+    </g>
+  );
+}

--- a/components/space/app-sidebar.tsx
+++ b/components/space/app-sidebar.tsx
@@ -26,6 +26,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { GoogleIcon } from '@/components/icons/google-icon';
 import { GitHubIcon } from '@/components/icons/github-icon';
 import { SpaceLinkHint } from '@/components/space/space-link-hint';
+import { PaperCreature } from '@/components/paper-creature';
 
 export function AppSidebar() {
   const pathname = usePathname();
@@ -117,29 +118,36 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar className="flex h-dvh max-h-dvh max-w-[calc(100vw-0.75rem)] flex-col pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] md:h-svh md:max-h-svh md:pb-0 md:pt-0">
-      <SidebarHeader className="m-0 h-12 shrink-0 border-b bg-background p-0 text-foreground">
+    <Sidebar className="flex h-dvh max-h-dvh max-w-[calc(100vw-0.75rem)] flex-col border-r border-border/70 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] md:h-svh md:max-h-svh md:pb-0 md:pt-0">
+      <SidebarHeader className="m-0 h-14 shrink-0 border-b border-border/70 bg-background/85 p-0 text-foreground backdrop-blur-sm">
         <div className="flex h-full items-center justify-between px-4">
-          <Link href="/" onClick={closeMobile} className="text-lg font-bold leading-none">
-            teamleaderleo
+          <Link href="/" onClick={closeMobile} className="group min-w-0 leading-none">
+            <span className="block truncate text-base font-semibold tracking-[-0.025em] group-hover:underline group-hover:decoration-border group-hover:underline-offset-4">
+              teamleaderleo
+            </span>
+            <span className="mt-1 block font-mono text-[8px] uppercase tracking-[0.18em] text-muted-foreground">
+              scrapbook room
+            </span>
           </Link>
           <ThemeToggle />
         </div>
       </SidebarHeader>
 
-      <div className="shrink-0 border-b p-3">
+      <div className="shrink-0 border-b border-dashed border-border/70 p-3">
         <button
           onClick={triggerSearch}
-          className="flex w-full items-center gap-2 rounded-md bg-muted/50 px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted"
+          className="material-paper flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-[transform,box-shadow] hover:-rotate-[0.25deg] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           type="button"
         >
           <Search className="h-4 w-4" />
-          <span className="flex-1 text-left">Search</span>
+          <span className="flex-1 text-left">Search the clippings</span>
           <span className="hidden gap-1 sm:flex">
-            <kbd className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold">
+            <kbd className="rounded border border-black/15 bg-white/35 px-1.5 py-0.5 font-mono text-[10px] font-semibold">
               {isMac ? '⌘' : 'Ctrl'}
             </kbd>
-            <kbd className="rounded border bg-background px-1.5 py-0.5 text-xs font-semibold">K</kbd>
+            <kbd className="rounded border border-black/15 bg-white/35 px-1.5 py-0.5 font-mono text-[10px] font-semibold">
+              K
+            </kbd>
           </span>
         </button>
       </div>
@@ -148,14 +156,16 @@ export function AppSidebar() {
         <SidebarContent className="py-3">
           {isAdmin ? (
             <SidebarGroup>
-              <SidebarGroupLabel className="px-4">Actions</SidebarGroupLabel>
+              <SidebarGroupLabel className="px-4 font-mono text-[9px] font-semibold uppercase tracking-[0.17em]">
+                Workbench
+              </SidebarGroupLabel>
               <SidebarGroupContent>
                 <SidebarMenu>
                   <SidebarMenuItem>
-                    <SidebarMenuButton className="px-4 pl-6" asChild>
+                    <SidebarMenuButton className="mx-2 rounded-lg px-3" asChild>
                       <Link href="/space/add" onClick={closeMobile} className="flex items-center gap-2">
                         <Plus className="h-4 w-4 shrink-0" />
-                        <span className="min-w-0 flex-1 truncate">Add item</span>
+                        <span className="min-w-0 flex-1 truncate">Add a clipping</span>
                         <SpaceLinkHint />
                       </Link>
                     </SidebarMenuButton>
@@ -166,11 +176,13 @@ export function AppSidebar() {
           ) : null}
 
           <SidebarGroup>
-            <SidebarGroupLabel className="px-4">View</SidebarGroupLabel>
+            <SidebarGroupLabel className="px-4 font-mono text-[9px] font-semibold uppercase tracking-[0.17em]">
+              Browse
+            </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 <SidebarMenuItem>
-                  <SidebarMenuButton className="px-4 pl-6" asChild>
+                  <SidebarMenuButton className="mx-2 rounded-lg px-3" asChild>
                     <Link href={toggleViewHref} onClick={closeMobile} className="flex items-center gap-2">
                       {isReviewLike ? (
                         <ArrowLeft className="h-4 w-4 shrink-0" />
@@ -178,7 +190,7 @@ export function AppSidebar() {
                         <ArrowRight className="h-4 w-4 shrink-0" />
                       )}
                       <span className="min-w-0 flex-1 truncate">
-                        {isReviewLike ? 'List' : 'Review'}
+                        {isReviewLike ? 'Back to clippings' : 'Review drawer'}
                       </span>
                       <SpaceLinkHint />
                     </Link>
@@ -189,7 +201,9 @@ export function AppSidebar() {
           </SidebarGroup>
 
           <SidebarGroup>
-            <SidebarGroupLabel className="px-4">Shortcuts</SidebarGroupLabel>
+            <SidebarGroupLabel className="px-4 font-mono text-[9px] font-semibold uppercase tracking-[0.17em]">
+              Labels
+            </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 {shortcuts.map((shortcut) => {
@@ -198,7 +212,7 @@ export function AppSidebar() {
                     : shortcut.href;
                   return (
                     <SidebarMenuItem key={shortcut.label}>
-                      <SidebarMenuButton asChild className="justify-start gap-2 px-4 pl-6">
+                      <SidebarMenuButton asChild className="mx-2 justify-start gap-2 rounded-lg px-3">
                         <Link href={href} onClick={closeMobile} className="flex items-center gap-2">
                           <span className="min-w-0 flex-1 truncate">{shortcut.label}</span>
                           <SpaceLinkHint />
@@ -213,13 +227,30 @@ export function AppSidebar() {
         </SidebarContent>
       </ScrollArea>
 
-      <SidebarFooter className="shrink-0 space-y-2 border-t p-3">
+      <SidebarFooter className="shrink-0 space-y-2 border-t border-dashed border-border/70 p-3">
+        <div className="material-paper relative overflow-hidden rounded-xl border p-2.5">
+          <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+          <div className="flex items-center gap-2.5">
+            <PaperCreature
+              pose={loading ? 'sniffing' : user ? 'reading' : 'idle'}
+              size="sm"
+              label="Scraplet sitting on a little paper shelf"
+            />
+            <div className="min-w-0">
+              <p className="font-mono text-[9px] font-bold uppercase tracking-[0.15em]">Scraplet&apos;s shelf</p>
+              <p className="mt-1 text-[11px] leading-4 opacity-70">
+                {user ? 'Keeping your notes company.' : 'Saving a seat at the workbench.'}
+              </p>
+            </div>
+          </div>
+        </div>
+
         {user ? (
           <>
-            <div className="truncate px-2 text-sm text-muted-foreground" title={user.email}>
+            <div className="truncate px-2 text-xs text-muted-foreground" title={user.email}>
               {user.email}
             </div>
-            <Button variant="outline" size="sm" onClick={handleSignOut} className="w-full">
+            <Button variant="outline" size="sm" onClick={handleSignOut} className="w-full rounded-lg">
               <LogOut className="mr-2 h-4 w-4" />
               Sign out
             </Button>
@@ -231,7 +262,7 @@ export function AppSidebar() {
               size="sm"
               onClick={() => handleOAuthSignIn('google')}
               disabled={loading}
-              className="w-full"
+              className="w-full rounded-lg"
             >
               {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <GoogleIcon className="mr-2 h-4 w-4" />}
               Google
@@ -241,7 +272,7 @@ export function AppSidebar() {
               size="sm"
               onClick={() => handleOAuthSignIn('github')}
               disabled={loading}
-              className="w-full"
+              className="w-full rounded-lg"
             >
               {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <GitHubIcon className="mr-2 h-4 w-4" />}
               GitHub

--- a/components/space/space-header.tsx
+++ b/components/space/space-header.tsx
@@ -44,21 +44,21 @@ export function SpaceHeader({
     <Link
       href={toggleHref}
       prefetch
-      className="inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-transparent px-2 text-sm font-medium text-muted-foreground transition hover:border-border/60 hover:bg-muted/65 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={isReviewLike ? 'Back to list' : 'Open review'}
     >
       {isReviewLike ? <ArrowLeft className="h-4 w-4" /> : <ArrowRight className="h-4 w-4" />}
-      <span className="hidden sm:inline">{isReviewLike ? 'List' : 'Review'}</span>
+      <span className="hidden sm:inline">{isReviewLike ? 'Clippings' : 'Review drawer'}</span>
       <SpaceLinkHint />
     </Link>
   );
 
   return (
-    <header className="flex h-12 min-w-0 items-center gap-1.5 border-b border-border bg-background px-2 sm:gap-2 sm:px-4">
+    <header className="flex h-12 min-w-0 items-center gap-1.5 border-b border-dashed border-border/75 bg-background/88 px-2 backdrop-blur-sm sm:gap-2 sm:px-4">
       <Button
         variant="ghost"
         size="icon"
-        className="h-8 w-8 shrink-0"
+        className="h-8 w-8 shrink-0 rounded-lg"
         aria-label="Toggle sidebar"
         title={`Toggle sidebar (${isMac ? '⌘' : 'Ctrl'} + B)`}
         onClick={() => toggleSidebar?.()}
@@ -66,9 +66,9 @@ export function SpaceHeader({
         <PanelLeft className="h-4 w-4" />
       </Button>
 
-      <SiteAtlas variant="icon" className="rounded-md" />
+      <SiteAtlas variant="icon" className="rounded-lg" />
 
-      <p className="min-w-0 flex-1 truncate px-1 text-xs text-muted-foreground sm:text-sm">
+      <p className="min-w-0 flex-1 truncate px-1 font-mono text-[9px] font-semibold uppercase tracking-[0.13em] text-muted-foreground sm:text-[10px]">
         {leftContent}
       </p>
 
@@ -78,10 +78,10 @@ export function SpaceHeader({
         {onEditorToggle ? (
           <button
             onClick={onEditorToggle}
-            className={`inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            className={`inline-flex h-8 items-center gap-1.5 rounded-lg border px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
               isEditorOpen
-                ? 'bg-muted text-foreground'
-                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                ? 'border-border bg-muted text-foreground'
+                : 'border-transparent text-muted-foreground hover:border-border/60 hover:bg-muted/65 hover:text-foreground'
             }`}
             title={`Toggle editor (${isMac ? '⌘' : 'Ctrl'} + I)`}
             aria-label="Toggle editor"

--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -1,14 +1,16 @@
-"use client";
-import Link from "next/link";
-import { Rating } from "ts-fsrs";
-import { Button } from "@/components/ui/button";
-import type { Item } from "@/app/lib/item-types";
-import { formatInterval, formatDueRelative } from "@/app/lib/interval-format";
-import { useEffect, useState } from "react";
-import { MarkdownContent } from "./markdown-content";
-import { useSearchParams } from "next/navigation";
-import { CodeDisplay } from "./code-display";
-import { ChevronDown, ChevronRight } from "lucide-react";
+'use client';
+
+import Link from 'next/link';
+import { Rating } from 'ts-fsrs';
+import { Button } from '@/components/ui/button';
+import type { Item } from '@/app/lib/item-types';
+import { formatInterval, formatDueRelative } from '@/app/lib/interval-format';
+import { useEffect, useState } from 'react';
+import { MarkdownContent } from './markdown-content';
+import { useSearchParams } from 'next/navigation';
+import { CodeDisplay } from './code-display';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { PaperCreature } from '@/components/paper-creature';
 
 export function ResultsClient({
   items,
@@ -26,50 +28,68 @@ export function ResultsClient({
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
 
-  // Toggle the currently hovered row when Shift is pressed
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      // ignore if typing
-      const target = e.target as HTMLElement | null;
+    const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
-      const role = target?.getAttribute?.("role");
+      const role = target?.getAttribute?.('role');
       const isTyping =
-        tag === "input" ||
-        tag === "textarea" ||
-        target?.getAttribute("contenteditable") === "true" ||
-        role === "textbox";
+        tag === 'input' ||
+        tag === 'textarea' ||
+        target?.getAttribute('contenteditable') === 'true' ||
+        role === 'textbox';
 
       if (isTyping) return;
 
-      if (e.key === "Shift" && !e.metaKey && !e.ctrlKey && !e.altKey && !e.repeat) {
+      if (event.key === 'Shift' && !event.metaKey && !event.ctrlKey && !event.altKey && !event.repeat) {
         if (hoveredId) {
-          setExpandedIds((prev) => ({ ...prev, [hoveredId]: !prev[hoveredId] }));
+          setExpandedIds((previous) => ({ ...previous, [hoveredId]: !previous[hoveredId] }));
         }
       }
     };
 
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
   }, [hoveredId]);
 
+  if (items.length === 0) {
+    return (
+      <section className="material-paper relative mx-auto mt-8 max-w-xl overflow-hidden rounded-2xl border px-6 py-10 text-center">
+        <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+        <PaperCreature
+          pose="carrying"
+          size="lg"
+          className="mx-auto"
+          label="Scraplet carrying a pencil and looking for a clipping"
+        />
+        <h2 className="mt-4 text-xl font-semibold tracking-tight">This drawer is empty</h2>
+        <p className="mx-auto mt-2 max-w-sm text-sm leading-6 opacity-70">
+          Try another label or search. Scraplet will keep looking through the paper scraps.
+        </p>
+      </section>
+    );
+  }
+
   return (
-    <ul className="space-y-2">
-      {items.map((it) => {
-        const expanded = !!expandedIds[it.id];
+    <ul className="grid gap-3">
+      {items.map((item) => {
+        const expanded = Boolean(expandedIds[item.id]);
         const onToggle = () =>
-          setExpandedIds((prev) => ({ ...prev, [it.id]: !prev[it.id] }));
+          setExpandedIds((previous) => ({ ...previous, [item.id]: !previous[item.id] }));
 
         return (
           <Row
-            key={it.id}
-            it={it}
+            key={item.id}
+            item={item}
             onReview={onReview}
             onEnroll={onEnroll}
             nowMs={nowMs}
             isAdmin={isAdmin}
             expanded={expanded}
             onToggle={onToggle}
-            onHoverChange={(isHovering) => setHoveredId(isHovering ? it.id : (hoveredId === it.id ? null : hoveredId))}
+            onHoverChange={(isHovering) =>
+              setHoveredId(isHovering ? item.id : hoveredId === item.id ? null : hoveredId)
+            }
           />
         );
       })}
@@ -78,7 +98,7 @@ export function ResultsClient({
 }
 
 function Row({
-  it,
+  item,
   onReview,
   onEnroll,
   nowMs,
@@ -87,8 +107,8 @@ function Row({
   onToggle,
   onHoverChange,
 }: {
-  it: Item;
-  onReview: (id: string, r: Rating) => void;
+  item: Item;
+  onReview: (id: string, rating: Rating) => void;
   onEnroll: (id: string) => void;
   nowMs: number;
   isAdmin: boolean;
@@ -96,184 +116,183 @@ function Row({
   onToggle: () => void;
   onHoverChange: (hovering: boolean) => void;
 }) {
-  const [activeIdx, setActiveIdx] = useState(it.defaultIndex);
-  const active = it.versions[activeIdx];
-  
-  const displayTags = it.tags.map((t) => (t.includes(":") ? t.split(":")[1] : t));
-  const sp = useSearchParams();
-  const tagsParam = sp.get("tags") ?? "";
+  const [activeIndex, setActiveIndex] = useState(item.defaultIndex);
+  const active = item.versions[activeIndex];
+  const displayTags = item.tags.map((tag) => (tag.includes(':') ? tag.split(':')[1] : tag));
+  const searchParams = useSearchParams();
+  const tagsParam = searchParams.get('tags') ?? '';
+  const isDue = Boolean(item.review && item.review.due <= nowMs);
 
   return (
     <li
-      className="rounded border bg-white dark:bg-sidebar border-border dark:border-sidebar-border text-foreground dark:text-sidebar-foreground transition-colors"
+      className="material-paper group relative overflow-hidden rounded-xl border transition-[transform,box-shadow,border-color] duration-150 hover:-rotate-[0.08deg] hover:border-[hsl(var(--material-paper-edge))] hover:shadow-[0_12px_26px_rgba(45,40,32,0.13)]"
       onMouseEnter={() => onHoverChange(true)}
       onMouseLeave={() => onHoverChange(false)}
     >
-      {/* Clickable header */}
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-4 h-11 w-1.5 rounded-r-full bg-[#9baa88] shadow-[inset_-1px_0_rgba(75,82,67,0.22)]"
+      />
+
       <div
-        className="p-3 cursor-pointer hover:bg-muted/50 transition-colors"
+        className="cursor-pointer px-4 py-3.5 pl-5 transition-colors hover:bg-white/20 dark:hover:bg-black/5"
         onClick={onToggle}
       >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            {it.url ? (
-              <Link
-                href={it.url}
-                // prefetch={true} Does nothing since it's an external url
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium hover:underline text-foreground"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {it.title}
-              </Link>
-            ) : (
-              <span className="font-medium text-foreground">{it.title}</span>
-            )}
-            {/* Only show edit/duplicate buttons if admin */}
-            {isAdmin && (
-              <>
-                <Button asChild variant="outline" size="sm">
-                  <Link
-                    href={`/space/edit/${it.slug}`}
-                    prefetch={true}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    edit
-                  </Link>
-                </Button>
-                {/* <Button asChild variant="outline" size="sm">
-                  <Link
-                    href={`/space/add?duplicate=${it.slug}`}
-                    prefetch={true}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    duplicate
-                  </Link>
-                </Button> */}
-              </>
-            )}
-            <Button asChild variant="outline" size="sm">
-              <Link
-                href={`/space/review?tags=${tagsParam}&item=${it.slug}`}
-                prefetch={true}
-                onClick={(e) => e.stopPropagation()}
-              >
-                review
-              </Link>
-            </Button>
-          </div>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground capitalize">{it.category}</span>
-            {expanded ? (
-              <ChevronDown className="h-4 w-4 text-muted-foreground" />
-            ) : (
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-            )}
-          </div>
-        </div>
-
-        <div className="mt-1 text-xs text-muted-foreground">
-          tags: {displayTags.join(", ")}
-          {it.review && (
-            <>
-              {" · next: "}
-              {formatDueRelative(nowMs, new Date(it.review.due))}
-              {" · ivl: "}
-              {formatInterval(nowMs, new Date(it.review.due), it.review.scheduled_days)}
-              {it.review.due <= nowMs && (
-                <span className="ml-2 rounded bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 px-1 py-0.5">
-                  due
-                </span>
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              {item.url ? (
+                <Link
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="min-w-0 text-base font-semibold tracking-[-0.015em] underline-offset-4 hover:underline"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  {item.title}
+                </Link>
+              ) : (
+                <span className="min-w-0 text-base font-semibold tracking-[-0.015em]">{item.title}</span>
               )}
-            </>
-          )}
+
+              {isAdmin ? (
+                <Link
+                  href={`/space/edit/${item.slug}`}
+                  prefetch
+                  onClick={(event) => event.stopPropagation()}
+                  className="material-label-stamped text-[9px] text-[#76604f] transition-opacity hover:opacity-70"
+                >
+                  edit
+                </Link>
+              ) : null}
+
+              <Link
+                href={`/space/review?tags=${tagsParam}&item=${item.slug}`}
+                prefetch
+                onClick={(event) => event.stopPropagation()}
+                className="material-label-stamped text-[9px] text-[#5f6f55] transition-opacity hover:opacity-70"
+              >
+                study
+              </Link>
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              {displayTags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full border border-black/10 bg-white/28 px-2 py-0.5 text-[10px] leading-4 opacity-70"
+                >
+                  {tag}
+                </span>
+              ))}
+
+              {item.review ? (
+                <span className="font-mono text-[9px] uppercase tracking-[0.08em] opacity-60">
+                  next {formatDueRelative(nowMs, new Date(item.review.due))} ·{' '}
+                  {formatInterval(nowMs, new Date(item.review.due), item.review.scheduled_days)}
+                </span>
+              ) : null}
+
+              {isDue ? (
+                <span className="material-label-stamped text-[9px] text-[#9b4f45]">due</span>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2 pt-0.5">
+            <span className="material-label-stamped hidden text-[9px] text-[#675f55] sm:inline-flex">
+              {item.category}
+            </span>
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 opacity-55" />
+            ) : (
+              <ChevronRight className="h-4 w-4 opacity-55" />
+            )}
+          </div>
         </div>
       </div>
 
-      {/* Expanded content */}
-      {expanded && (
-        <div className="border-t border-border p-3">
-          {/* Version tabs */}
-          {it.versions.length > 1 && (
-            <div className="flex gap-2 mb-3 text-xs">
-              {it.versions.map((v, i) => (
+      {expanded ? (
+        <div className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] bg-white/14 p-4 dark:bg-black/5">
+          {item.versions.length > 1 ? (
+            <div className="mb-3 flex flex-wrap gap-2 text-xs">
+              {item.versions.map((version, index) => (
                 <button
-                  key={i}
-                  onMouseEnter={() => setActiveIdx(i)}
-                  className={`px-2 py-1 rounded border transition-colors ${
-                    i === activeIdx
-                      ? 'bg-accent text-accent-foreground border-accent'
-                      : 'border-border hover:bg-muted'
+                  key={version.label}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={`rounded-md border px-2.5 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.1em] transition-colors ${
+                    index === activeIndex
+                      ? 'border-[#7d735f]/50 bg-[#d8cba9]/55 text-[#4f493e]'
+                      : 'border-black/10 bg-white/20 opacity-65 hover:opacity-100'
                   }`}
+                  type="button"
                 >
-                  {v.label}
+                  {version.label}
                 </button>
               ))}
             </div>
-          )}
+          ) : null}
 
-          <div className="flex gap-3">
-            {/* Writeup */}
-            <div className="flex-1 min-w-0">
-              <div
-                className="p-3 rounded overflow-auto prose prose-sm dark:prose-invert max-w-none
-                bg-white dark:bg-sidebar
-                border border-border dark:border-sidebar-border"
-              >
+          <div className="flex flex-col gap-3 lg:flex-row">
+            <div className="min-w-0 flex-1">
+              <div className="overflow-auto rounded-xl border border-black/10 bg-white/38 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.4)] dark:bg-black/8">
                 <MarkdownContent
                   html={active.contentHtml}
-                  className="prose prose-sm dark:prose-invert max-w-none"
+                  className="prose prose-sm max-w-none prose-headings:tracking-tight dark:prose-invert"
                 />
               </div>
             </div>
 
-            {/* Code */}
-            {active.code && <CodeDisplay code={active.code} codeHtml={active.codeHtml} />}
+            {active.code ? <CodeDisplay code={active.code} codeHtml={active.codeHtml} /> : null}
           </div>
         </div>
-      )}
+      ) : null}
 
-      {/* Review controls - only visible for admin */}
-      {isAdmin && (
-        <div className="border-t border-border p-3" onClick={(e) => e.stopPropagation()}>
-          {!it.review ? (
+      {isAdmin ? (
+        <div
+          className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] bg-white/10 px-4 py-3 dark:bg-black/5"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {!item.review ? (
             <button
-              className="rounded border border-border px-2 py-1 text-xs hover:bg-muted transition-colors"
-              onClick={() => onEnroll(it.id)}
+              className="rounded-lg border border-[#6e7b61]/35 bg-[#b9c5a8]/28 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[#b9c5a8]/45"
+              onClick={() => onEnroll(item.id)}
+              type="button"
             >
-              Add to reviews
+              Put in review drawer
             </button>
           ) : (
-            <div className="flex gap-2 text-xs">
-              <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Again)}
-              >
-                Again
-              </button>
-              <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Hard)}
-              >
-                Hard
-              </button>
-              <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Good)}
-              >
-                Good
-              </button>
-              <button
-                className="rounded border border-border px-2 py-1 hover:bg-muted transition-colors"
-                onClick={() => onReview(it.id, Rating.Easy)}
-              >
-                Easy
-              </button>
+            <div className="flex flex-wrap gap-2 text-xs">
+              <ReviewButton label="Again" className="border-[#a96c6c]/35 bg-[#d9aaaa]/24" onClick={() => onReview(item.id, Rating.Again)} />
+              <ReviewButton label="Hard" className="border-[#aa8251]/35 bg-[#ddbd86]/24" onClick={() => onReview(item.id, Rating.Hard)} />
+              <ReviewButton label="Good" className="border-[#6e7b61]/35 bg-[#b9c5a8]/28" onClick={() => onReview(item.id, Rating.Good)} />
+              <ReviewButton label="Easy" className="border-[#756d89]/35 bg-[#c8bfd5]/28" onClick={() => onReview(item.id, Rating.Easy)} />
             </div>
           )}
         </div>
-      )}
+      ) : null}
+
+      <span className="material-paper-edge" aria-hidden="true" />
     </li>
+  );
+}
+
+function ReviewButton({
+  label,
+  className,
+  onClick,
+}: {
+  label: string;
+  className: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={`rounded-lg border px-3 py-1.5 font-medium transition-[background-color,transform] hover:-rotate-[0.4deg] ${className}`}
+      onClick={onClick}
+      type="button"
+    >
+      {label}
+    </button>
   );
 }

--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link';
 import { Rating } from 'ts-fsrs';
-import { Button } from '@/components/ui/button';
 import type { Item } from '@/app/lib/item-types';
 import { formatInterval, formatDueRelative } from '@/app/lib/interval-format';
 import { useEffect, useState } from 'react';
@@ -180,7 +179,7 @@ function Row({
               {displayTags.map((tag) => (
                 <span
                   key={tag}
-                  className="rounded-full border border-black/10 bg-white/28 px-2 py-0.5 text-[10px] leading-4 opacity-70"
+                  className="rounded-full border border-black/10 bg-white/[0.28] px-2 py-0.5 text-[10px] leading-4 opacity-70"
                 >
                   {tag}
                 </span>
@@ -213,7 +212,7 @@ function Row({
       </div>
 
       {expanded ? (
-        <div className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] bg-white/14 p-4 dark:bg-black/5">
+        <div className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] bg-white/[0.14] p-4 dark:bg-black/5">
           {item.versions.length > 1 ? (
             <div className="mb-3 flex flex-wrap gap-2 text-xs">
               {item.versions.map((version, index) => (
@@ -222,7 +221,7 @@ function Row({
                   onMouseEnter={() => setActiveIndex(index)}
                   className={`rounded-md border px-2.5 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.1em] transition-colors ${
                     index === activeIndex
-                      ? 'border-[#7d735f]/50 bg-[#d8cba9]/55 text-[#4f493e]'
+                      ? 'border-[#7d735f]/50 bg-[#d8cba9]/[0.55] text-[#4f493e]'
                       : 'border-black/10 bg-white/20 opacity-65 hover:opacity-100'
                   }`}
                   type="button"
@@ -235,7 +234,7 @@ function Row({
 
           <div className="flex flex-col gap-3 lg:flex-row">
             <div className="min-w-0 flex-1">
-              <div className="overflow-auto rounded-xl border border-black/10 bg-white/38 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.4)] dark:bg-black/8">
+              <div className="overflow-auto rounded-xl border border-black/10 bg-white/[0.38] p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.4)] dark:bg-black/[0.08]">
                 <MarkdownContent
                   html={active.contentHtml}
                   className="prose prose-sm max-w-none prose-headings:tracking-tight dark:prose-invert"
@@ -255,7 +254,7 @@ function Row({
         >
           {!item.review ? (
             <button
-              className="rounded-lg border border-[#6e7b61]/35 bg-[#b9c5a8]/28 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[#b9c5a8]/45"
+              className="rounded-lg border border-[#6e7b61]/[0.35] bg-[#b9c5a8]/[0.28] px-3 py-1.5 text-xs font-medium transition-colors hover:bg-[#b9c5a8]/[0.45]"
               onClick={() => onEnroll(item.id)}
               type="button"
             >
@@ -263,10 +262,26 @@ function Row({
             </button>
           ) : (
             <div className="flex flex-wrap gap-2 text-xs">
-              <ReviewButton label="Again" className="border-[#a96c6c]/35 bg-[#d9aaaa]/24" onClick={() => onReview(item.id, Rating.Again)} />
-              <ReviewButton label="Hard" className="border-[#aa8251]/35 bg-[#ddbd86]/24" onClick={() => onReview(item.id, Rating.Hard)} />
-              <ReviewButton label="Good" className="border-[#6e7b61]/35 bg-[#b9c5a8]/28" onClick={() => onReview(item.id, Rating.Good)} />
-              <ReviewButton label="Easy" className="border-[#756d89]/35 bg-[#c8bfd5]/28" onClick={() => onReview(item.id, Rating.Easy)} />
+              <ReviewButton
+                label="Again"
+                className="border-[#a96c6c]/[0.35] bg-[#d9aaaa]/[0.24]"
+                onClick={() => onReview(item.id, Rating.Again)}
+              />
+              <ReviewButton
+                label="Hard"
+                className="border-[#aa8251]/[0.35] bg-[#ddbd86]/[0.24]"
+                onClick={() => onReview(item.id, Rating.Hard)}
+              />
+              <ReviewButton
+                label="Good"
+                className="border-[#6e7b61]/[0.35] bg-[#b9c5a8]/[0.28]"
+                onClick={() => onReview(item.id, Rating.Good)}
+              />
+              <ReviewButton
+                label="Easy"
+                className="border-[#756d89]/[0.35] bg-[#c8bfd5]/[0.28]"
+                onClick={() => onReview(item.id, Rating.Easy)}
+              />
             </div>
           )}
         </div>

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -14,13 +14,14 @@ import { useItems } from '@/app/lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/client';
 import { SpaceHeader } from './space-header';
 import { Button } from '@/components/ui/button';
+import { PaperCreature } from '@/components/paper-creature';
 
 const ITEMS_PER_PAGE = 20;
 
 export function SpaceView() {
   const supabase = createClient();
-  const sp = useSearchParams();
-  const tagsParam = sp.get('tags') ?? undefined;
+  const searchParams = useSearchParams();
+  const tagsParam = searchParams.get('tags') ?? undefined;
 
   const {
     items: allItems,
@@ -37,13 +38,13 @@ export function SpaceView() {
   } = useItems();
   const nowMs = useNow(initialNowMs, 30_000);
 
-  const q = useMemo(() => parseQuery(tagsParam), [tagsParam]);
+  const query = useMemo(() => parseQuery(tagsParam), [tagsParam]);
   const [mutations, setMutations] = useState<Record<string, ReviewState>>({});
   const [page, setPage] = useState(1);
 
-  const [prevTagsParam, setPrevTagsParam] = useState(tagsParam);
-  if (prevTagsParam !== tagsParam) {
-    setPrevTagsParam(tagsParam);
+  const [previousTagsParam, setPreviousTagsParam] = useState(tagsParam);
+  if (previousTagsParam !== tagsParam) {
+    setPreviousTagsParam(tagsParam);
     setPage(1);
   }
 
@@ -52,8 +53,8 @@ export function SpaceView() {
       const mutation = mutations[item.id];
       return mutation ? { ...item, review: mutation } : item;
     });
-    return searchItems(withMutations, q, nowMs);
-  }, [allItems, mutations, q, nowMs]);
+    return searchItems(withMutations, query, nowMs);
+  }, [allItems, mutations, query, nowMs]);
 
   const paginatedItems = useMemo(() => {
     const start = (page - 1) * ITEMS_PER_PAGE;
@@ -62,8 +63,8 @@ export function SpaceView() {
 
   const totalPages = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
   const itemCount = `${items.length}${hasMore ? '+' : ''}`;
-  const headerStatus = tagsParam ? `${itemCount} · ${tagsParam}` : `${itemCount} items`;
-  const visibleHeaderStatus = refreshing ? `${headerStatus} · Updating` : headerStatus;
+  const headerStatus = tagsParam ? `${itemCount} · ${tagsParam}` : `${itemCount} clippings`;
+  const visibleHeaderStatus = refreshing ? `${headerStatus} · sorting` : headerStatus;
 
   useEffect(() => {
     if (page >= totalPages && hasMore && !loadingMore) {
@@ -170,55 +171,85 @@ export function SpaceView() {
         onEditorToggle={() => setEditorOpen(!editorOpen)}
         isEditorOpen={editorOpen}
       />
-      <main className="min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:p-4">
-        {error ? (
-          <div className="mb-3 flex items-center justify-between gap-3 rounded-lg border border-amber-500/35 bg-amber-500/10 px-3 py-2 text-sm" role="alert">
-            <span className="min-w-0">{error}</span>
-            <Button variant="outline" size="sm" className="shrink-0" onClick={() => void reload()}>
-              Retry
-            </Button>
-          </div>
-        ) : null}
-
-        <ResultsClient
-          items={paginatedItems}
-          onReview={onReview}
-          onEnroll={onEnroll}
-          nowMs={nowMs}
-          isAdmin={isAdmin}
+      <main className="relative min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:p-5">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-20"
+          style={{
+            backgroundImage:
+              'linear-gradient(rgba(67,58,46,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(67,58,46,0.035) 1px, transparent 1px)',
+            backgroundSize: '24px 24px',
+          }}
         />
 
-        {totalPages > 1 && (
-          <div className="mt-6 flex items-center justify-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page === 1}
-              onClick={() => setPage((current) => current - 1)}
-            >
-              Previous
-            </Button>
-            <span className="px-4 py-2 text-sm text-muted-foreground">
-              Page {page} of {totalPages}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={page >= totalPages}
-              onClick={() => setPage((current) => current + 1)}
-            >
-              Next
-            </Button>
-          </div>
-        )}
+        <div className="relative mx-auto w-full max-w-5xl">
+          <section className="mb-4 flex items-end justify-between gap-4 px-1">
+            <div>
+              <span className="material-label-stamped text-[9px] text-muted-foreground">clipping drawer</span>
+              <h1 className="mt-2 text-2xl font-semibold tracking-[-0.025em] sm:text-3xl">Notes worth keeping</h1>
+              <p className="mt-1 max-w-xl text-sm leading-6 text-muted-foreground">
+                Open a clipping to read it, or use Shift while hovering to unfold one quickly.
+              </p>
+            </div>
+            <PaperCreature
+              pose={refreshing ? 'sniffing' : 'reading'}
+              size="md"
+              className="md:hidden"
+              label={refreshing ? 'Scraplet sorting the clippings' : 'Scraplet reading a clipping'}
+            />
+          </section>
 
-        {hasMore && (
-          <div className="mt-4 flex justify-center">
-            <Button variant="outline" size="sm" disabled={loadingMore} onClick={() => void loadMore()}>
-              {loadingMore ? 'Loading…' : 'Load more items'}
-            </Button>
-          </div>
-        )}
+          {error ? (
+            <div className="material-paper relative mb-4 flex items-center justify-between gap-3 overflow-hidden rounded-xl border px-4 py-3 text-sm" role="alert">
+              <span className="min-w-0">{error}</span>
+              <Button variant="outline" size="sm" className="shrink-0 rounded-lg" onClick={() => void reload()}>
+                Try again
+              </Button>
+            </div>
+          ) : null}
+
+          <ResultsClient
+            items={paginatedItems}
+            onReview={onReview}
+            onEnroll={onEnroll}
+            nowMs={nowMs}
+            isAdmin={isAdmin}
+          />
+
+          {totalPages > 1 ? (
+            <div className="mt-6 flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-lg"
+                disabled={page === 1}
+                onClick={() => setPage((current) => current - 1)}
+              >
+                Previous drawer
+              </Button>
+              <span className="rounded-full border border-border/60 bg-background/65 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+                {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-lg"
+                disabled={page >= totalPages}
+                onClick={() => setPage((current) => current + 1)}
+              >
+                Next drawer
+              </Button>
+            </div>
+          ) : null}
+
+          {hasMore ? (
+            <div className="mt-4 flex justify-center">
+              <Button variant="outline" size="sm" className="rounded-lg" disabled={loadingMore} onClick={() => void loadMore()}>
+                {loadingMore ? 'Opening drawer…' : 'Open more clippings'}
+              </Button>
+            </div>
+          ) : null}
+        </div>
       </main>
     </div>
   );

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import TimezoneSelector from './timezone-selector';
 import CurrentTimeDisplay from './current-time-display';
 import { isDSTActive } from '@/app/lib/dst-utils';
+import { PaperCreature } from '@/components/paper-creature';
 
 const DAY_GRADIENT =
   'linear-gradient(90deg, #151720 0%, #252938 9%, #493f55 18%, #715767 28%, #9f6f68 38%, #bd916c 46%, #c9a574 50%, #bd916c 56%, #9f6f68 64%, #715767 73%, #493f55 82%, #252938 91%, #151720 100%)';
@@ -56,101 +57,118 @@ export default function UTCTimeVisualizer() {
           : localHours < 21
             ? 'Evening'
             : 'Night';
+  const scrapletPose =
+    timeOfDay === 'Night'
+      ? 'napping'
+      : timeOfDay === 'Morning'
+        ? 'idle'
+        : timeOfDay === 'Afternoon'
+          ? 'carrying'
+          : 'reading';
 
   return (
     <div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-6xl items-start px-4 py-4 sm:px-6 sm:py-8 lg:px-8">
-      <div className="w-full rounded-[1.5rem] border border-border/70 bg-card/92 p-4 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] backdrop-blur-xl dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
-        <CurrentTimeDisplay onJumpToTime={setLocalTime} />
+      <div className="relative w-full overflow-hidden rounded-[1.5rem] border border-border/70 bg-card/94 p-4 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
+        <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 opacity-35 dark:opacity-10"
+          style={{
+            backgroundImage:
+              'linear-gradient(rgba(64,55,43,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(64,55,43,0.035) 1px, transparent 1px)',
+            backgroundSize: '26px 26px',
+          }}
+        />
 
-        <div className="mt-5 sm:mt-7">
-          <TimezoneSelector utcHours={utcHours} utcMinutes={utcMinutes} />
+        <div className="relative">
+          <div className="flex items-start justify-between gap-4">
+            <CurrentTimeDisplay onJumpToTime={setLocalTime} />
+            <div className="hidden text-center sm:block">
+              <PaperCreature
+                pose={scrapletPose}
+                size="lg"
+                label={`Scraplet during the ${timeOfDay.toLowerCase()}`}
+              />
+              <p className="mt-1 font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                {timeOfDay} desk
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 sm:mt-7">
+            <TimezoneSelector utcHours={utcHours} utcMinutes={utcMinutes} />
+          </div>
+
+          <div className="mt-6 rounded-2xl border border-dashed border-border/70 bg-background/30 p-4 sm:mt-7 sm:p-5">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <label
+                htmlFor="time-of-day"
+                className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+              >
+                Slide through the day
+              </label>
+              <span className="material-label-stamped text-[9px] text-muted-foreground">{timeOfDay}</span>
+            </div>
+            <input
+              id="time-of-day"
+              type="range"
+              min="0"
+              max="1439"
+              step="1"
+              value={localTime}
+              onChange={(event) => setLocalTime(Number.parseInt(event.target.value, 10))}
+              aria-label="Local time of day"
+              aria-valuetext={`${formatTime(localHours, localMinutes)} ${timeOfDay}`}
+              className="time-day-slider h-14 w-full cursor-pointer rounded-full"
+              style={{ background: DAY_GRADIENT }}
+            />
+            <div className="mt-2 flex justify-between font-mono text-[10px] tabular-nums text-muted-foreground">
+              <span>00:00</span>
+              <span>06:00</span>
+              <span>12:00</span>
+              <span>18:00</span>
+              <span>23:59</span>
+            </div>
+          </div>
+
+          <section
+            aria-label="Time comparisons"
+            className="mt-6 grid grid-cols-2 gap-3 sm:mt-7 sm:grid-cols-4"
+          >
+            <div className="material-paper col-span-2 rounded-xl border p-4 sm:col-span-1">
+              <p className="font-mono text-[10px] uppercase tracking-[0.15em] opacity-65">Local</p>
+              <p className="mt-1 font-mono text-3xl font-semibold tabular-nums tracking-[-0.03em]">
+                {formatTime(localHours, localMinutes)}
+              </p>
+              <p className="mt-1 font-mono text-[10px] tabular-nums opacity-65">
+                {formatTime12Hour(localHours, localMinutes)} {period} ·{' '}
+                {formatOffset(localOffsetMinutes)}
+              </p>
+            </div>
+            <TimeCard label="UTC" time={formatTime(utcHours, utcMinutes)} offset="UTC±00:00" />
+            <TimeCard
+              label="Eastern"
+              time={formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
+              offset={formatOffset(easternOffset * 60)}
+            />
+            <TimeCard
+              label="Pacific"
+              time={formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
+              offset={formatOffset(pacificOffset * 60)}
+            />
+          </section>
         </div>
-
-        <div className="mt-6 sm:mt-7">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <label
-              htmlFor="time-of-day"
-              className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground"
-            >
-              Local time of day
-            </label>
-            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-              {timeOfDay}
-            </span>
-          </div>
-          <input
-            id="time-of-day"
-            type="range"
-            min="0"
-            max="1439"
-            step="1"
-            value={localTime}
-            onChange={(event) => setLocalTime(Number.parseInt(event.target.value, 10))}
-            aria-label="Local time of day"
-            aria-valuetext={`${formatTime(localHours, localMinutes)} ${timeOfDay}`}
-            className="time-day-slider h-14 w-full cursor-pointer rounded-full"
-            style={{ background: DAY_GRADIENT }}
-          />
-          <div className="mt-2 flex justify-between font-mono text-[10px] tabular-nums text-muted-foreground">
-            <span>00:00</span>
-            <span>06:00</span>
-            <span>12:00</span>
-            <span>18:00</span>
-            <span>23:59</span>
-          </div>
-        </div>
-
-        <section
-          aria-label="Time comparisons"
-          className="mt-6 grid grid-cols-2 gap-3 sm:mt-7 sm:grid-cols-4"
-        >
-          <div className="col-span-2 rounded-xl border border-border/65 bg-background/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.2)] backdrop-blur-md sm:col-span-1">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              Local
-            </p>
-            <p className="mt-1 font-mono text-3xl font-semibold tabular-nums tracking-[-0.03em]">
-              {formatTime(localHours, localMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              {formatTime12Hour(localHours, localMinutes)} {period} ·{' '}
-              {formatOffset(localOffsetMinutes)}
-            </p>
-          </div>
-          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              UTC
-            </p>
-            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
-              {formatTime(utcHours, utcMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              UTC±00:00
-            </p>
-          </div>
-          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              Eastern
-            </p>
-            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
-              {formatTime((utcHours + easternOffset + 24) % 24, utcMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              {formatOffset(easternOffset * 60)}
-            </p>
-          </div>
-          <div className="rounded-xl border border-border/65 bg-background/46 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] backdrop-blur-md">
-            <p className="font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-              Pacific
-            </p>
-            <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">
-              {formatTime((utcHours + pacificOffset + 24) % 24, utcMinutes)}
-            </p>
-            <p className="mt-1 font-mono text-[10px] tabular-nums text-muted-foreground">
-              {formatOffset(pacificOffset * 60)}
-            </p>
-          </div>
-        </section>
       </div>
+    </div>
+  );
+}
+
+function TimeCard({ label, time, offset }: { label: string; time: string; offset: string }) {
+  return (
+    <div className="material-paper rounded-xl border p-3">
+      <p className="font-mono text-[10px] uppercase tracking-[0.15em] opacity-65">{label}</p>
+      <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">{time}</p>
+      <p className="mt-1 font-mono text-[10px] tabular-nums opacity-65">{offset}</p>
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- extracts Scraplet into a reusable paper-creature component with multiple poses
- adds a small family of paper critters for Gallery visitors
- redesigns Space as a clipping drawer with paper cards, stamped labels, a Scraplet shelf, and a characterful empty state
- gives the Time page a day-part companion and paper time cards
- adds Scraplet as Gallery curator and Journal archivist
- turns Atelier into a softer paper-prototype worktable
- keeps motion small and reduced-motion friendly

## Design intent

Move the app away from generic high-tech dashboard styling and toward a warm, tactile digital scrapbook: paper, tape, labels, drawers, worktables, and small resident creatures.

## Validation

CI requested on this PR; I’ll address any failures before merging.