### PR TITLE
Explore a layered paper counter motion system

### DIFF
--- a/components/home/activity-scoreboard.module.css
+++ b/components/home/activity-scoreboard.module.css
@@ -1,0 +1,244 @@
+.counter {
+  position: relative;
+  isolation: isolate;
+  perspective: 920px;
+  padding: 0.28rem 0.12rem 0.42rem;
+}
+
+.counter::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  top: 0.8rem;
+  right: 0.4rem;
+  left: 0.4rem;
+  height: 0.16rem;
+  border-radius: 999px;
+  background: hsl(var(--border) / 0.78);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.34),
+    0 4px 9px rgb(64 52 37 / 0.1);
+  transform-origin: center;
+}
+
+.counterShadow {
+  position: absolute;
+  z-index: -2;
+  right: 3%;
+  bottom: 0.08rem;
+  left: 3%;
+  height: 18%;
+  border-radius: 50%;
+  background: rgb(66 52 34 / 0.15);
+  filter: blur(9px);
+  opacity: 0.46;
+  pointer-events: none;
+}
+
+.digitSlot {
+  position: relative;
+  min-width: 0;
+  transform-style: preserve-3d;
+}
+
+.digit {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  color: hsl(var(--foreground));
+  transform-style: preserve-3d;
+}
+
+.digit::before,
+.digit::after {
+  content: '';
+  position: absolute;
+  inset: 0.18rem 0.08rem -0.12rem;
+  z-index: -1;
+  border: 1px solid hsl(var(--border) / 0.58);
+  border-radius: 0.48rem 0.56rem 0.5rem 0.44rem;
+  background: hsl(var(--muted) / 0.76);
+  box-shadow: 0 4px 8px rgb(65 51 34 / 0.07);
+  transform: rotate(1.2deg) translateY(0.08rem);
+}
+
+.digit::after {
+  inset: 0.24rem 0.02rem -0.18rem 0.13rem;
+  z-index: -2;
+  opacity: 0.62;
+  transform: rotate(-1deg) translateY(0.1rem);
+}
+
+.face,
+.sheet {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid hsl(var(--border) / 0.88);
+  border-radius: 0.48rem 0.56rem 0.5rem 0.44rem;
+  background:
+    repeating-linear-gradient(
+      102deg,
+      transparent 0 19px,
+      hsl(var(--foreground) / 0.018) 19px 20px
+    ),
+    linear-gradient(145deg, hsl(var(--card)), hsl(var(--accent) / 0.7));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.48),
+    inset 0 -1px 0 hsl(var(--foreground) / 0.045),
+    0 8px 18px rgb(61 48 32 / 0.11);
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+}
+
+.face::before,
+.sheet::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 19% 14%, hsl(var(--foreground) / 0.035) 0 0.7px, transparent 0.9px),
+    radial-gradient(circle at 76% 68%, hsl(var(--foreground) / 0.025) 0 0.65px, transparent 0.85px);
+  background-size: 15px 17px, 19px 21px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.face::after,
+.sheet::after {
+  content: '';
+  position: absolute;
+  right: 12%;
+  bottom: 18%;
+  left: 12%;
+  height: 1px;
+  background: hsl(var(--foreground) / 0.07);
+  box-shadow: 0 0.42rem 0 hsl(var(--foreground) / 0.035);
+}
+
+.number {
+  position: relative;
+  z-index: 1;
+  display: block;
+  line-height: 1;
+  text-shadow:
+    0 1px 0 hsl(var(--background) / 0.72),
+    0 0 0.025em currentColor;
+  transform: translateY(-0.01em);
+}
+
+.binding {
+  position: absolute;
+  z-index: 6;
+  top: 0.34rem;
+  left: 50%;
+  width: 52%;
+  height: 0.24rem;
+  border: 1px solid hsl(var(--border) / 0.86);
+  border-radius: 999px;
+  background: hsl(var(--secondary));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.4),
+    0 2px 4px rgb(56 44 29 / 0.12);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.binding::before,
+.binding::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 0.22rem;
+  height: 0.22rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  background: hsl(var(--card));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.44);
+  transform: translateY(-50%);
+}
+
+.binding::before {
+  left: 13%;
+}
+
+.binding::after {
+  right: 13%;
+}
+
+.departing {
+  z-index: 4;
+  transform-origin: 50% 0.45rem;
+  will-change: transform, opacity, filter;
+}
+
+.arriving {
+  z-index: 5;
+  transform-origin: 50% 0.45rem;
+  will-change: transform, opacity;
+}
+
+.dark .counter::before {
+  background: hsl(var(--border) / 0.9);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.08),
+    0 5px 10px rgb(0 0 0 / 0.28);
+}
+
+.dark .counterShadow {
+  background: rgb(0 0 0 / 0.34);
+  opacity: 0.58;
+}
+
+.dark .digit::before,
+.dark .digit::after {
+  border-color: hsl(var(--border) / 0.66);
+  background: hsl(var(--muted) / 0.72);
+  box-shadow: 0 5px 10px rgb(0 0 0 / 0.24);
+}
+
+.dark .face,
+.dark .sheet {
+  background:
+    repeating-linear-gradient(
+      102deg,
+      transparent 0 19px,
+      hsl(var(--foreground) / 0.022) 19px 20px
+    ),
+    linear-gradient(145deg, hsl(var(--card)), hsl(var(--accent) / 0.78));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    inset 0 -1px 0 rgb(0 0 0 / 0.24),
+    0 9px 20px rgb(0 0 0 / 0.3);
+}
+
+.dark .binding {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    0 2px 5px rgb(0 0 0 / 0.28);
+}
+
+@media (forced-colors: active) {
+  .counter::before,
+  .counterShadow,
+  .digit::before,
+  .digit::after,
+  .face::before,
+  .face::after,
+  .sheet::before,
+  .sheet::after,
+  .binding {
+    display: none;
+  }
+
+  .face,
+  .sheet {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+    color: CanvasText;
+  }
+}

