### PR TITLE
test: split sigil-lab visual studies by viewport

### DIFF
--- a/tests/e2e/sigil-lab.spec.ts
+++ b/tests/e2e/sigil-lab.spec.ts
@@ -16,10 +16,10 @@ const variants = [
   { theme: 'dark' as const, width: 1366, height: 768 },
 ];
 
-test('sigil lab exposes layered generations and visual evidence', async ({ page }, testInfo) => {
-  test.slow();
-
-  for (const variant of variants) {
+for (const variant of variants) {
+  test(`sigil lab exposes layered generations in ${variant.theme} at ${variant.width}x${variant.height}`, async ({
+    page,
+  }, testInfo) => {
     await page.emulateMedia({ colorScheme: variant.theme });
     await page.setViewportSize({ width: variant.width, height: variant.height });
 
@@ -57,8 +57,8 @@ test('sigil lab exposes layered generations and visual evidence', async ({ page 
       ),
       fullPage: true,
     });
-  }
-});
+  });
+}
 
 test('repository, designation, and description seeds stay isolated', async ({ page }) => {
   await page.goto('/sigil-lab');


### PR DESCRIPTION
## Problem

The current sigil-lab visual regression loops through four large light/dark mobile/desktop studies inside one Playwright test. WebKit repeatedly exceeds the 30-second test budget while loading and capturing the combined Generation 2 plus Kumiko page, causing unrelated pull requests to fail despite their changed surfaces passing.

Recent examples include PR #468 run 530, where the guestbook tests passed but the shared sigil-lab test timed out twice during `page.goto('/sigil-lab')`.

## Fix

Create one independent Playwright test per theme/viewport study. Every existing assertion and screenshot remains unchanged; each study simply receives its own normal test timeout and isolated page lifecycle.

## Scope

One test file only: `tests/e2e/sigil-lab.spec.ts`.

Base: `6b22df4420860d6719c0026e1d49075a2227e42e`  
Head: `2a494244da1f2a3679459a5a8c29471e3803191f`

## Validation

Exact-head CI run 534 (`30363827065`) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- full Chromium and WebKit browser regressions;
- existing sigil and Kumiko screenshots and assertions unchanged.

No application code, renderer, geometry, population, assertion threshold, screenshot, or production behaviour changed. Ready for review. Do not merge automatically.