### PR TITLE
Prototype Kumiko-informed lattice sigils

### DIFF
--- a/app/sigil-lab/page.tsx
+++ b/app/sigil-lab/page.tsx
@@ -1,4 +1,5 @@
 import { AgentSigilLab } from '@/components/labs/agent-sigil-lab';
+import { KumikoSigilLab } from '@/components/labs/kumiko-sigil-lab';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { ArrowLeft } from 'lucide-react';
 import type { Metadata } from 'next';
@@ -36,13 +37,13 @@ export default function AgentSigilLabPage() {
             Back to gallery
           </Link>
           <p className="mt-6 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Issue #435 · identity generation reference
+            Issues #435 and #447 · identity generation reference
           </p>
           <h1 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
             Generative sigils for agents
           </h1>
           <p className="mx-auto mt-4 max-w-2xl text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
-            Each mark is assembled from circles, arcs, petals, rounded tiles, rings, symmetry, overlap, and a seeded palette. The same identity inputs and generation selection always produce the same SVG.
+            The lab compares the current layered identity system with quieter construction-graph experiments. Stable inputs and explicit variants always produce the same SVG; experimental lineages stay here until their full populations are reviewed.
           </p>
         </header>
 
@@ -50,12 +51,16 @@ export default function AgentSigilLabPage() {
           <AgentSigilLab />
         </div>
 
+        <div className="mt-5">
+          <KumikoSigilLab />
+        </div>
+
         <aside className="mx-auto mt-5 max-w-4xl rounded-[1.25rem] border border-border/70 bg-card p-4 text-sm leading-relaxed text-muted-foreground shadow-[0_16px_38px_rgba(35,31,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.24)] sm:p-5">
           <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-foreground">
             Generation contract
           </p>
           <p className="mt-2">
-            The guestbook uses Generation 2 by default. This route remains the population-level reference for comparing generations, verifying layered seed behaviour, and reviewing future palettes or grammars before they become another selectable lineage.
+            The guestbook still uses Generation 2. The Kumiko-informed lattice is a separate Generation 3 experiment with no production integration, and it must pass population-level monochrome, small-size, light/dark, and cross-browser review before becoming selectable.
           </p>
         </aside>
       </main>

--- a/components/agent-kumiko-sigil.tsx
+++ b/components/agent-kumiko-sigil.tsx
@@ -1,0 +1,119 @@
+import {
+  createAgentKumikoSigilRecipe,
+  type AgentKumikoSigilInput,
+  type AgentKumikoSigilRecipe,
+} from '@/lib/agent-kumiko-sigils';
+import type { AgentSigilTone } from '@/lib/agent-sigils';
+
+export type AgentKumikoSigilProps = AgentKumikoSigilInput & {
+  recipe?: AgentKumikoSigilRecipe;
+  size?: number;
+  className?: string;
+  label?: string | null;
+  monochrome?: boolean;
+  debug?: boolean;
+};
+
+function toneColor(
+  recipe: AgentKumikoSigilRecipe,
+  tone: AgentSigilTone,
+  monochrome: boolean,
+) {
+  return monochrome ? 'currentColor' : recipe.palette[tone];
+}
+
+export default function AgentKumikoSigil({
+  recipe: providedRecipe,
+  size = 48,
+  className,
+  label,
+  monochrome = false,
+  debug = false,
+  ...input
+}: AgentKumikoSigilProps) {
+  const recipe = providedRecipe ?? createAgentKumikoSigilRecipe(input);
+  const accessibleLabel =
+    label === undefined
+      ? `${recipe.identity.designation} experimental Kumiko-informed generation ${recipe.generation} sigil ${recipe.fingerprint}`
+      : label;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      className={className}
+      role={accessibleLabel ? 'img' : undefined}
+      aria-label={accessibleLabel ?? undefined}
+      aria-hidden={accessibleLabel === null ? true : undefined}
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      data-agent-kumiko={recipe.fingerprint}
+      data-agent-kumiko-family={recipe.family}
+      data-agent-kumiko-graph={recipe.graphFingerprint}
+      data-agent-kumiko-occupancy={recipe.occupancyDescriptor}
+      data-agent-kumiko-lattice={recipe.layerFingerprints.lattice}
+      data-agent-kumiko-infill={recipe.layerFingerprints.infill}
+      data-agent-kumiko-accents={recipe.layerFingerprints.accents}
+      data-agent-kumiko-palette={recipe.layerFingerprints.palette}
+    >
+      {accessibleLabel ? <title>{accessibleLabel}</title> : null}
+      {recipe.struts.map((strut, index) => {
+        const from = recipe.nodes[strut.from]!;
+        const to = recipe.nodes[strut.to]!;
+        return (
+          <line
+            key={`strut-${index}`}
+            x1={from.x}
+            y1={from.y}
+            x2={to.x}
+            y2={to.y}
+            stroke={toneColor(recipe, strut.tone, monochrome)}
+            strokeOpacity={strut.opacity}
+            strokeWidth={strut.width}
+            data-kumiko-strut-role={strut.role}
+          />
+        );
+      })}
+      {recipe.joints.map((joint, index) => {
+        const point = recipe.nodes[joint.node]!;
+        return (
+          <circle
+            key={`joint-${index}`}
+            cx={point.x}
+            cy={point.y}
+            r={joint.radius}
+            fill={toneColor(recipe, joint.tone, monochrome)}
+            fillOpacity={joint.opacity}
+            data-kumiko-joint
+          />
+        );
+      })}
+      {debug
+        ? recipe.nodes.map((point, index) => (
+            <g key={`debug-${index}`} data-kumiko-debug-node>
+              <circle
+                cx={point.x}
+                cy={point.y}
+                r={1.15}
+                fill="none"
+                stroke="currentColor"
+                strokeOpacity={0.45}
+                strokeWidth={0.55}
+              />
+              <text
+                x={point.x + 1.8}
+                y={point.y - 1.8}
+                fill="currentColor"
+                fillOpacity={0.55}
+                fontSize={3}
+              >
+                {index}
+              </text>
+            </g>
+          ))
+        : null}
+    </svg>
+  );
+}

--- a/components/labs/kumiko-sigil-lab.tsx
+++ b/components/labs/kumiko-sigil-lab.tsx
@@ -1,0 +1,403 @@
+import AgentIdentitySigil from '@/components/agent-identity-sigil';
+import AgentKumikoSigil from '@/components/agent-kumiko-sigil';
+import {
+  agentKumikoFamilies,
+  agentKumikoOccupancyDistance,
+  createAgentKumikoSigilRecipe,
+  createDistinctAgentKumikoPopulation,
+  type AgentKumikoSigilInput,
+} from '@/lib/agent-kumiko-sigils';
+
+const kumikoIdentities: AgentKumikoSigilInput[] = [
+  {
+    scope: 'openai/codex',
+    designation: 'Testing review',
+    description: 'Found three actionable test findings in the current patch.',
+  },
+  {
+    scope: 'openai/codex',
+    designation: 'Change size',
+    description: 'Split a large patch below the repository review threshold.',
+  },
+  {
+    scope: 'openai/codex',
+    designation: 'Context review',
+    description: 'Checked the model-visible context for missing constraints.',
+  },
+  {
+    scope: 'openai/codex',
+    designation: 'Breaking changes',
+    description: 'Reviewed the public surface for compatibility changes.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing audit',
+    description: 'Verified the current browser and unit coverage before handoff.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Breaking Changes final',
+    description: 'Closed the last material documentation correction.',
+  },
+  {
+    scope: 'teamleaderleo/stensibly',
+    designation: 'Context audit',
+    description: 'Checked the active coordination lanes and their handoffs.',
+  },
+  {
+    scope: 'teamleaderleo/proofwake',
+    designation: 'Size review',
+    description: 'Measured a focused patch against the project review boundary.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 1 coordination',
+    description: 'Integrated clean work and kept acceptance-blocked work isolated.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 2 behaviour review',
+    description: 'Checked input behaviour and shortcut ownership.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 3 regression audit',
+    description: 'Reviewed the time control and browser regression surface.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 4 visual review',
+    description: 'Compared the shared visual language across current surfaces.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 5 integration',
+    description: 'Reconciled the compact homepage and its browser evidence.',
+  },
+  {
+    scope: 'teamleaderleo/stensibly',
+    designation: 'Thread Compass',
+    description: 'Mapped four moving lanes and documented the next handoff.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Fifth Drawer',
+    description: 'Audited the crowded workbench and divided the next pass.',
+  },
+  {
+    scope: 'teamleaderleo/gh-tidy-branches',
+    designation: 'Release Raccoon',
+    description: 'Found the release metadata trap and verified installation.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Codex Routekeeper',
+    description: 'Kept old pages visible while routes warmed.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Mothbit Gallery Room',
+    description: 'Built the first draggable gallery scene without trapping scroll.',
+  },
+];
+
+const contactInputs = kumikoIdentities.map((identity, index) => ({
+  ...identity,
+  family: agentKumikoFamilies[index % agentKumikoFamilies.length],
+}));
+
+const contactRecipes = createDistinctAgentKumikoPopulation(contactInputs, {
+  minimumOccupancyDistance: 8,
+});
+
+const minimumPopulationDistance = contactRecipes.reduce((minimum, recipe, index) => {
+  const distances = contactRecipes
+    .slice(0, index)
+    .map((other) =>
+      agentKumikoOccupancyDistance(recipe.occupancyDescriptor, other.occupancyDescriptor),
+    );
+  return distances.length === 0 ? minimum : Math.min(minimum, ...distances);
+}, Number.POSITIVE_INFINITY);
+
+const layerExamples: Array<AgentKumikoSigilInput & { label: string }> = [
+  {
+    label: 'Baseline',
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing review',
+    description: 'Found three actionable test findings.',
+    family: 'diamond-weave',
+    complexity: 'regular',
+  },
+  {
+    label: 'Assignment changed',
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing review',
+    description: 'Reviewed release documentation and compatibility notes.',
+    family: 'diamond-weave',
+    complexity: 'regular',
+  },
+  {
+    label: 'No assignment accent',
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing review',
+    family: 'diamond-weave',
+    complexity: 'regular',
+  },
+];
+
+export function KumikoSigilLab() {
+  return (
+    <div className="space-y-5" data-kumiko-lab>
+      <section className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 shadow-[0_18px_42px_rgba(28,26,24,0.08)] dark:shadow-[0_18px_42px_rgba(0,0,0,0.24)] sm:p-5">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Issue #447 · isolated lattice experiment
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight">
+              Kumiko-informed construction graphs
+            </h2>
+          </div>
+          <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+            Thin struts, visible joints, selected infill, and protected voids replace the
+            usual stack of rings and decorative satellites. This is a procedural study of
+            construction logic, not a claim of authentic Kumiko craft.
+          </p>
+        </div>
+
+        <div className="mt-4 grid gap-3 lg:grid-cols-3">
+          <div className="rounded-xl border border-border/65 bg-background p-3">
+            <p className="font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Scope
+            </p>
+            <p className="mt-1 text-sm">Family, proportion, rotation, and reflection</p>
+          </div>
+          <div className="rounded-xl border border-border/65 bg-background p-3">
+            <p className="font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Designation
+            </p>
+            <p className="mt-1 text-sm">Joint cadence, retained braces, and internal infill</p>
+          </div>
+          <div className="rounded-xl border border-border/65 bg-background p-3">
+            <p className="font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Description
+            </p>
+            <p className="mt-1 text-sm">One highlighted strut or joint; geometry stays fixed</p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        data-kumiko-contact-sheet
+        data-kumiko-minimum-distance={minimumPopulationDistance}
+        className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Labels-hidden monochrome review
+            </p>
+            <h2 className="mt-1 text-lg font-semibold tracking-tight">
+              Geometry has to carry the identity before colour
+            </h2>
+          </div>
+          <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+            The population helper rerolls reproducible variants until canonical graphs are
+            unique and coarse 12×12 occupancy descriptors remain separated. Minimum observed
+            distance: {Number.isFinite(minimumPopulationDistance) ? minimumPopulationDistance : 0}.
+          </p>
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-2 sm:grid-cols-6 lg:grid-cols-9">
+          {contactRecipes.map((recipe) => (
+            <div
+              key={`${recipe.identity.scope}:${recipe.identity.designation}`}
+              data-kumiko-contact-card
+              data-kumiko-family={recipe.family}
+              data-kumiko-graph={recipe.graphFingerprint}
+              data-kumiko-occupancy={recipe.occupancyDescriptor}
+              className="grid aspect-square place-items-center rounded-xl border border-border/65 bg-background p-2 text-foreground"
+            >
+              <AgentKumikoSigil
+                {...recipe.identity}
+                recipe={recipe}
+                size={58}
+                monochrome
+                label={`${recipe.identity.designation} monochrome Kumiko-informed lattice`}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+          Same identities · different lineage
+        </p>
+        <h2 className="mt-1 text-lg font-semibold tracking-tight">
+          Generation 2 beside the lattice experiment
+        </h2>
+        <div className="mt-4 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-3">
+          {kumikoIdentities.slice(0, 6).map((identity, index) => {
+            const kumikoInput = {
+              ...identity,
+              family: agentKumikoFamilies[index % agentKumikoFamilies.length],
+            };
+            const recipe = createAgentKumikoSigilRecipe(kumikoInput);
+            return (
+              <article
+                key={`${identity.scope}:${identity.designation}`}
+                data-kumiko-comparison
+                className="rounded-[1.1rem] border border-border/70 bg-background p-3"
+              >
+                <div className="flex items-center justify-center gap-5">
+                  <div className="grid place-items-center gap-1.5">
+                    <AgentIdentitySigil {...identity} size={58} />
+                    <span className="font-mono text-[8px] uppercase tracking-[0.12em] text-muted-foreground">
+                      Generation 2
+                    </span>
+                  </div>
+                  <div className="h-12 w-px bg-border" aria-hidden="true" />
+                  <div className="grid place-items-center gap-1.5">
+                    <AgentKumikoSigil {...kumikoInput} recipe={recipe} size={58} />
+                    <span className="font-mono text-[8px] uppercase tracking-[0.12em] text-muted-foreground">
+                      {recipe.family}
+                    </span>
+                  </div>
+                </div>
+                <p className="mt-2 truncate text-center text-xs font-medium">
+                  {identity.designation}
+                </p>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+          Eight construction families
+        </p>
+        <h2 className="mt-1 text-lg font-semibold tracking-tight">
+          Different topologies, not one badge with renamed parameters
+        </h2>
+        <div className="mt-4 grid grid-cols-2 gap-2.5 sm:grid-cols-4 xl:grid-cols-8">
+          {agentKumikoFamilies.map((family) => {
+            const input = {
+              scope: `lab/${family}`,
+              designation: 'Lattice specimen',
+              description: 'Highlight one reviewed joint.',
+              family,
+              complexity: 'regular' as const,
+            };
+            const recipe = createAgentKumikoSigilRecipe(input);
+            return (
+              <div
+                key={family}
+                data-kumiko-family-card
+                data-kumiko-family={family}
+                className="grid min-w-0 place-items-center rounded-xl border border-border/65 bg-background p-3 text-center"
+              >
+                <AgentKumikoSigil {...input} recipe={recipe} size={68} />
+                <span className="mt-2 text-[10px] font-medium leading-tight">
+                  {family.replaceAll('-', ' ')}
+                </span>
+                <span className="mt-1 font-mono text-[8px] uppercase tracking-[0.08em] text-muted-foreground">
+                  {recipe.struts.length} struts · {recipe.protectedVoids} voids
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid min-w-0 gap-5 lg:grid-cols-2">
+        <div className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5">
+          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+            Description isolation
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight">
+            Assignment edits change an accent, not the graph
+          </h2>
+          <div className="mt-4 grid grid-cols-3 gap-2.5">
+            {layerExamples.map(({ label, ...input }) => {
+              const recipe = createAgentKumikoSigilRecipe(input);
+              return (
+                <div
+                  key={label}
+                  data-kumiko-layer-example
+                  className="grid place-items-center rounded-xl border border-border/65 bg-background p-3 text-center"
+                >
+                  <AgentKumikoSigil {...input} recipe={recipe} size={68} />
+                  <span className="mt-2 text-xs font-medium">{label}</span>
+                  <span className="mt-1 font-mono text-[8px] uppercase tracking-[0.08em] text-muted-foreground">
+                    {recipe.graphFingerprint.slice(0, 4)} ·{' '}
+                    {recipe.layerFingerprints.accents.slice(0, 4)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5">
+          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+            Construction graph overlay
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight">
+            Nodes and joints stay inspectable
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            The debug view exposes numbered graph nodes. The shipping renderer uses only the
+            struts and selected high-degree joints.
+          </p>
+          <div
+            data-kumiko-debug
+            className="mt-4 grid place-items-center rounded-xl border border-border/65 bg-background p-4"
+          >
+            <AgentKumikoSigil
+              scope="teamleaderleo/scrapbook"
+              designation="Construction review"
+              description="Inspect the selected joint."
+              family="nested-joint"
+              complexity="regular"
+              size={150}
+              debug
+            />
+          </div>
+        </div>
+      </section>
+
+      <section
+        data-kumiko-small-sizes
+        className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Small-size check
+            </p>
+            <h2 className="mt-1 text-lg font-semibold tracking-tight">
+              Struts and voids must survive before extra infill appears
+            </h2>
+          </div>
+          <div className="flex items-end gap-4 rounded-xl border border-border/65 bg-background px-4 py-3">
+            {[16, 24, 32, 48, 72].map((size) => (
+              <div key={size} className="grid place-items-center gap-1">
+                <AgentKumikoSigil
+                  scope="openai/codex"
+                  designation="Breaking changes"
+                  description="Reviewed compatibility changes."
+                  family="triangular-brace"
+                  size={size}
+                  monochrome
+                />
+                <span className="font-mono text-[8px] text-muted-foreground">{size}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lib/agent-kumiko-sigils.test.ts
+++ b/lib/agent-kumiko-sigils.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  agentKumikoFamilies,
+  agentKumikoOccupancyDistance,
+  createAgentKumikoSigilRecipe,
+  createDistinctAgentKumikoPopulation,
+  generateAgentKumikoSigil,
+  renderAgentKumikoSigilSvg,
+} from './agent-kumiko-sigils';
+
+const baseIdentity = {
+  scope: 'teamleaderleo/scrapbook',
+  designation: 'Testing review',
+  description: 'Found three actionable test findings in the current patch.',
+  family: 'diamond-weave' as const,
+};
+
+describe('experimental Kumiko-informed agent sigils', () => {
+  it('repeats the exact construction graph for the same layered inputs', () => {
+    expect(createAgentKumikoSigilRecipe(baseIdentity)).toEqual(
+      createAgentKumikoSigilRecipe(baseIdentity),
+    );
+  });
+
+  it('keeps description changes inside the accent layer', () => {
+    const original = createAgentKumikoSigilRecipe(baseIdentity);
+    const reassigned = createAgentKumikoSigilRecipe({
+      ...baseIdentity,
+      description: 'Reviewed release documentation and compatibility notes.',
+    });
+
+    expect(reassigned.graphFingerprint).toBe(original.graphFingerprint);
+    expect(reassigned.occupancyDescriptor).toBe(original.occupancyDescriptor);
+    expect(reassigned.layerFingerprints.lattice).toBe(original.layerFingerprints.lattice);
+    expect(reassigned.layerFingerprints.infill).toBe(original.layerFingerprints.infill);
+    expect(reassigned.layerFingerprints.palette).toBe(original.layerFingerprints.palette);
+    expect(reassigned.layerFingerprints.accents).not.toBe(
+      original.layerFingerprints.accents,
+    );
+    expect(reassigned.paletteName).toBe(original.paletteName);
+  });
+
+  it('lets scope alter the lattice without recolouring from the description', () => {
+    const original = createAgentKumikoSigilRecipe(baseIdentity);
+    const moved = createAgentKumikoSigilRecipe({
+      ...baseIdentity,
+      scope: 'teamleaderleo/stensibly',
+    });
+
+    expect(moved.layerFingerprints.lattice).not.toBe(
+      original.layerFingerprints.lattice,
+    );
+    expect(moved.graphFingerprint).not.toBe(original.graphFingerprint);
+  });
+
+  it('lets designation alter infill while keeping description out of palette selection', () => {
+    const original = createAgentKumikoSigilRecipe(baseIdentity);
+    const renamed = createAgentKumikoSigilRecipe({
+      ...baseIdentity,
+      designation: 'Context review',
+    });
+    const wordingOnly = createAgentKumikoSigilRecipe({
+      ...baseIdentity,
+      description: 'A completely different assignment sentence.',
+    });
+
+    expect(renamed.layerFingerprints.infill).not.toBe(
+      original.layerFingerprints.infill,
+    );
+    expect(wordingOnly.layerFingerprints.palette).toBe(
+      original.layerFingerprints.palette,
+    );
+  });
+
+  it('provides eight visibly different construction families', () => {
+    const recipes = agentKumikoFamilies.map((family) =>
+      createAgentKumikoSigilRecipe({
+        scope: `lab/${family}`,
+        designation: 'Lattice specimen',
+        description: 'Highlight one reviewed joint.',
+        family,
+        complexity: 'regular',
+      }),
+    );
+
+    expect(new Set(recipes.map((recipe) => recipe.graphFingerprint)).size).toBe(
+      agentKumikoFamilies.length,
+    );
+    expect(new Set(recipes.map((recipe) => recipe.occupancyDescriptor)).size).toBe(
+      agentKumikoFamilies.length,
+    );
+    expect(recipes.every((recipe) => recipe.protectedVoids >= 2)).toBe(true);
+  });
+
+  it('selects a deterministic population with separated occupancy descriptors', () => {
+    const inputs = agentKumikoFamilies.map((family, index) => ({
+      scope: `population/project-${index}`,
+      designation: `Review designation ${index}`,
+      description: `Assignment ${index}`,
+      family,
+    }));
+    const first = createDistinctAgentKumikoPopulation(inputs, {
+      minimumOccupancyDistance: 8,
+    });
+    const second = createDistinctAgentKumikoPopulation(inputs, {
+      minimumOccupancyDistance: 8,
+    });
+
+    expect(first).toEqual(second);
+    expect(new Set(first.map((recipe) => recipe.graphFingerprint)).size).toBe(
+      first.length,
+    );
+
+    for (let left = 0; left < first.length; left += 1) {
+      for (let right = left + 1; right < first.length; right += 1) {
+        expect(
+          agentKumikoOccupancyDistance(
+            first[left]!.occupancyDescriptor,
+            first[right]!.occupancyDescriptor,
+          ),
+        ).toBeGreaterThanOrEqual(8);
+      }
+    }
+  });
+
+  it('keeps output bounded, portable, and legible as monochrome SVG', () => {
+    for (let index = 0; index < 96; index += 1) {
+      const generated = generateAgentKumikoSigil({
+        scope: `owner/project-${index % 11}`,
+        designation: `Agent designation ${index}`,
+        description: `Assignment description ${index % 13}`,
+        variant: index % 7,
+        family: agentKumikoFamilies[index % agentKumikoFamilies.length],
+        complexity:
+          index % 3 === 0 ? 'dense' : index % 2 === 0 ? 'quiet' : 'regular',
+      });
+      const monochrome = renderAgentKumikoSigilSvg(generated.recipe, {
+        size: 24,
+        monochrome: true,
+      });
+
+      expect(generated.recipe.nodes.length).toBeGreaterThanOrEqual(6);
+      expect(generated.recipe.struts.length).toBeGreaterThanOrEqual(5);
+      expect(generated.recipe.struts.length).toBeLessThanOrEqual(36);
+      expect(generated.svg.length).toBeLessThan(20_000);
+      expect(generated.dataUri.startsWith('data:image/svg+xml,')).toBe(true);
+      expect(generated.svg).not.toContain('<script');
+      expect(monochrome).toContain('currentColor');
+      expect(monochrome).toContain('width="24"');
+    }
+  });
+
+  it('rejects empty and unbounded identity fields', () => {
+    expect(() =>
+      createAgentKumikoSigilRecipe({ scope: ' ', designation: 'Testing review' }),
+    ).toThrow(/scope must not be empty/i);
+    expect(() =>
+      createAgentKumikoSigilRecipe({
+        scope: 'teamleaderleo/scrapbook',
+        designation: ' ',
+      }),
+    ).toThrow(/designation must not be empty/i);
+    expect(() =>
+      createAgentKumikoSigilRecipe({
+        scope: 'teamleaderleo/scrapbook',
+        designation: 'Testing review',
+        description: 'x'.repeat(513),
+      }),
+    ).toThrow(/description must contain at most 512/i);
+  });
+});

--- a/lib/agent-kumiko-sigils.ts
+++ b/lib/agent-kumiko-sigils.ts
@@ -1,0 +1,776 @@
+import {
+  createAgentSigilRecipe,
+  type AgentSigilComplexity,
+  type AgentSigilPalette,
+  type AgentSigilPaletteMode,
+  type AgentSigilTone,
+} from './agent-sigils';
+
+export const AGENT_KUMIKO_SIGIL_RENDERER_VERSION = 1 as const;
+export const AGENT_KUMIKO_SIGIL_GENERATION = 3 as const;
+
+export const agentKumikoFamilies = [
+  'triangular-brace',
+  'hex-cell',
+  'diamond-weave',
+  'square-sash',
+  'nested-joint',
+  'broken-lattice',
+  'star-joint',
+  'rosette-lattice',
+] as const;
+
+export type AgentKumikoFamily = (typeof agentKumikoFamilies)[number];
+export type AgentKumikoStrutRole = 'primary' | 'secondary' | 'accent';
+
+export type AgentKumikoPoint = {
+  x: number;
+  y: number;
+};
+
+export type AgentKumikoStrut = {
+  from: number;
+  to: number;
+  role: AgentKumikoStrutRole;
+  tone: AgentSigilTone;
+  opacity: number;
+  width: number;
+};
+
+export type AgentKumikoJoint = {
+  node: number;
+  tone: AgentSigilTone;
+  opacity: number;
+  radius: number;
+};
+
+export type AgentKumikoSigilInput = {
+  /** Stable repository, project, or organisation identifier. Controls the lattice family and proportion. */
+  scope: string;
+  /** Agent title or designation. Controls the joint cadence and internal infill. */
+  designation: string;
+  /** Work note. Selects at most one accent without changing the lattice geometry or palette. */
+  description?: string;
+  /** Reproducible candidate inside this experimental lineage. */
+  variant?: number;
+  palette?: AgentSigilPaletteMode;
+  /** Quiet is the default for this experiment. */
+  complexity?: AgentSigilComplexity;
+  /** Explicit lab-only family override. Normal generation lets scope select the family. */
+  family?: AgentKumikoFamily;
+};
+
+export type AgentKumikoSigilRecipe = {
+  rendererVersion: typeof AGENT_KUMIKO_SIGIL_RENDERER_VERSION;
+  generation: typeof AGENT_KUMIKO_SIGIL_GENERATION;
+  variant: number;
+  family: AgentKumikoFamily;
+  identity: {
+    scope: string;
+    designation: string;
+    description: string;
+  };
+  complexity: AgentSigilComplexity;
+  paletteName: string;
+  palette: AgentSigilPalette;
+  rotation: number;
+  reflected: boolean;
+  nodes: AgentKumikoPoint[];
+  struts: AgentKumikoStrut[];
+  joints: AgentKumikoJoint[];
+  protectedVoids: number;
+  fingerprint: string;
+  graphFingerprint: string;
+  occupancyDescriptor: string;
+  layerFingerprints: {
+    lattice: string;
+    infill: string;
+    accents: string;
+    palette: string;
+  };
+};
+
+export type GeneratedAgentKumikoSigil = {
+  recipe: AgentKumikoSigilRecipe;
+  svg: string;
+  dataUri: string;
+  accessibleLabel: string;
+};
+
+type RawStrut = {
+  from: number;
+  to: number;
+  role: Exclude<AgentKumikoStrutRole, 'accent'>;
+};
+
+type RawGraph = {
+  nodes: AgentKumikoPoint[];
+  struts: RawStrut[];
+  protectedVoids: number;
+};
+
+const MAX_SCOPE_LENGTH = 192;
+const MAX_DESIGNATION_LENGTH = 160;
+const MAX_DESCRIPTION_LENGTH = 512;
+const OCCUPANCY_GRID_SIZE = 12;
+
+function normaliseRequired(value: string, label: string, maximum: number) {
+  const normalised = value.trim().replace(/\s+/g, ' ');
+  if (!normalised) throw new Error(`Agent Kumiko sigil ${label} must not be empty.`);
+  if (normalised.length > maximum) {
+    throw new Error(`Agent Kumiko sigil ${label} must contain at most ${maximum} characters.`);
+  }
+  return normalised;
+}
+
+function normaliseDescription(value: string | undefined) {
+  const normalised = value?.trim().replace(/\s+/g, ' ') ?? '';
+  if (normalised.length > MAX_DESCRIPTION_LENGTH) {
+    throw new Error(
+      `Agent Kumiko sigil description must contain at most ${MAX_DESCRIPTION_LENGTH} characters.`,
+    );
+  }
+  return normalised;
+}
+
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function fingerprint(value: string) {
+  return hashString(value).toString(16).padStart(8, '0');
+}
+
+function createRandom(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function between(random: () => number, minimum: number, maximum: number) {
+  return minimum + (maximum - minimum) * random();
+}
+
+function integer(random: () => number, minimum: number, maximum: number) {
+  return Math.floor(between(random, minimum, maximum + 1));
+}
+
+function choose<T>(random: () => number, values: readonly T[]) {
+  return values[Math.min(values.length - 1, Math.floor(random() * values.length))]!;
+}
+
+function round(value: number, precision = 3) {
+  const scale = 10 ** precision;
+  return Math.round(value * scale) / scale;
+}
+
+function polar(radius: number, angleDegrees: number): AgentKumikoPoint {
+  const angle = (angleDegrees * Math.PI) / 180;
+  return {
+    x: round(50 + Math.cos(angle) * radius),
+    y: round(50 + Math.sin(angle) * radius),
+  };
+}
+
+function edge(
+  from: number,
+  to: number,
+  role: Exclude<AgentKumikoStrutRole, 'accent'> = 'primary',
+): RawStrut {
+  return { from, to, role };
+}
+
+function triangularBraceGraph(random: () => number): RawGraph {
+  const shoulder = between(random, 31, 36);
+  const nodes = [
+    { x: 50, y: 12 },
+    { x: 17, y: 80 },
+    { x: 83, y: 80 },
+    { x: 50, y: 54 },
+    { x: shoulder, y: 43 },
+    { x: 100 - shoulder, y: 43 },
+  ];
+  return {
+    nodes,
+    struts: [
+      edge(0, 4),
+      edge(0, 5),
+      edge(4, 1),
+      edge(5, 2),
+      edge(4, 3),
+      edge(5, 3),
+      edge(3, 1, 'secondary'),
+      edge(3, 2, 'secondary'),
+      edge(1, 2, 'secondary'),
+    ],
+    protectedVoids: 3,
+  };
+}
+
+function hexCellGraph(random: () => number): RawGraph {
+  const rotation = choose(random, [0, 30] as const);
+  const outer = Array.from({ length: 6 }, (_, index) => polar(35, rotation + index * 60));
+  const inner = Array.from({ length: 3 }, (_, index) => polar(14, rotation + 30 + index * 120));
+  const nodes = [...outer, ...inner, { x: 50, y: 50 }];
+  return {
+    nodes,
+    struts: [
+      edge(0, 1),
+      edge(1, 2),
+      edge(2, 3),
+      edge(3, 4),
+      edge(4, 5),
+      edge(0, 6, 'secondary'),
+      edge(2, 7, 'secondary'),
+      edge(4, 8, 'secondary'),
+      edge(6, 7),
+      edge(7, 8),
+      edge(8, 6),
+      edge(6, 9, 'secondary'),
+      edge(7, 9, 'secondary'),
+      edge(8, 9, 'secondary'),
+    ],
+    protectedVoids: 4,
+  };
+}
+
+function diamondWeaveGraph(random: () => number): RawGraph {
+  const spread = between(random, 25, 31);
+  const nodes = [
+    { x: 50, y: 10 },
+    { x: 50 - spread, y: 31 },
+    { x: 50 + spread, y: 31 },
+    { x: 50, y: 50 },
+    { x: 50 - spread, y: 69 },
+    { x: 50 + spread, y: 69 },
+    { x: 50, y: 90 },
+    { x: 30, y: 50 },
+    { x: 70, y: 50 },
+  ];
+  return {
+    nodes,
+    struts: [
+      edge(0, 1),
+      edge(0, 2),
+      edge(1, 3),
+      edge(2, 3),
+      edge(3, 4),
+      edge(3, 5),
+      edge(4, 6),
+      edge(5, 6),
+      edge(1, 7, 'secondary'),
+      edge(7, 4, 'secondary'),
+      edge(2, 8, 'secondary'),
+      edge(8, 5, 'secondary'),
+      edge(7, 3, 'secondary'),
+      edge(3, 8, 'secondary'),
+    ],
+    protectedVoids: 4,
+  };
+}
+
+function squareSashGraph(random: () => number): RawGraph {
+  const inset = between(random, 16, 21);
+  const far = 100 - inset;
+  const nodes = [
+    { x: inset, y: inset },
+    { x: 50, y: inset },
+    { x: far, y: inset },
+    { x: far, y: 50 },
+    { x: far, y: far },
+    { x: 50, y: far },
+    { x: inset, y: far },
+    { x: inset, y: 50 },
+    { x: 50, y: 50 },
+    { x: 35, y: 35 },
+    { x: 65, y: 35 },
+    { x: 65, y: 65 },
+    { x: 35, y: 65 },
+  ];
+  return {
+    nodes,
+    struts: [
+      edge(0, 1),
+      edge(1, 2),
+      edge(2, 3),
+      edge(3, 4),
+      edge(4, 5),
+      edge(5, 6),
+      edge(7, 0),
+      edge(9, 10),
+      edge(10, 11),
+      edge(11, 12),
+      edge(12, 9),
+      edge(1, 8, 'secondary'),
+      edge(3, 8, 'secondary'),
+      edge(5, 8, 'secondary'),
+      edge(7, 8, 'secondary'),
+    ],
+    protectedVoids: 5,
+  };
+}
+
+function nestedJointGraph(random: () => number): RawGraph {
+  const outerRadius = between(random, 36, 40);
+  const innerRadius = between(random, 15, 19);
+  const outer = Array.from({ length: 4 }, (_, index) => polar(outerRadius, -90 + index * 90));
+  const inner = Array.from({ length: 4 }, (_, index) => polar(innerRadius, -45 + index * 90));
+  return {
+    nodes: [...outer, ...inner],
+    struts: [
+      edge(0, 1),
+      edge(1, 2),
+      edge(2, 3),
+      edge(4, 5),
+      edge(5, 6),
+      edge(6, 7),
+      edge(7, 4),
+      edge(0, 4, 'secondary'),
+      edge(1, 5, 'secondary'),
+      edge(2, 6, 'secondary'),
+      edge(3, 7, 'secondary'),
+      edge(4, 6, 'secondary'),
+      edge(5, 7, 'secondary'),
+    ],
+    protectedVoids: 5,
+  };
+}
+
+function brokenLatticeGraph(random: () => number): RawGraph {
+  const coordinates = [19, 50, 81];
+  const nodes = coordinates.flatMap((y) => coordinates.map((x) => ({ x, y })));
+  const candidates = [
+    edge(0, 1),
+    edge(1, 2),
+    edge(3, 4),
+    edge(4, 5),
+    edge(6, 7),
+    edge(7, 8),
+    edge(0, 3),
+    edge(3, 6),
+    edge(1, 4),
+    edge(4, 7),
+    edge(2, 5),
+    edge(5, 8),
+    edge(0, 4, 'secondary'),
+    edge(2, 4, 'secondary'),
+    edge(4, 6, 'secondary'),
+    edge(4, 8, 'secondary'),
+  ];
+  const required = new Set([1, 2, 6, 9, 10]);
+  const struts = candidates.filter((_, index) => required.has(index) || random() > 0.48);
+  return {
+    nodes,
+    struts,
+    protectedVoids: Math.max(2, 8 - Math.floor(struts.length / 2)),
+  };
+}
+
+function starJointGraph(random: () => number): RawGraph {
+  const rotation = choose(random, [0, 22.5] as const);
+  const outer = Array.from({ length: 8 }, (_, index) => polar(37, rotation + index * 45));
+  const inner = Array.from({ length: 4 }, (_, index) => polar(15, rotation + index * 90));
+  const nodes = [{ x: 50, y: 50 }, ...outer, ...inner];
+  return {
+    nodes,
+    struts: [
+      edge(0, 9),
+      edge(0, 10),
+      edge(0, 11),
+      edge(0, 12),
+      edge(9, 1),
+      edge(9, 2, 'secondary'),
+      edge(10, 3),
+      edge(10, 4, 'secondary'),
+      edge(11, 5),
+      edge(11, 6, 'secondary'),
+      edge(12, 7),
+      edge(12, 8, 'secondary'),
+      edge(1, 2, 'secondary'),
+      edge(3, 4, 'secondary'),
+      edge(5, 6, 'secondary'),
+      edge(7, 8, 'secondary'),
+    ],
+    protectedVoids: 6,
+  };
+}
+
+function rosetteLatticeGraph(random: () => number): RawGraph {
+  const count = choose(random, [6, 8] as const);
+  const rotation = count === 6 ? 0 : 22.5;
+  const inner = Array.from({ length: count }, (_, index) =>
+    polar(between(random, 20, 23), rotation + index * (360 / count)),
+  );
+  const outer = Array.from({ length: count }, (_, index) =>
+    polar(between(random, 35, 39), rotation + index * (360 / count)),
+  );
+  const nodes = [{ x: 50, y: 50 }, ...inner, ...outer];
+  const struts: RawStrut[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const innerIndex = 1 + index;
+    const nextInnerIndex = 1 + ((index + 1) % count);
+    const outerIndex = 1 + count + index;
+    struts.push(edge(innerIndex, nextInnerIndex));
+    if (index % 2 === 0) struts.push(edge(0, innerIndex, 'secondary'));
+    struts.push(edge(innerIndex, outerIndex, index % 2 === 0 ? 'primary' : 'secondary'));
+    if (index % 3 !== 1) {
+      struts.push(edge(outerIndex, 1 + count + ((index + 1) % count), 'secondary'));
+    }
+  }
+  return {
+    nodes,
+    struts,
+    protectedVoids: count,
+  };
+}
+
+function graphFor(family: AgentKumikoFamily, random: () => number) {
+  if (family === 'triangular-brace') return triangularBraceGraph(random);
+  if (family === 'hex-cell') return hexCellGraph(random);
+  if (family === 'diamond-weave') return diamondWeaveGraph(random);
+  if (family === 'square-sash') return squareSashGraph(random);
+  if (family === 'nested-joint') return nestedJointGraph(random);
+  if (family === 'broken-lattice') return brokenLatticeGraph(random);
+  if (family === 'star-joint') return starJointGraph(random);
+  return rosetteLatticeGraph(random);
+}
+
+function transformPoint(
+  point: AgentKumikoPoint,
+  rotation: number,
+  reflected: boolean,
+  scaleX: number,
+  scaleY: number,
+): AgentKumikoPoint {
+  const sourceX = reflected ? 100 - point.x : point.x;
+  const scaledX = 50 + (sourceX - 50) * scaleX;
+  const scaledY = 50 + (point.y - 50) * scaleY;
+  const angle = (rotation * Math.PI) / 180;
+  const x = scaledX - 50;
+  const y = scaledY - 50;
+  return {
+    x: round(50 + x * Math.cos(angle) - y * Math.sin(angle)),
+    y: round(50 + x * Math.sin(angle) + y * Math.cos(angle)),
+  };
+}
+
+function graphString(nodes: AgentKumikoPoint[], struts: RawStrut[]) {
+  const nodeString = nodes.map((node) => `${round(node.x, 1)},${round(node.y, 1)}`).join(';');
+  const edgeString = struts
+    .map((strut) => {
+      const start = Math.min(strut.from, strut.to);
+      const end = Math.max(strut.from, strut.to);
+      return `${start}-${end}-${strut.role}`;
+    })
+    .sort()
+    .join(';');
+  return `${nodeString}|${edgeString}`;
+}
+
+function occupancyDescriptor(nodes: AgentKumikoPoint[], struts: RawStrut[]) {
+  const cells = Array.from({ length: OCCUPANCY_GRID_SIZE * OCCUPANCY_GRID_SIZE }, () => false);
+  for (const strut of struts) {
+    const from = nodes[strut.from];
+    const to = nodes[strut.to];
+    if (!from || !to) continue;
+    for (let step = 0; step <= 32; step += 1) {
+      const progress = step / 32;
+      const x = from.x + (to.x - from.x) * progress;
+      const y = from.y + (to.y - from.y) * progress;
+      const column = Math.max(
+        0,
+        Math.min(OCCUPANCY_GRID_SIZE - 1, Math.floor((x / 100) * OCCUPANCY_GRID_SIZE)),
+      );
+      const row = Math.max(
+        0,
+        Math.min(OCCUPANCY_GRID_SIZE - 1, Math.floor((y / 100) * OCCUPANCY_GRID_SIZE)),
+      );
+      cells[row * OCCUPANCY_GRID_SIZE + column] = true;
+    }
+  }
+  return cells.map((value) => (value ? '1' : '0')).join('');
+}
+
+export function agentKumikoOccupancyDistance(left: string, right: string) {
+  const length = Math.max(left.length, right.length);
+  let distance = 0;
+  for (let index = 0; index < length; index += 1) {
+    if (left[index] !== right[index]) distance += 1;
+  }
+  return distance;
+}
+
+function strutWidth(role: RawStrut['role'], complexity: AgentSigilComplexity) {
+  if (role === 'primary') return complexity === 'dense' ? 4.1 : 4.5;
+  return complexity === 'quiet' ? 2.25 : complexity === 'dense' ? 2.75 : 2.5;
+}
+
+function includedStruts(
+  struts: RawStrut[],
+  complexity: AgentSigilComplexity,
+  random: () => number,
+): RawStrut[] {
+  const primary = struts.filter((strut) => strut.role === 'primary');
+  const secondary = struts.filter((strut) => strut.role === 'secondary');
+  if (complexity === 'quiet') {
+    const allowance = Math.max(1, Math.min(3, Math.floor(primary.length / 4)));
+    return [
+      ...primary,
+      ...secondary
+        .map((strut) => ({ strut, order: random() }))
+        .sort((left, right) => left.order - right.order)
+        .slice(0, allowance)
+        .map(({ strut }) => strut),
+    ];
+  }
+  if (complexity === 'regular') {
+    return [
+      ...primary,
+      ...secondary.filter(() => random() > 0.36),
+    ];
+  }
+  return [...primary, ...secondary];
+}
+
+function visibleJoints(nodes: AgentKumikoPoint[], struts: RawStrut[]): AgentKumikoJoint[] {
+  const degree = Array.from({ length: nodes.length }, () => 0);
+  for (const strut of struts) {
+    degree[strut.from] = (degree[strut.from] ?? 0) + 1;
+    degree[strut.to] = (degree[strut.to] ?? 0) + 1;
+  }
+  return degree.flatMap((value, node) =>
+    value >= 3
+      ? [
+          {
+            node,
+            tone: 'highlight' as const,
+            opacity: value >= 5 ? 0.84 : 0.64,
+            radius: value >= 5 ? 2.25 : 1.65,
+          },
+        ]
+      : [],
+  );
+}
+
+export function createAgentKumikoSigilRecipe(
+  input: AgentKumikoSigilInput,
+): AgentKumikoSigilRecipe {
+  const scope = normaliseRequired(input.scope, 'scope', MAX_SCOPE_LENGTH);
+  const designation = normaliseRequired(
+    input.designation,
+    'designation',
+    MAX_DESIGNATION_LENGTH,
+  );
+  const description = normaliseDescription(input.description);
+  const variant = Math.max(0, Math.floor(input.variant ?? 0));
+  const complexity = input.complexity ?? 'quiet';
+  const paletteMode = input.palette ?? 'auto';
+
+  const scopeRandom = createRandom(hashString(`g3-kumiko:scope:${variant}:${scope}`));
+  const designationRandom = createRandom(
+    hashString(`g3-kumiko:designation:${variant}:${designation}`),
+  );
+  const family =
+    input.family ??
+    agentKumikoFamilies[hashString(`g3-kumiko:family:${scope}`) % agentKumikoFamilies.length]!;
+  const rotationStep = family === 'square-sash' || family === 'broken-lattice' ? 45 : 30;
+  const rotation = integer(scopeRandom, 0, Math.floor(360 / rotationStep) - 1) * rotationStep;
+  const reflected = scopeRandom() > 0.5;
+  const scaleX = between(scopeRandom, 0.9, 1.05);
+  const scaleY = between(scopeRandom, 0.9, 1.05);
+
+  const rawGraph = graphFor(family, designationRandom);
+  const nodes = rawGraph.nodes.map((point) =>
+    transformPoint(point, rotation, reflected, scaleX, scaleY),
+  );
+  const selectedStruts = includedStruts(rawGraph.struts, complexity, designationRandom);
+  const descriptionHash = description
+    ? hashString(`g3-kumiko:accent:${variant}:${description}`)
+    : null;
+  const accentIndex =
+    descriptionHash === null || selectedStruts.length === 0
+      ? -1
+      : descriptionHash % selectedStruts.length;
+  const struts: AgentKumikoStrut[] = selectedStruts.map((strut, index) => {
+    const accent = index === accentIndex;
+    return {
+      ...strut,
+      role: accent ? 'accent' : strut.role,
+      tone: accent ? 'highlight' : strut.role === 'primary' ? 'base' : 'accent',
+      opacity: accent ? 0.96 : strut.role === 'primary' ? 0.92 : 0.7,
+      width: accent
+        ? round(strutWidth(strut.role, complexity) + 0.5)
+        : strutWidth(strut.role, complexity),
+    };
+  });
+  const joints = visibleJoints(nodes, selectedStruts);
+  if (descriptionHash !== null && joints.length > 0) {
+    const joint = joints[descriptionHash % joints.length]!;
+    joint.tone = 'highlight';
+    joint.opacity = 0.96;
+    joint.radius = round(joint.radius + 0.35);
+  }
+
+  const paletteRecipe = createAgentSigilRecipe({
+    seed: `g3-kumiko-palette:${scope}:${designation}`.slice(0, 256),
+    nonce: variant,
+    palette: paletteMode,
+    complexity: 'quiet',
+  });
+  const canonicalGraph = graphString(nodes, selectedStruts);
+  const graphFingerprint = fingerprint(`g3-kumiko:graph:${family}:${canonicalGraph}`);
+  const occupancy = occupancyDescriptor(nodes, selectedStruts);
+  const latticeFingerprint = fingerprint(
+    `g3-kumiko:lattice:${family}:${variant}:${scope}:${rotation}:${reflected}:${round(scaleX)}:${round(scaleY)}`,
+  );
+  const infillFingerprint = fingerprint(
+    `g3-kumiko:infill:${family}:${variant}:${designation}:${canonicalGraph}`,
+  );
+  const accentFingerprint = fingerprint(
+    `g3-kumiko:accent:${variant}:${description || 'none'}`,
+  );
+  const paletteFingerprint = fingerprint(
+    `g3-kumiko:palette:${variant}:${paletteMode}:${scope}:${designation}:${paletteRecipe.paletteName}`,
+  );
+  const identityFingerprint = fingerprint(
+    `g3-kumiko:${variant}:${family}:${complexity}:${paletteMode}:${scope}:${designation}:${description}:${graphFingerprint}`,
+  );
+
+  return {
+    rendererVersion: AGENT_KUMIKO_SIGIL_RENDERER_VERSION,
+    generation: AGENT_KUMIKO_SIGIL_GENERATION,
+    variant,
+    family,
+    identity: { scope, designation, description },
+    complexity,
+    paletteName: paletteRecipe.paletteName,
+    palette: paletteRecipe.palette,
+    rotation,
+    reflected,
+    nodes,
+    struts,
+    joints,
+    protectedVoids: rawGraph.protectedVoids,
+    fingerprint: identityFingerprint,
+    graphFingerprint,
+    occupancyDescriptor: occupancy,
+    layerFingerprints: {
+      lattice: latticeFingerprint,
+      infill: infillFingerprint,
+      accents: accentFingerprint,
+      palette: paletteFingerprint,
+    },
+  };
+}
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function toneColor(
+  recipe: AgentKumikoSigilRecipe,
+  tone: AgentSigilTone,
+  monochrome: boolean,
+) {
+  return monochrome ? 'currentColor' : recipe.palette[tone];
+}
+
+export function renderAgentKumikoSigilSvg(
+  recipe: AgentKumikoSigilRecipe,
+  options: {
+    size?: number;
+    label?: string;
+    monochrome?: boolean;
+    debug?: boolean;
+  } = {},
+) {
+  const size = Math.max(1, Math.min(2048, Math.floor(options.size ?? 100)));
+  const monochrome = options.monochrome ?? false;
+  const label =
+    options.label ??
+    `${recipe.identity.designation} experimental Kumiko-informed generation ${recipe.generation} sigil ${recipe.fingerprint}`;
+  const struts = recipe.struts
+    .map((strut) => {
+      const from = recipe.nodes[strut.from]!;
+      const to = recipe.nodes[strut.to]!;
+      return `<line x1="${from.x}" y1="${from.y}" x2="${to.x}" y2="${to.y}" stroke="${toneColor(recipe, strut.tone, monochrome)}" stroke-opacity="${strut.opacity}" stroke-width="${strut.width}"/>`;
+    })
+    .join('');
+  const joints = recipe.joints
+    .map((joint) => {
+      const point = recipe.nodes[joint.node]!;
+      return `<circle cx="${point.x}" cy="${point.y}" r="${joint.radius}" fill="${toneColor(recipe, joint.tone, monochrome)}" fill-opacity="${joint.opacity}"/>`;
+    })
+    .join('');
+  const debug = options.debug
+    ? recipe.nodes
+        .map(
+          (point, index) =>
+            `<g><circle cx="${point.x}" cy="${point.y}" r="1.15" fill="none" stroke="currentColor" stroke-opacity=".45" stroke-width=".55"/><text x="${point.x + 1.8}" y="${point.y - 1.8}" fill="currentColor" fill-opacity=".55" font-size="3">${index}</text></g>`,
+        )
+        .join('')
+    : '';
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 100 100" role="img" aria-label="${escapeXml(label)}" fill="none" stroke-linecap="round" stroke-linejoin="round">${struts}${joints}${debug}</svg>`;
+}
+
+export function generateAgentKumikoSigil(
+  input: AgentKumikoSigilInput,
+): GeneratedAgentKumikoSigil {
+  const recipe = createAgentKumikoSigilRecipe(input);
+  const accessibleLabel = `${recipe.identity.designation} experimental Kumiko-informed generation ${recipe.generation} sigil ${recipe.fingerprint}`;
+  const svg = renderAgentKumikoSigilSvg(recipe, { label: accessibleLabel });
+  return {
+    recipe,
+    svg,
+    dataUri: `data:image/svg+xml,${encodeURIComponent(svg)}`,
+    accessibleLabel,
+  };
+}
+
+export function createDistinctAgentKumikoPopulation(
+  inputs: readonly AgentKumikoSigilInput[],
+  options: { minimumOccupancyDistance?: number; maximumVariantAttempts?: number } = {},
+) {
+  const minimumDistance = Math.max(0, options.minimumOccupancyDistance ?? 8);
+  const maximumAttempts = Math.max(1, options.maximumVariantAttempts ?? 48);
+  const recipes: AgentKumikoSigilRecipe[] = [];
+
+  return inputs.map((input) => {
+    const initialVariant = Math.max(0, Math.floor(input.variant ?? 0));
+    let candidate = createAgentKumikoSigilRecipe(input);
+    for (let attempt = 0; attempt < maximumAttempts; attempt += 1) {
+      const variant = initialVariant + attempt;
+      const next = createAgentKumikoSigilRecipe({ ...input, variant });
+      const graphIsUnique = recipes.every(
+        (recipe) => recipe.graphFingerprint !== next.graphFingerprint,
+      );
+      const occupancyIsDistinct = recipes.every(
+        (recipe) =>
+          agentKumikoOccupancyDistance(
+            recipe.occupancyDescriptor,
+            next.occupancyDescriptor,
+          ) >= minimumDistance,
+      );
+      candidate = next;
+      if (graphIsUnique && occupancyIsDistinct) break;
+    }
+    recipes.push(candidate);
+    return candidate;
+  });
+}

--- a/tests/e2e/sigil-lab.spec.ts
+++ b/tests/e2e/sigil-lab.spec.ts
@@ -24,6 +24,9 @@ test('sigil lab exposes layered generations and visual evidence', async ({ page 
     const response = await page.goto('/sigil-lab');
     expect(response?.ok()).toBe(true);
     await expect(page.getByRole('heading', { name: 'Generative sigils for agents' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Kumiko-informed construction graphs' }),
+    ).toBeVisible();
 
     const cards = page.locator('[data-sigil-card]');
     await expect(cards).toHaveCount(18);
@@ -42,7 +45,8 @@ test('sigil lab exposes layered generations and visual evidence', async ({ page 
 
     await expect(page.locator('[data-sigil-layer-example]')).toHaveCount(3);
     await expect(page.locator('[data-sigil-generation-example]')).toHaveCount(2);
-    await expect(page.locator('[data-agent-sigil]')).toHaveCount(38);
+    await expect(page.locator('[data-agent-sigil]')).toHaveCount(44);
+    await expect(page.locator('[data-agent-kumiko]')).toHaveCount(41);
     await expectNoHorizontalOverflow(page);
 
     await page.screenshot({
@@ -75,20 +79,95 @@ test('repository, designation, and description seeds stay isolated', async ({ pa
   expect(layers[2]?.accents).not.toBe(layers[0]?.accents);
 });
 
-test('small layered sigils remain measurable and accessible', async ({ page }) => {
+test('Kumiko population stays graph-distinct and occupancy-separated', async ({ page }) => {
   await page.goto('/sigil-lab');
 
-  const sigils = page.locator('[data-sigil-small-sizes] [data-agent-sigil]');
-  await expect(sigils).toHaveCount(4);
+  const contactSheet = page.locator('[data-kumiko-contact-sheet]');
+  await expect(contactSheet).toBeVisible();
+  const minimumDistance = Number(
+    await contactSheet.getAttribute('data-kumiko-minimum-distance'),
+  );
+  expect(minimumDistance).toBeGreaterThanOrEqual(8);
 
-  const sizes = await sigils.evaluateAll((elements) =>
+  const cards = page.locator('[data-kumiko-contact-card]');
+  await expect(cards).toHaveCount(18);
+  const descriptors = await cards.evaluateAll((elements) =>
+    elements.map((element) => ({
+      family: element.getAttribute('data-kumiko-family'),
+      graph: element.getAttribute('data-kumiko-graph'),
+      occupancy: element.getAttribute('data-kumiko-occupancy'),
+    })),
+  );
+
+  expect(descriptors.every((descriptor) => descriptor.graph && descriptor.occupancy)).toBe(true);
+  expect(new Set(descriptors.map((descriptor) => descriptor.graph)).size).toBe(
+    descriptors.length,
+  );
+  expect(new Set(descriptors.map((descriptor) => descriptor.occupancy)).size).toBe(
+    descriptors.length,
+  );
+  expect(new Set(descriptors.map((descriptor) => descriptor.family)).size).toBe(8);
+
+  const familyCards = page.locator('[data-kumiko-family-card]');
+  await expect(familyCards).toHaveCount(8);
+  const families = await familyCards.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute('data-kumiko-family')),
+  );
+  expect(new Set(families).size).toBe(8);
+});
+
+test('Kumiko description edits change accents without changing the graph', async ({ page }) => {
+  await page.goto('/sigil-lab');
+
+  const examples = page.locator('[data-kumiko-layer-example] [data-agent-kumiko]');
+  await expect(examples).toHaveCount(3);
+  const layers = await examples.evaluateAll((elements) =>
+    elements.map((element) => ({
+      graph: element.getAttribute('data-agent-kumiko-graph'),
+      occupancy: element.getAttribute('data-agent-kumiko-occupancy'),
+      lattice: element.getAttribute('data-agent-kumiko-lattice'),
+      infill: element.getAttribute('data-agent-kumiko-infill'),
+      accents: element.getAttribute('data-agent-kumiko-accents'),
+      palette: element.getAttribute('data-agent-kumiko-palette'),
+    })),
+  );
+
+  expect(new Set(layers.map((layer) => layer.graph)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.occupancy)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.lattice)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.infill)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.palette)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.accents)).size).toBe(3);
+
+  await expect(page.locator('[data-kumiko-debug-node]')).not.toHaveCount(0);
+});
+
+test('small layered and lattice sigils remain measurable and accessible', async ({ page }) => {
+  await page.goto('/sigil-lab');
+
+  const layered = page.locator('[data-sigil-small-sizes] [data-agent-sigil]');
+  await expect(layered).toHaveCount(4);
+  const layeredSizes = await layered.evaluateAll((elements) =>
     elements.map((element) => {
       const box = element.getBoundingClientRect();
       return { width: box.width, height: box.height, label: element.getAttribute('aria-label') };
     }),
   );
 
-  expect(sizes.map((size) => Math.round(size.width))).toEqual([24, 32, 48, 72]);
-  expect(sizes.every((size) => size.width === size.height)).toBe(true);
-  expect(sizes.every((size) => size.label?.includes('agent identity sigil'))).toBe(true);
+  expect(layeredSizes.map((size) => Math.round(size.width))).toEqual([24, 32, 48, 72]);
+  expect(layeredSizes.every((size) => size.width === size.height)).toBe(true);
+  expect(layeredSizes.every((size) => size.label?.includes('agent identity sigil'))).toBe(true);
+
+  const kumiko = page.locator('[data-kumiko-small-sizes] [data-agent-kumiko]');
+  await expect(kumiko).toHaveCount(5);
+  const kumikoSizes = await kumiko.evaluateAll((elements) =>
+    elements.map((element) => {
+      const box = element.getBoundingClientRect();
+      return { width: box.width, height: box.height, label: element.getAttribute('aria-label') };
+    }),
+  );
+
+  expect(kumikoSizes.map((size) => Math.round(size.width))).toEqual([16, 24, 32, 48, 72]);
+  expect(kumikoSizes.every((size) => size.width === size.height)).toBe(true);
+  expect(kumikoSizes.every((size) => size.label?.includes('Kumiko-informed'))).toBe(true);
 });


### PR DESCRIPTION
## Direction

Add an isolated Generation 3 experiment informed by Kumiko construction logic without changing Generation 1, Generation 2, or the production guestbook.

## Construction model

The experiment represents each mark as an inspectable graph:

```text
nodes -> struts -> selected infill -> visible joints -> protected voids
```

Layered inputs remain separate:

- scope controls the family, broad proportion, rotation, and reflection;
- designation controls retained braces and internal infill;
- description highlights at most one existing strut or joint;
- scope plus designation controls the bounded existing palette catalogue;
- variant produces another reproducible candidate.

## Families

- triangular brace
- hex cell
- diamond weave
- square sash
- nested joint
- broken lattice
- star joint
- rosette lattice

These are original procedural families built from general graph mechanics. The UI and documentation call them Kumiko-informed and do not claim authentic craft reproduction.

## Review surface

`/sigil-lab` now adds:

- an 18-mark labels-hidden monochrome contact sheet;
- Generation 2 versus lattice comparisons for the same identities;
- all eight construction families;
- description/accent isolation examples;
- a numbered graph overlay;
- 16, 24, 32, 48, and 72 px output;
- existing light/dark mobile and desktop screenshot coverage in Chromium and WebKit.

## Similarity and determinism

- canonical graph fingerprints;
- 12×12 occupancy descriptors;
- deterministic Hamming-distance comparison;
- a deterministic population helper that advances explicit variants until graph and occupancy thresholds are met;
- bounded headless SVG and React renderers.

## Guardrail

This remains lab-only. No gallery or guestbook integration is included. Visual acceptance of the full population is required before #443 can consider Generation 3 selectable.

Tracks #447 and #443.