--- a/components/home/activity-scoreboard.module.css
+++ b/components/home/activity-scoreboard.module.css
@@ -38,6 +38,9 @@
 .digitSlot {
   position: relative;
   min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 0.48rem 0.56rem 0.5rem 0.44rem;
+  background: hsl(var(--card));
   transform-style: preserve-3d;
 }
 
@@ -100,8 +103,16 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 19% 14%, hsl(var(--foreground) / 0.035) 0 0.7px, transparent 0.9px),
-    radial-gradient(circle at 76% 68%, hsl(var(--foreground) / 0.025) 0 0.65px, transparent 0.85px);
+    radial-gradient(
+      circle at 19% 14%,
+      hsl(var(--foreground) / 0.035) 0 0.7px,
+      transparent 0.9px
+    ),
+    radial-gradient(
+      circle at 76% 68%,
+      hsl(var(--foreground) / 0.025) 0 0.65px,
+      transparent 0.85px
+    );
   background-size: 15px 17px, 19px 21px;
   opacity: 0.55;
   pointer-events: none;
@@ -181,27 +192,27 @@
   will-change: transform, opacity;
 }
 
-.dark .counter::before {
+:global(.dark) .counter::before {
   background: hsl(var(--border) / 0.9);
   box-shadow:
     0 1px 0 rgb(255 255 255 / 0.08),
     0 5px 10px rgb(0 0 0 / 0.28);
 }
 
-.dark .counterShadow {
+:global(.dark) .counterShadow {
   background: rgb(0 0 0 / 0.34);
   opacity: 0.58;
 }
 
-.dark .digit::before,
-.dark .digit::after {
+:global(.dark) .digit::before,
+:global(.dark) .digit::after {
   border-color: hsl(var(--border) / 0.66);
   background: hsl(var(--muted) / 0.72);
   box-shadow: 0 5px 10px rgb(0 0 0 / 0.24);
 }
 
-.dark .face,
-.dark .sheet {
+:global(.dark) .face,
+:global(.dark) .sheet {
   background:
     repeating-linear-gradient(
       102deg,
@@ -215,7 +226,7 @@
     0 9px 20px rgb(0 0 0 / 0.3);
 }
 
-.dark .binding {
+:global(.dark) .binding {
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.08),
     0 2px 5px rgb(0 0 0 / 0.28);
@@ -234,6 +245,7 @@
     display: none;
   }
 
+  .digitSlot,
   .face,
   .sheet {
     border-color: CanvasText;

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { ScrapbookPet } from '@/components/home/scrapbook-pet';
-import { motion, useReducedMotion } from 'framer-motion';
-import { useEffect, useMemo, useState } from 'react';
+import { motion, useAnimate, useReducedMotion } from 'framer-motion';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import styles from './activity-scoreboard.module.css';
 
 function countdownToUtcMidnight() {
   const now = new Date();
@@ -14,27 +15,21 @@ function countdownToUtcMidnight() {
   return [hours, minutes, remainder].map((part) => String(part).padStart(2, '0')).join(':');
 }
 
-function StaticHalf({ digit, half }: { digit: string; half: 'top' | 'bottom' }) {
+function PaperFace({ digit, className = '' }: { digit: string; className?: string }) {
   return (
-    <span
-      aria-hidden="true"
-      className={`absolute inset-x-0 h-1/2 overflow-hidden ${half === 'top' ? 'top-0' : 'bottom-0'}`}
-    >
-      <span
-        className={`absolute inset-x-0 flex h-[200%] items-center justify-center tabular-nums ${half === 'top' ? 'top-0' : 'bottom-0'}`}
-      >
-        {digit}
-      </span>
+    <span aria-hidden="true" className={`${styles.face} ${className}`}>
+      <span className={styles.number}>{digit}</span>
     </span>
   );
 }
 
-function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
+function PaperDigit({ digit, index }: { digit: string; index: number }) {
   const reduceMotion = useReducedMotion();
   const [current, setCurrent] = useState(digit);
   const [previous, setPrevious] = useState(digit);
   const [sequence, setSequence] = useState(0);
   const [animating, setAnimating] = useState(false);
+  const restingTilt = index % 2 === 0 ? -0.72 : 0.58;
 
   useEffect(() => {
     if (digit === current) return;
@@ -44,57 +39,97 @@ function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
     setAnimating(!reduceMotion && document.visibilityState === 'visible');
   }, [current, digit, reduceMotion]);
 
-  const stagger = (3 - index) * 0.035;
+  const delay = (3 - index) * 0.055;
 
   return (
-    <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
-      <StaticHalf digit={current} half="top" />
-      <StaticHalf digit={current} half="bottom" />
+    <motion.span
+      className={styles.digit}
+      data-paper-digit
+      initial={
+        reduceMotion
+          ? false
+          : {
+              opacity: 0,
+              y: 13,
+              rotateZ: restingTilt * 2.4,
+              scale: 0.965,
+            }
+      }
+      animate={{ opacity: 1, y: 0, rotateZ: restingTilt, scale: 1 }}
+      transition={
+        reduceMotion
+          ? { duration: 0 }
+          : {
+              type: 'spring',
+              stiffness: 280,
+              damping: 22,
+              mass: 0.72,
+              delay: 0.08 + index * 0.055,
+            }
+      }
+    >
+      <span className={styles.binding} data-paper-counter-binding />
+      <PaperFace digit={current} />
 
       {animating ? (
         <>
           <motion.span
             key={`depart-${sequence}`}
             aria-hidden="true"
-            className="absolute inset-x-0 top-0 z-20 h-1/2 origin-bottom overflow-hidden bg-[#1b1c20] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-8px_12px_rgba(0,0,0,0.2)] [backface-visibility:hidden] [transform-style:preserve-3d]"
-            initial={{ rotateX: 0 }}
-            animate={{ rotateX: -90 }}
-            transition={{ duration: 0.22, delay: stagger, ease: [0.55, 0.06, 0.68, 0.19] }}
+            className={`${styles.sheet} ${styles.departing}`}
+            initial={{ rotateX: 0, y: 0, opacity: 1, filter: 'blur(0px)' }}
+            animate={{
+              rotateX: [0, -24, -103],
+              y: [0, -2, -12],
+              opacity: [1, 1, 0],
+              filter: ['blur(0px)', 'blur(0px)', 'blur(1.4px)'],
+            }}
+            transition={{
+              duration: 0.46,
+              delay,
+              times: [0, 0.42, 1],
+              ease: [0.55, 0.06, 0.68, 0.19],
+            }}
           >
-            <span className="absolute inset-x-0 top-0 flex h-[200%] items-center justify-center tabular-nums">
-              {previous}
-            </span>
+            <span className={styles.number}>{previous}</span>
           </motion.span>
+
           <motion.span
             key={`arrive-${sequence}`}
             aria-hidden="true"
-            className="absolute inset-x-0 bottom-0 z-30 h-1/2 origin-top overflow-hidden bg-[#15161a] shadow-[inset_0_8px_12px_rgba(0,0,0,0.34)] [backface-visibility:hidden] [transform-style:preserve-3d]"
-            initial={{ rotateX: 90 }}
-            animate={{ rotateX: 0 }}
-            transition={{ duration: 0.28, delay: stagger + 0.19, ease: [0.22, 1, 0.36, 1] }}
+            className={`${styles.sheet} ${styles.arriving}`}
+            initial={{ rotateX: 88, y: '20%', opacity: 0.2, scale: 0.955 }}
+            animate={{
+              rotateX: [88, -9, 2, 0],
+              y: ['20%', '-2.5%', '0.7%', '0%'],
+              opacity: [0.2, 1, 1, 1],
+              scale: [0.955, 1.018, 0.997, 1],
+            }}
+            transition={{
+              duration: 0.62,
+              delay: delay + 0.16,
+              times: [0, 0.58, 0.82, 1],
+              ease: [0.22, 1, 0.36, 1],
+            }}
             onAnimationComplete={() => setAnimating(false)}
           >
-            <span className="absolute inset-x-0 bottom-0 flex h-[200%] items-center justify-center tabular-nums">
+            <motion.span
+              className={styles.number}
+              initial={{ opacity: 0.35, scale: 1.2, filter: 'blur(2px)' }}
+              animate={{ opacity: 1, scale: [1.2, 0.96, 1], filter: 'blur(0px)' }}
+              transition={{
+                duration: 0.34,
+                delay: delay + 0.34,
+                times: [0, 0.7, 1],
+                ease: [0.16, 1, 0.3, 1],
+              }}
+            >
               {current}
-            </span>
+            </motion.span>
           </motion.span>
         </>
       ) : null}
-
-      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px bg-black/80" />
-      <span
-        aria-hidden="true"
-        className="absolute inset-x-0 top-1/2 z-40 h-px -translate-y-px bg-white/[0.05]"
-      />
-      <span
-        aria-hidden="true"
-        className="absolute left-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]"
-      />
-      <span
-        aria-hidden="true"
-        className="absolute right-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]"
-      />
-    </span>
+    </motion.span>
   );
 }
 
@@ -103,20 +138,56 @@ function ScoreDigits({ value }: { value: number }) {
     () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
     [value],
   );
+  const reduceMotion = useReducedMotion();
+  const previousValue = useRef(value);
+  const [scope, animate] = useAnimate();
+
+  useEffect(() => {
+    if (previousValue.current === value) return;
+    previousValue.current = value;
+    if (reduceMotion || !scope.current) return;
+
+    void animate(
+      scope.current,
+      {
+        y: [0, -2.5, 1, 0],
+        rotateZ: [0, -0.32, 0.14, 0],
+      },
+      { duration: 0.72, times: [0, 0.32, 0.72, 1], ease: [0.2, 0.8, 0.2, 1] },
+    );
+    void animate(
+      '[data-paper-counter-binding]',
+      { scaleX: [1, 1.055, 0.985, 1] },
+      { duration: 0.68, ease: [0.2, 0.8, 0.2, 1] },
+    );
+    void animate(
+      '[data-paper-counter-shadow]',
+      { opacity: [0.46, 0.68, 0.38, 0.46], scaleX: [1, 1.025, 0.99, 1] },
+      { duration: 0.72, ease: [0.2, 0.8, 0.2, 1] },
+    );
+  }, [animate, reduceMotion, scope, value]);
 
   return (
     <div
-      className="flex min-w-0 gap-1.5 sm:gap-2"
+      ref={scope}
+      className={`${styles.counter} flex min-w-0 gap-1.5 sm:gap-2`}
       aria-label={`${value} contributions today`}
+      data-paper-counter
+      data-reduced-motion={reduceMotion ? 'true' : 'false'}
       data-wind-scoreboard
     >
+      <span
+        aria-hidden="true"
+        className={styles.counterShadow}
+        data-paper-counter-shadow
+      />
       {digits.map((digit, index) => (
         <div
           key={index}
           data-activity-digit
-          className="relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_7px_18px_rgba(0,0,0,0.2)]"
+          className={`${styles.digitSlot} relative aspect-[0.78] min-w-0 flex-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none tabular-nums`}
         >
-          <SplitFlapDigit digit={digit} index={index} />
+          <PaperDigit digit={digit} index={index} />
         </div>
       ))}
     </div>

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -49,13 +49,12 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
         reduceMotion
           ? false
           : {
-              opacity: 0,
               y: 13,
               rotateZ: restingTilt * 2.4,
               scale: 0.965,
             }
       }
-      animate={{ opacity: 1, y: 0, rotateZ: restingTilt, scale: 1 }}
+      animate={{ y: 0, rotateZ: restingTilt, scale: 1 }}
       transition={
         reduceMotion
           ? { duration: 0 }
@@ -69,7 +68,7 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
       }
     >
       <span className={styles.binding} data-paper-counter-binding />
-      <PaperFace digit={current} />
+      <PaperFace digit={animating ? previous : current} />
 
       {animating ? (
         <>

--- a/docs/animation-exploration-placeholder.md
+++ b/docs/animation-exploration-placeholder.md
@@ -1,0 +1,1 @@
+placeholder

--- a/docs/animation-exploration-placeholder.md
+++ b/docs/animation-exploration-placeholder.md
@@ -1,1 +1,0 @@
-placeholder

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -40,12 +40,13 @@ for (const study of studies) {
     const paperFaces = await scoreboard.locator('[data-activity-digit]').evaluateAll((digits) =>
       digits.map((digit) => {
         const face = digit.querySelector<HTMLElement>('[aria-hidden="true"]');
-        if (!face) throw new Error('Missing paper digit face');
+        const paperDigit = digit.querySelector<HTMLElement>('[data-paper-digit]');
+        if (!face || !paperDigit) throw new Error('Missing paper digit face');
         const style = getComputedStyle(face);
         return {
           backgroundImage: style.backgroundImage,
           borderStyle: style.borderStyle,
-          transformStyle: getComputedStyle(digit.querySelector<HTMLElement>('[data-paper-digit]')!).transformStyle,
+          transformStyle: getComputedStyle(paperDigit).transformStyle,
         };
       }),
     );
@@ -80,6 +81,106 @@ for (const study of studies) {
     await page.screenshot({ path: screenshotPath, animations: 'disabled' });
   });
 }
+
+test('captures the live paper counter choreography', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.addInitScript(() => {
+    const actualNow = Date.now.bind(Date);
+    Date.now = () => actualNow() + 60 * 60 * 1_000;
+    window.localStorage.setItem('theme', 'light');
+  });
+
+  let releaseResponse!: () => void;
+  const responseGate = new Promise<void>((resolve) => {
+    releaseResponse = resolve;
+  });
+  let targetToday = 0;
+  const days = Array.from({ length: 28 }, (_, index) => ({
+    date: `2026-07-${String(index + 1).padStart(2, '0')}`,
+    count: index % 7,
+  }));
+
+  await page.route('**/api/github-activity', async (route) => {
+    await responseGate;
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        source: 'public-profile',
+        today: targetToday,
+        weekTotal: 321,
+        yearTotal: 4_321,
+        days,
+        generatedAt: new Date().toISOString(),
+      }),
+    });
+  });
+
+  const refreshRequest = page.waitForRequest(
+    (request) => new URL(request.url()).pathname === '/api/github-activity',
+  );
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const scoreboard = page.locator('[data-activity-scoreboard]');
+  const counter = scoreboard.locator('[data-paper-counter]');
+  await expect(counter).toBeVisible();
+  await refreshRequest;
+
+  const initialLabel = await counter.getAttribute('aria-label');
+  const initialToday = Number(initialLabel?.match(/^\d+/)?.[0] ?? 0);
+  const changedDigits = String(initialToday)
+    .slice(-4)
+    .padStart(4, '0')
+    .split('')
+    .map((digit) => (Number(digit) + 5) % 10)
+    .join('');
+  targetToday = Number(changedDigits);
+
+  const frameDirectory = path.join(
+    'test-results',
+    'scoreboard-appearance',
+    'motion',
+    testInfo.project.name,
+  );
+  await mkdir(frameDirectory, { recursive: true });
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '00-before.png'),
+    animations: 'allow',
+  });
+
+  releaseResponse();
+  const lastDigitFaces = counter
+    .locator('[data-paper-digit]')
+    .last()
+    .locator('[aria-hidden="true"]');
+  await expect(lastDigitFaces).toHaveCount(3, { timeout: 2_000 });
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '01-lift.png'),
+    animations: 'allow',
+  });
+
+  await page.waitForTimeout(220);
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '02-turn.png'),
+    animations: 'allow',
+  });
+
+  await page.waitForTimeout(300);
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '03-ink.png'),
+    animations: 'allow',
+  });
+
+  await expect(counter).toHaveAttribute(
+    'aria-label',
+    `${targetToday} contributions today`,
+  );
+  await expect(lastDigitFaces).toHaveCount(1, { timeout: 3_000 });
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '04-settled.png'),
+    animations: 'allow',
+  });
+});
 
 test('keeps the paper counter calm with reduced motion', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -29,10 +29,31 @@ for (const study of studies) {
     }
 
     const scoreboard = page.locator('[data-activity-scoreboard]');
+    const counter = scoreboard.locator('[data-paper-counter]');
     await expect(scoreboard).toBeVisible();
+    await expect(counter).toBeVisible();
     await expect(scoreboard.locator('[data-activity-digit]')).toHaveCount(4);
+    await expect(counter.locator('[data-paper-digit]')).toHaveCount(4);
     await expect(scoreboard.getByText('7D', { exact: true })).toBeVisible();
     await expect(scoreboard.getByText('YTD', { exact: true })).toBeVisible();
+
+    const paperFaces = await scoreboard.locator('[data-activity-digit]').evaluateAll((digits) =>
+      digits.map((digit) => {
+        const face = digit.querySelector<HTMLElement>('[aria-hidden="true"]');
+        if (!face) throw new Error('Missing paper digit face');
+        const style = getComputedStyle(face);
+        return {
+          backgroundImage: style.backgroundImage,
+          borderStyle: style.borderStyle,
+          transformStyle: getComputedStyle(digit.querySelector<HTMLElement>('[data-paper-digit]')!).transformStyle,
+        };
+      }),
+    );
+    for (const face of paperFaces) {
+      expect(face.backgroundImage).not.toBe('none');
+      expect(face.borderStyle).toBe('solid');
+      expect(face.transformStyle).toBe('preserve-3d');
+    }
 
     const overflow = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
@@ -60,7 +81,7 @@ for (const study of studies) {
   });
 }
 
