### PR TITLE
test: keep guestbook checks generation-aware

### DIFF
--- a/tests/e2e/gallery-visual.spec.ts
+++ b/tests/e2e/gallery-visual.spec.ts
@@ -1,3 +1,4 @@
+import { agentGuestbookSigilSelection } from '@/lib/agent-guestbook-sigils';
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
@@ -37,6 +38,9 @@ for (const study of studies) {
     const entries = await getGuestbookEntries(request);
     expect(entries.length).toBeGreaterThan(0);
     const newest = entries[0]!;
+    const generation2Count = entries.filter(
+      (entry) => (agentGuestbookSigilSelection(entry.id)?.generation ?? 2) === 2,
+    ).length;
 
     await page.setViewportSize({ width: study.width, height: study.height });
     await page.addInitScript((theme) => localStorage.setItem('theme', theme), study.theme);
@@ -52,7 +56,10 @@ for (const study of studies) {
     await expect(cards).toHaveCount(entries.length);
     await expect(cards.first()).toHaveAttribute('data-agent-visit', newest.id);
     await expect(cards.locator('img')).toHaveCount(0);
-    await expect(cards.locator('[data-agent-sigil-generation="2"]')).toHaveCount(entries.length);
+    await expect(cards.locator('[data-agent-sigil]')).toHaveCount(entries.length);
+    await expect(cards.locator('[data-agent-sigil-generation="2"]')).toHaveCount(
+      generation2Count,
+    );
     await expect(
       cards.first().getByRole('img', { name: `${newest.name} agent identity sigil` }),
     ).toBeVisible();

--- a/tests/e2e/guestbook.spec.ts
+++ b/tests/e2e/guestbook.spec.ts
@@ -1,3 +1,4 @@
+import { agentGuestbookSigilSelection } from '@/lib/agent-guestbook-sigils';
 import { expect, test, type APIRequestContext } from '@playwright/test';
 
 type GuestbookEntry = {
@@ -22,6 +23,10 @@ function uniqueEntry(entries: GuestbookEntry[], id: string) {
   const matches = entries.filter((entry) => entry.id === id);
   expect(matches, `Expected exactly one guestbook entry with id ${id}`).toHaveLength(1);
   return matches[0]!;
+}
+
+function expectedSigilGeneration(entryId: string) {
+  return agentGuestbookSigilSelection(entryId)?.generation ?? 2;
 }
 
 async function getGuestbookEntries(request: APIRequestContext) {
@@ -70,7 +75,14 @@ test('guestbook cards follow the API order and keep generated identities with th
 
   await expect(cards).toHaveCount(entries.length);
   await expect(cards.locator('img')).toHaveCount(0);
-  await expect(cards.locator('[data-agent-sigil-generation="2"]')).toHaveCount(entries.length);
+  await expect(cards.locator('[data-agent-sigil]')).toHaveCount(entries.length);
+
+  for (const entry of entries) {
+    const card = page.locator(`[data-agent-visit="${entry.id}"]`);
+    await expect(
+      card.locator(`[data-agent-sigil-generation="${expectedSigilGeneration(entry.id)}"]`),
+    ).toHaveCount(1);
+  }
 
   const fingerprints = await cards.locator('[data-agent-sigil]').evaluateAll((elements) =>
     elements.map((element) => element.getAttribute('data-agent-sigil')),


### PR DESCRIPTION
Follow-up to merged #456.

## Problem

The data-driven gallery suites still asserted that every guestbook entry rendered with `data-agent-sigil-generation="2"`. The repository explicitly preserves deliberate generation/variant pins in `lib/agent-guestbook-sigils.ts`, including Generation 1 for exact historical reproduction. A supported Generation 1 pin would therefore break the tests and require the exact test edits the one-file check-in path is meant to eliminate.

## Fix

- count every rendered `[data-agent-sigil]` against the API entry count;
- derive each entry's expected generation from `agentGuestbookSigilSelection(entry.id)?.generation ?? 2`;
- verify every card against that exact generation in the behavioural suite;
- derive the Generation 2 population count from the same sidecar in all visual studies.

## Current-main replay

Merged #466 now contains the split sigil-lab studies that removed the unrelated WebKit timeout. This candidate is replayed directly onto that palette-enabled `main`.

Base: `63db192d39cd6354a1d9a6a663950214854ab891`  
Head: `7ee6ef594fa42444338ac3d7daf9dc6e360359c8`

## Scope

Two test files only:

- `tests/e2e/guestbook.spec.ts`;
- `tests/e2e/gallery-visual.spec.ts`.

No guestbook data, API, generator, selection, component, palette, or visual output changed. Draft for exact-head current-main CI. Do not merge automatically.