-test('keeps the scoreboard calm with reduced motion', async ({ page }) => {
+test('keeps the paper counter calm with reduced motion', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
   await page.setViewportSize({ width: 390, height: 844 });
   await page.addInitScript(() => {
@@ -69,8 +90,10 @@ test('keeps the scoreboard calm with reduced motion', async ({ page }) => {
   await page.goto('/');
 
   const scoreboard = page.locator('[data-activity-scoreboard]');
+  const counter = scoreboard.locator('[data-paper-counter]');
   const digit = scoreboard.locator('[data-activity-digit]').first();
   await expect(digit).toBeVisible();
+  await expect(counter).toHaveAttribute('data-reduced-motion', 'true');
   const before = await digit.evaluate((element) => (element as HTMLElement).style.transform);
   await digit.hover();
   const after = await digit.evaluate((element) => (element as HTMLElement).style.transform);
@@ -78,7 +101,7 @@ test('keeps the scoreboard calm with reduced motion', async ({ page }) => {
   expect(after).toBe(before);
 });
 
-test('keeps split-flap digits readable in forced colours', async ({ page }, testInfo) => {
+test('keeps paper digits readable in forced colours', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'chromium', 'Forced-colour emulation is checked in Chromium.');
 
   await page.emulateMedia({ forcedColors: 'active' });

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -62,13 +62,20 @@ for (const study of studies) {
     }));
     expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
 
+    const minimumHeight = study.height <= 780 ? 232 : 248;
+    await expect
+      .poll(async () =>
+        scoreboard.evaluate((element, expectedHeight) => {
+          const rect = element.getBoundingClientRect();
+          return rect.width > 0 && rect.height >= expectedHeight;
+        }, minimumHeight),
+      )
+      .toBe(true);
     const dimensions = await scoreboard.evaluate((element) => {
       const rect = element.getBoundingClientRect();
       return { width: rect.width, height: rect.height };
     });
-    expect(dimensions.width).toBeGreaterThan(0);
     expect(dimensions.width).toBeLessThanOrEqual(study.width);
-    expect(dimensions.height).toBeGreaterThanOrEqual(study.height <= 780 ? 232 : 248);
 
     const screenshotPath = path.join(
       'test-results',


### PR DESCRIPTION
## Stack

Targets `feature/home-paper-grid-scraplet` so the counter exploration can be reviewed separately from #445.

## Direction

Reinterprets the black split-flap counter as a small bound stack of numbered paper leaves while keeping the same four-digit footprint and live value semantics.

## Motion system

Uses the Motion dependency already in the repository rather than adding a package:

- scoped `useAnimate` sequences coordinate the shared binding line, counter body and contact shadow;
- each paper leaf settles on mount with spring physics while remaining readable from first paint;
- changed digits run a three-stage sequence: old leaf lifts away, new leaf swings down in 3D, then the ink lands and settles;
- the resting leaf holds the old number until the incoming page lands, avoiding a premature value flash beneath the turn;
- updates stagger right-to-left so the counter reads like a physical mechanism rather than four unrelated fades;
- reduced-motion keeps the paper design and replaces values instantly.

## Why not React Three Fiber

R3F and Drei are already installed, but this instrument is still DOM text and should remain selectable, accessible and cheap when idle. A WebGL canvas would add a scene/rendering boundary without providing an essential visual capability for this pass.

## Visual treatment

- warm paper stacks and subtle fibres in light mode;
- dusky paper leaves with pale ink in dark mode;
- shared binding bar and small fasteners;
- irregular resting angles and layered sheet edges;
- forced-colour mode collapses decoration to Canvas/CanvasText.

## Behaviour fence

- no data-fetching or refresh cadence changes;
- no layout dimensions or information hierarchy changes;
- no counter interaction or fake controls added;
- no new dependency;
- Scraplet and the paper-grid work remain unchanged.

The stacked diff is limited to:

- `components/home/activity-scoreboard.tsx`;
- `components/home/activity-scoreboard.module.css`;
- `tests/e2e/material-system.spec.ts`.

## Visual review

Reviewed static light/dark mobile and desktop captures plus a controlled five-frame live refresh in Chromium and WebKit:

- digits remain visible during initial spring settling;
- light paper leaves retain enough edge and ink contrast against the warm card;
- dark leaves stay paperlike rather than reverting to black instrument panels;
- the sequence holds the old value through lift/turn, introduces the new ink during landing, and removes all temporary sheets after settling;
- the counter remains contained at 390px and does not change the homepage footprint.

## Validation

[CI run 528](https://github.com/teamleaderleo/scrapbook/actions/runs/30362575887) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- **138 passed, two intentional skips, zero retries**.

Scoreboard appearance and motion frames: `sha256:0e669ce4ff56c61c5a0af2ac85a91c0fe4cae0d602575541a17e8a3d49a048f`.
Playwright log: `sha256:7b2d78c177bd7055e19ac8d9c71e601da7115598f957b5aceed413e314637c6f`.

## Self-review corrections

- removed the mount opacity fade after a desktop capture showed primary digits could briefly disappear;
- held the old ink on the base leaf until the incoming page completed;
- replaced one immediate screenshot-geometry read with a bounded paint-stability poll, producing the final zero-retry run.

Kept as a draft for visual approval before merge.