### PR TITLE
Bring the paper counter motion onto current main

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,0 +1,20 @@
+.paperGrid {
+  --home-grid-rgb: 73 65 54;
+  --home-grid-alpha: 0.036;
+
+  background-image:
+    linear-gradient(rgb(var(--home-grid-rgb) / var(--home-grid-alpha)) 1px, transparent 1px),
+    linear-gradient(90deg, rgb(var(--home-grid-rgb) / var(--home-grid-alpha)) 1px, transparent 1px);
+  background-size: 28px 28px;
+}
+
+:global(.dark) .paperGrid {
+  --home-grid-rgb: 229 220 235;
+  --home-grid-alpha: 0.044;
+}
+
+@media (forced-colors: active) {
+  .paperGrid {
+    display: none;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { ArrowUpRight } from 'lucide-react';
 import type { Metadata } from 'next';
 import { connection } from 'next/server';
 import { Suspense } from 'react';
+import styles from './page.module.css';
 
 export const metadata: Metadata = {
   title: 'Leo · GitHub activity',
@@ -114,12 +115,8 @@ export default function Page() {
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-30 dark:opacity-12"
-        style={{
-          backgroundImage:
-            'linear-gradient(rgba(30,30,34,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(30,30,34,0.04) 1px, transparent 1px)',
-          backgroundSize: '28px 28px',
-        }}
+        className={`${styles.paperGrid} pointer-events-none absolute inset-0`}
+        data-home-paper-grid
       />
 
       <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-start px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">

--- a/components/home/activity-scoreboard.module.css
+++ b/components/home/activity-scoreboard.module.css
@@ -1,0 +1,257 @@
+.counter {
+  position: relative;
+  isolation: isolate;
+  perspective: 920px;
+  padding: 0.28rem 0.12rem 0.42rem;
+}
+
+.counter::before {
+  content: '';
+  position: absolute;
+  z-index: -1;
+  top: 0.8rem;
+  right: 0.4rem;
+  left: 0.4rem;
+  height: 0.16rem;
+  border-radius: 999px;
+  background: hsl(var(--border) / 0.78);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.34),
+    0 4px 9px rgb(64 52 37 / 0.1);
+  transform-origin: center;
+}
+
+.counterShadow {
+  position: absolute;
+  z-index: -2;
+  right: 3%;
+  bottom: 0.08rem;
+  left: 3%;
+  height: 18%;
+  border-radius: 50%;
+  background: rgb(66 52 34 / 0.15);
+  filter: blur(9px);
+  opacity: 0.46;
+  pointer-events: none;
+  transform-origin: center;
+}
+
+.digitSlot {
+  position: relative;
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 0.48rem 0.56rem 0.5rem 0.44rem;
+  background: hsl(var(--card));
+  transform-style: preserve-3d;
+}
+
+.digit {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  color: hsl(var(--foreground));
+  transform-style: preserve-3d;
+}
+
+.digit::before,
+.digit::after {
+  content: '';
+  position: absolute;
+  inset: 0.18rem 0.08rem -0.12rem;
+  z-index: -1;
+  border: 1px solid hsl(var(--border) / 0.58);
+  border-radius: 0.48rem 0.56rem 0.5rem 0.44rem;
+  background: hsl(var(--muted) / 0.76);
+  box-shadow: 0 4px 8px rgb(65 51 34 / 0.07);
+  transform: rotate(1.2deg) translateY(0.08rem);
+}
+
+.digit::after {
+  inset: 0.24rem 0.02rem -0.18rem 0.13rem;
+  z-index: -2;
+  opacity: 0.62;
+  transform: rotate(-1deg) translateY(0.1rem);
+}
+
+.face,
+.sheet {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid hsl(var(--border) / 0.88);
+  border-radius: 0.48rem 0.56rem 0.5rem 0.44rem;
+  background:
+    repeating-linear-gradient(
+      102deg,
+      transparent 0 19px,
+      hsl(var(--foreground) / 0.018) 19px 20px
+    ),
+    linear-gradient(145deg, hsl(var(--card)), hsl(var(--accent) / 0.7));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.48),
+    inset 0 -1px 0 hsl(var(--foreground) / 0.045),
+    0 8px 18px rgb(61 48 32 / 0.11);
+  backface-visibility: hidden;
+  transform-style: preserve-3d;
+}
+
+.face::before,
+.sheet::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      circle at 19% 14%,
+      hsl(var(--foreground) / 0.035) 0 0.7px,
+      transparent 0.9px
+    ),
+    radial-gradient(
+      circle at 76% 68%,
+      hsl(var(--foreground) / 0.025) 0 0.65px,
+      transparent 0.85px
+    );
+  background-size: 15px 17px, 19px 21px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.face::after,
+.sheet::after {
+  content: '';
+  position: absolute;
+  right: 12%;
+  bottom: 18%;
+  left: 12%;
+  height: 1px;
+  background: hsl(var(--foreground) / 0.07);
+  box-shadow: 0 0.42rem 0 hsl(var(--foreground) / 0.035);
+}
+
+.number {
+  position: relative;
+  z-index: 1;
+  display: block;
+  line-height: 1;
+  text-shadow:
+    0 1px 0 hsl(var(--background) / 0.72),
+    0 0 0.025em currentColor;
+  transform: translateY(-0.01em);
+}
+
+.binding {
+  position: absolute;
+  z-index: 6;
+  top: 0.34rem;
+  left: 50%;
+  width: 52%;
+  height: 0.24rem;
+  border: 1px solid hsl(var(--border) / 0.86);
+  border-radius: 999px;
+  background: hsl(var(--secondary));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.4),
+    0 2px 4px rgb(56 44 29 / 0.12);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.binding::before,
+.binding::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 0.22rem;
+  height: 0.22rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  background: hsl(var(--card));
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.44);
+  transform: translateY(-50%);
+}
+
+.binding::before {
+  left: 13%;
+}
+
+.binding::after {
+  right: 13%;
+}
+
+.departing {
+  z-index: 4;
+  transform-origin: 50% 0.45rem;
+  will-change: transform, opacity, filter;
+}
+
+.arriving {
+  z-index: 5;
+  transform-origin: 50% 0.45rem;
+  will-change: transform, opacity;
+}
+
+:global(.dark) .counter::before {
+  background: hsl(var(--border) / 0.9);
+  box-shadow:
+    0 1px 0 rgb(255 255 255 / 0.08),
+    0 5px 10px rgb(0 0 0 / 0.28);
+}
+
+:global(.dark) .counterShadow {
+  background: rgb(0 0 0 / 0.34);
+  opacity: 0.58;
+}
+
+:global(.dark) .digit::before,
+:global(.dark) .digit::after {
+  border-color: hsl(var(--border) / 0.66);
+  background: hsl(var(--muted) / 0.72);
+  box-shadow: 0 5px 10px rgb(0 0 0 / 0.24);
+}
+
+:global(.dark) .face,
+:global(.dark) .sheet {
+  background:
+    repeating-linear-gradient(
+      102deg,
+      transparent 0 19px,
+      hsl(var(--foreground) / 0.022) 19px 20px
+    ),
+    linear-gradient(145deg, hsl(var(--card)), hsl(var(--accent) / 0.78));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    inset 0 -1px 0 rgb(0 0 0 / 0.24),
+    0 9px 20px rgb(0 0 0 / 0.3);
+}
+
+:global(.dark) .binding {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08),
+    0 2px 5px rgb(0 0 0 / 0.28);
+}
+
+@media (forced-colors: active) {
+  .counter::before,
+  .counterShadow,
+  .digit::before,
+  .digit::after,
+  .face::before,
+  .face::after,
+  .sheet::before,
+  .sheet::after,
+  .binding {
+    display: none;
+  }
+
+  .digitSlot,
+  .face,
+  .sheet {
+    border-color: CanvasText;
+    background: Canvas;
+    box-shadow: none;
+    color: CanvasText;
+  }
+}

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { ScrapbookPet } from '@/components/home/scrapbook-pet';
-import { motion, useReducedMotion } from 'framer-motion';
-import { useEffect, useMemo, useState } from 'react';
+import { motion, useAnimate, useReducedMotion } from 'framer-motion';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import styles from './activity-scoreboard.module.css';
 
 function countdownToUtcMidnight() {
   const now = new Date();
@@ -14,87 +15,132 @@ function countdownToUtcMidnight() {
   return [hours, minutes, remainder].map((part) => String(part).padStart(2, '0')).join(':');
 }
 
-function StaticHalf({ digit, half }: { digit: string; half: 'top' | 'bottom' }) {
+function PaperFace({ digit, className = '' }: { digit: string; className?: string }) {
   return (
-    <span
-      aria-hidden="true"
-      className={`absolute inset-x-0 h-1/2 overflow-hidden ${half === 'top' ? 'top-0' : 'bottom-0'}`}
-    >
-      <span
-        className={`absolute inset-x-0 flex h-[200%] items-center justify-center tabular-nums ${half === 'top' ? 'top-0' : 'bottom-0'}`}
-      >
-        {digit}
-      </span>
+    <span aria-hidden="true" className={`${styles.face} ${className}`}>
+      <span className={styles.number}>{digit}</span>
     </span>
   );
 }
 
-function SplitFlapDigit({ digit, index }: { digit: string; index: number }) {
+type DigitTurn = {
+  id: number;
+  from: string;
+  to: string;
+};
+
+function PaperDigit({ digit, index }: { digit: string; index: number }) {
   const reduceMotion = useReducedMotion();
-  const [current, setCurrent] = useState(digit);
-  const [previous, setPrevious] = useState(digit);
-  const [sequence, setSequence] = useState(0);
-  const [animating, setAnimating] = useState(false);
+  const [displayed, setDisplayed] = useState(digit);
+  const [turn, setTurn] = useState<DigitTurn | null>(null);
+  const sequence = useRef(0);
+  const restingTilt = index % 2 === 0 ? -0.72 : 0.58;
 
   useEffect(() => {
-    if (digit === current) return;
-    setPrevious(current);
-    setCurrent(digit);
-    setSequence((value) => value + 1);
-    setAnimating(!reduceMotion && document.visibilityState === 'visible');
-  }, [current, digit, reduceMotion]);
+    if (reduceMotion || document.visibilityState !== 'visible') {
+      setDisplayed(digit);
+      setTurn(null);
+      return;
+    }
 
-  const stagger = (3 - index) * 0.035;
+    if (turn || digit === displayed) return;
+    sequence.current += 1;
+    setTurn({ id: sequence.current, from: displayed, to: digit });
+  }, [digit, displayed, reduceMotion, turn]);
+
+  const delay = (3 - index) * 0.055;
 
   return (
-    <span className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
-      <StaticHalf digit={current} half="top" />
-      <StaticHalf digit={current} half="bottom" />
+    <motion.span
+      className={styles.digit}
+      data-paper-digit
+      initial={
+        reduceMotion
+          ? false
+          : {
+              y: 13,
+              rotateZ: restingTilt * 2.4,
+              scale: 0.965,
+            }
+      }
+      animate={{ y: 0, rotateZ: restingTilt, scale: 1 }}
+      transition={
+        reduceMotion
+          ? { duration: 0 }
+          : {
+              type: 'spring',
+              stiffness: 280,
+              damping: 22,
+              mass: 0.72,
+              delay: 0.08 + index * 0.055,
+            }
+      }
+    >
+      <span className={styles.binding} data-paper-counter-binding />
+      <PaperFace digit={displayed} />
 
-      {animating ? (
+      {turn ? (
         <>
           <motion.span
-            key={`depart-${sequence}`}
+            key={`depart-${turn.id}`}
             aria-hidden="true"
-            className="absolute inset-x-0 top-0 z-20 h-1/2 origin-bottom overflow-hidden bg-[#1b1c20] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),inset_0_-8px_12px_rgba(0,0,0,0.2)] [backface-visibility:hidden] [transform-style:preserve-3d]"
-            initial={{ rotateX: 0 }}
-            animate={{ rotateX: -90 }}
-            transition={{ duration: 0.22, delay: stagger, ease: [0.55, 0.06, 0.68, 0.19] }}
+            className={`${styles.sheet} ${styles.departing}`}
+            initial={{ rotateX: 0, y: 0, opacity: 1, filter: 'blur(0px)' }}
+            animate={{
+              rotateX: [0, -24, -103],
+              y: [0, -2, -12],
+              opacity: [1, 1, 0],
+              filter: ['blur(0px)', 'blur(0px)', 'blur(1.4px)'],
+            }}
+            transition={{
+              duration: 0.46,
+              delay,
+              times: [0, 0.42, 1],
+              ease: [0.55, 0.06, 0.68, 0.19],
+            }}
           >
-            <span className="absolute inset-x-0 top-0 flex h-[200%] items-center justify-center tabular-nums">
-              {previous}
-            </span>
+            <span className={styles.number}>{turn.from}</span>
           </motion.span>
+
           <motion.span
-            key={`arrive-${sequence}`}
+            key={`arrive-${turn.id}`}
             aria-hidden="true"
-            className="absolute inset-x-0 bottom-0 z-30 h-1/2 origin-top overflow-hidden bg-[#15161a] shadow-[inset_0_8px_12px_rgba(0,0,0,0.34)] [backface-visibility:hidden] [transform-style:preserve-3d]"
-            initial={{ rotateX: 90 }}
-            animate={{ rotateX: 0 }}
-            transition={{ duration: 0.28, delay: stagger + 0.19, ease: [0.22, 1, 0.36, 1] }}
-            onAnimationComplete={() => setAnimating(false)}
+            className={`${styles.sheet} ${styles.arriving}`}
+            initial={{ rotateX: 88, y: '20%', opacity: 0.2, scale: 0.955 }}
+            animate={{
+              rotateX: [88, -9, 2, 0],
+              y: ['20%', '-2.5%', '0.7%', '0%'],
+              opacity: [0.2, 1, 1, 1],
+              scale: [0.955, 1.018, 0.997, 1],
+            }}
+            transition={{
+              duration: 0.62,
+              delay: delay + 0.16,
+              times: [0, 0.58, 0.82, 1],
+              ease: [0.22, 1, 0.36, 1],
+            }}
+            onAnimationComplete={() => {
+              setDisplayed(turn.to);
+              setTurn(null);
+            }}
           >
-            <span className="absolute inset-x-0 bottom-0 flex h-[200%] items-center justify-center tabular-nums">
-              {current}
-            </span>
+            <motion.span
+              className={styles.number}
+              initial={{ opacity: 0.35, scale: 1.2, filter: 'blur(2px)' }}
+              animate={{ opacity: 1, scale: [1.2, 0.96, 1], filter: 'blur(0px)' }}
+              transition={{
+                duration: 0.34,
+                delay: delay + 0.34,
+                times: [0, 0.7, 1],
+                ease: [0.16, 1, 0.3, 1],
+              }}
+            >
+              {turn.to}
+            </motion.span>
           </motion.span>
         </>
       ) : null}
-
-      <span aria-hidden="true" className="absolute inset-x-0 top-1/2 z-40 h-px bg-black/80" />
-      <span
-        aria-hidden="true"
-        className="absolute inset-x-0 top-1/2 z-40 h-px -translate-y-px bg-white/[0.05]"
-      />
-      <span
-        aria-hidden="true"
-        className="absolute left-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]"
-      />
-      <span
-        aria-hidden="true"
-        className="absolute right-1 top-1/2 z-50 h-1.5 w-1 -translate-y-1/2 rounded-sm bg-black/65 shadow-[0_0_0_1px_rgba(255,255,255,0.04)]"
-      />
-    </span>
+    </motion.span>
   );
 }
 
@@ -103,21 +149,61 @@ function ScoreDigits({ value }: { value: number }) {
     () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
     [value],
   );
+  const reduceMotion = useReducedMotion();
+  const previousValue = useRef(value);
+  const [scope, animate] = useAnimate();
+
+  useEffect(() => {
+    if (previousValue.current === value) return;
+    previousValue.current = value;
+    if (reduceMotion || !scope.current) return;
+
+    const controls = [
+      animate(
+        scope.current,
+        {
+          y: [0, -2.5, 1, 0],
+          rotateZ: [0, -0.32, 0.14, 0],
+        },
+        { duration: 0.72, times: [0, 0.32, 0.72, 1], ease: [0.2, 0.8, 0.2, 1] },
+      ),
+      animate(
+        '[data-paper-counter-binding]',
+        { scaleX: [1, 1.055, 0.985, 1] },
+        { duration: 0.68, ease: [0.2, 0.8, 0.2, 1] },
+      ),
+      animate(
+        '[data-paper-counter-shadow]',
+        { scaleX: [1, 1.025, 0.99, 1], y: [0, 1, -0.5, 0] },
+        { duration: 0.72, ease: [0.2, 0.8, 0.2, 1] },
+      ),
+    ];
+
+    return () => controls.forEach((control) => control.stop());
+  }, [animate, reduceMotion, scope, value]);
 
   return (
     <div
-      className="flex min-w-0 gap-1.5 sm:gap-2"
+      ref={scope}
+      className={`${styles.counter} flex min-w-0 gap-1.5 sm:gap-2`}
       aria-label={`${value} contributions today`}
+      data-paper-counter
+      data-reduced-motion={reduceMotion ? 'true' : 'false'}
       data-wind-scoreboard
     >
+      <span
+        aria-hidden="true"
+        className={styles.counterShadow}
+        data-paper-counter-shadow
+      />
       {digits.map((digit, index) => (
         <div
           key={index}
           data-activity-digit
-          className={`relative aspect-[0.78] min-w-0 flex-1 overflow-hidden rounded-[0.55rem] border border-white/12 bg-[#17181b] px-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none text-[#f3f0e9] shadow-[inset_0_1px_0_rgba(255,255,255,0.06),inset_0_-10px_18px_rgba(0,0,0,0.3),0_7px_18px_rgba(0,0,0,0.2)] transition-[transform,box-shadow] duration-300 ease-out group-hover:-translate-y-1 group-hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_-12px_20px_rgba(0,0,0,0.34),0_14px_26px_rgba(0,0,0,0.28)] motion-reduce:transition-none ${index % 2 === 0 ? 'group-hover:-rotate-[0.7deg]' : 'group-hover:rotate-[0.7deg]'}`}
+          className={`${styles.digitSlot} relative aspect-[0.78] min-w-0 flex-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none tabular-nums transition-transform duration-300 ease-out group-hover:-translate-y-1 motion-reduce:transform-none motion-reduce:transition-none ${index % 2 === 0 ? 'group-hover:-rotate-[0.7deg]' : 'group-hover:rotate-[0.7deg]'}`}
           style={{ transitionDelay: `${index * 24}ms` }}
         >
-          <SplitFlapDigit digit={digit} index={index} />
+          <PaperDigit digit={digit} index={index} />
         </div>
       ))}
     </div>

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -9,6 +9,24 @@ const studies = [
   { theme: 'dark', width: 1440, height: 900 },
 ] as const;
 
+function shiftedDigits(value: number, amount: number) {
+  return Number(
+    String(value)
+      .slice(-4)
+      .padStart(4, '0')
+      .split('')
+      .map((digit) => (Number(digit) + amount) % 10)
+      .join(''),
+  );
+}
+
+function activityDays() {
+  return Array.from({ length: 35 }, (_, index) => ({
+    date: `2026-07-${String(index + 1).padStart(2, '0')}`,
+    count: index % 7,
+  }));
+}
+
 for (const study of studies) {
   test(`captures ${study.theme} scoreboard appearance at ${study.width}x${study.height}`, async ({
     page,
@@ -29,16 +47,32 @@ for (const study of studies) {
     }
 
     const scoreboard = page.locator('[data-activity-scoreboard]');
+    const counter = scoreboard.locator('[data-paper-counter]');
     await expect(scoreboard).toBeVisible({ timeout: 15_000 });
+    await expect(counter).toBeVisible();
     await expect(scoreboard.locator('[data-activity-digit]')).toHaveCount(4);
+    await expect(counter.locator('[data-paper-digit]')).toHaveCount(4);
     await expect(scoreboard.getByText('7D', { exact: true })).toBeVisible();
     await expect(scoreboard.getByText('1Y', { exact: true })).toBeVisible();
-    await expect
-      .poll(async () => {
-        const box = await scoreboard.boundingBox();
-        return box ? Math.min(box.width, box.height) : 0;
-      })
-      .toBeGreaterThan(0);
+
+    const paperFaces = await scoreboard.locator('[data-activity-digit]').evaluateAll((digits) =>
+      digits.map((digit) => {
+        const face = digit.querySelector<HTMLElement>('[aria-hidden="true"]');
+        const paperDigit = digit.querySelector<HTMLElement>('[data-paper-digit]');
+        if (!face || !paperDigit) throw new Error('Missing paper digit face');
+        const style = getComputedStyle(face);
+        return {
+          backgroundImage: style.backgroundImage,
+          borderStyle: style.borderStyle,
+          transformStyle: getComputedStyle(paperDigit).transformStyle,
+        };
+      }),
+    );
+    for (const face of paperFaces) {
+      expect(face.backgroundImage).not.toBe('none');
+      expect(face.borderStyle).toBe('solid');
+      expect(face.transformStyle).toBe('preserve-3d');
+    }
 
     const overflow = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
@@ -46,10 +80,18 @@ for (const study of studies) {
     }));
     expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
 
+    const minimumHeight = study.height <= 780 ? 232 : 248;
+    await expect
+      .poll(async () =>
+        scoreboard.evaluate((element, expectedHeight) => {
+          const rect = element.getBoundingClientRect();
+          return rect.width > 0 && rect.height >= expectedHeight;
+        }, minimumHeight),
+      )
+      .toBe(true);
     const dimensions = await scoreboard.boundingBox();
     expect(dimensions).toBeTruthy();
     expect(dimensions!.width).toBeLessThanOrEqual(study.width);
-    expect(dimensions!.height).toBeGreaterThanOrEqual(study.height <= 780 ? 232 : 248);
 
     const screenshotPath = path.join(
       'test-results',
@@ -63,7 +105,179 @@ for (const study of studies) {
   });
 }
 
-test('keeps the scoreboard calm with reduced motion', async ({ page }) => {
+test('captures the live paper counter choreography', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.addInitScript(() => {
+    const actualNow = Date.now.bind(Date);
+    Date.now = () => actualNow() + 60 * 60 * 1_000;
+    window.localStorage.setItem('theme', 'light');
+  });
+
+  let releaseResponse!: () => void;
+  const responseGate = new Promise<void>((resolve) => {
+    releaseResponse = resolve;
+  });
+  let targetToday = 0;
+
+  await page.route('**/api/github-activity', async (route) => {
+    await responseGate;
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        source: 'public-profile',
+        today: targetToday,
+        weekTotal: 321,
+        yearTotal: 4_321,
+        days: activityDays(),
+        generatedAt: new Date().toISOString(),
+      }),
+    });
+  });
+
+  const refreshRequest = page.waitForRequest(
+    (request) => new URL(request.url()).pathname === '/api/github-activity',
+  );
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const scoreboard = page.locator('[data-activity-scoreboard]');
+  const counter = scoreboard.locator('[data-paper-counter]');
+  await expect(counter).toBeVisible({ timeout: 15_000 });
+  await refreshRequest;
+
+  const initialLabel = await counter.getAttribute('aria-label');
+  const initialToday = Number(initialLabel?.match(/^\d+/)?.[0] ?? 0);
+  targetToday = shiftedDigits(initialToday, 5);
+
+  const frameDirectory = path.join(
+    'test-results',
+    'scoreboard-appearance',
+    'motion',
+    testInfo.project.name,
+  );
+  await mkdir(frameDirectory, { recursive: true });
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '00-before.png'),
+    animations: 'allow',
+  });
+
+  releaseResponse();
+  const lastDigitFaces = counter
+    .locator('[data-paper-digit]')
+    .last()
+    .locator('[aria-hidden="true"]');
+  await expect(lastDigitFaces).toHaveCount(3, { timeout: 2_000 });
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '01-lift.png'),
+    animations: 'allow',
+  });
+
+  await page.waitForTimeout(220);
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '02-turn.png'),
+    animations: 'allow',
+  });
+
+  await page.waitForTimeout(300);
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '03-ink.png'),
+    animations: 'allow',
+  });
+
+  await expect(counter).toHaveAttribute(
+    'aria-label',
+    `${targetToday} contributions today`,
+  );
+  await expect(lastDigitFaces).toHaveCount(1, { timeout: 3_000 });
+  await scoreboard.screenshot({
+    path: path.join(frameDirectory, '04-settled.png'),
+    animations: 'allow',
+  });
+});
+
+test('queues a newer activity value while paper leaves are still turning', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.addInitScript(() => {
+    const actualNow = Date.now.bind(Date);
+    let offset = 60 * 60 * 1_000;
+    Date.now = () => actualNow() + offset;
+    (window as Window & { __advanceActivityClock: (milliseconds: number) => void }).__advanceActivityClock =
+      (milliseconds) => {
+        offset += milliseconds;
+      };
+  });
+
+  let releaseFirst!: () => void;
+  let releaseSecond!: () => void;
+  const gates = [
+    new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    }),
+    new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    }),
+  ];
+  let requestIndex = 0;
+  let targets = [0, 0];
+
+  await page.route('**/api/github-activity', async (route) => {
+    const index = Math.min(requestIndex, 1);
+    requestIndex += 1;
+    await gates[index];
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        source: 'public-profile',
+        today: targets[index],
+        weekTotal: 654,
+        yearTotal: 7_654,
+        days: activityDays(),
+        generatedAt: new Date(Date.now() + index * 1_000).toISOString(),
+      }),
+    });
+  });
+
+  const firstRequest = page.waitForRequest(
+    (request) => new URL(request.url()).pathname === '/api/github-activity',
+  );
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const counter = page.locator('[data-paper-counter]');
+  await expect(counter).toBeVisible({ timeout: 15_000 });
+  await firstRequest;
+
+  const initialLabel = await counter.getAttribute('aria-label');
+  const initialToday = Number(initialLabel?.match(/^\d+/)?.[0] ?? 0);
+  targets = [shiftedDigits(initialToday, 4), shiftedDigits(initialToday, 7)];
+  releaseFirst();
+
+  await expect(counter).toHaveAttribute('aria-label', `${targets[0]} contributions today`);
+  const lastDigitFaces = counter
+    .locator('[data-paper-digit]')
+    .last()
+    .locator('[aria-hidden="true"]');
+  await expect(lastDigitFaces).toHaveCount(3, { timeout: 2_000 });
+
+  const secondRequest = page.waitForRequest(
+    (request) => new URL(request.url()).pathname === '/api/github-activity',
+  );
+  await page.evaluate(() => {
+    (
+      window as Window & { __advanceActivityClock: (milliseconds: number) => void }
+    ).__advanceActivityClock(31_000);
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await secondRequest;
+  releaseSecond();
+
+  await expect(counter).toHaveAttribute('aria-label', `${targets[1]} contributions today`);
+  await expect(counter.locator('[data-paper-digit] [aria-hidden="true"]')).toHaveCount(4, {
+    timeout: 5_000,
+  });
+});
+
+test('keeps the paper counter calm with reduced motion', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
   await page.setViewportSize({ width: 390, height: 844 });
   await page.addInitScript(() => {
@@ -72,8 +286,10 @@ test('keeps the scoreboard calm with reduced motion', async ({ page }) => {
   await page.goto('/');
 
   const scoreboard = page.locator('[data-activity-scoreboard]');
+  const counter = scoreboard.locator('[data-paper-counter]');
   const digit = scoreboard.locator('[data-activity-digit]').first();
   await expect(digit).toBeVisible({ timeout: 15_000 });
+  await expect(counter).toHaveAttribute('data-reduced-motion', 'true');
   const before = await scoreboard.evaluate((element) => getComputedStyle(element).transform);
   await scoreboard.hover();
   const after = await scoreboard.evaluate((element) => getComputedStyle(element).transform);
@@ -81,7 +297,7 @@ test('keeps the scoreboard calm with reduced motion', async ({ page }) => {
   expect(after).toBe(before);
 });
 
-test('keeps split-flap digits readable in forced colours', async ({ page }, testInfo) => {
+test('keeps paper digits readable in forced colours', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'chromium', 'Forced-colour emulation is checked in Chromium.');
 
   await page.emulateMedia({ forcedColors: 'active' });

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -57,24 +57,25 @@ for (const study of studies) {
     await expect(scoreboard.getByText('7D', { exact: true })).toBeVisible();
     await expect(scoreboard.getByText('1Y', { exact: true })).toBeVisible();
 
-    const paperFaces = await scoreboard.locator('[data-activity-digit]').evaluateAll((digits) =>
-      digits.map((digit) => {
-        const face = digit.querySelector<HTMLElement>('[aria-hidden="true"]');
-        const paperDigit = digit.querySelector<HTMLElement>('[data-paper-digit]');
-        if (!face || !paperDigit) throw new Error('Missing paper digit face');
-        const style = getComputedStyle(face);
-        return {
-          backgroundImage: style.backgroundImage,
-          borderStyle: style.borderStyle,
-          transformStyle: getComputedStyle(paperDigit).transformStyle,
-        };
-      }),
-    );
-    for (const face of paperFaces) {
-      expect(face.backgroundImage).not.toBe('none');
-      expect(face.borderStyle).toBe('solid');
-      expect(face.transformStyle).toBe('preserve-3d');
-    }
+    await expect
+      .poll(
+        () =>
+          scoreboard.locator('[data-activity-digit]').evaluateAll((digits) =>
+            digits.every((digit) => {
+              const face = digit.querySelector<HTMLElement>('[aria-hidden="true"]');
+              const paperDigit = digit.querySelector<HTMLElement>('[data-paper-digit]');
+              if (!face || !paperDigit) return false;
+              const faceStyle = getComputedStyle(face);
+              return (
+                faceStyle.backgroundImage !== 'none' &&
+                faceStyle.borderStyle === 'solid' &&
+                getComputedStyle(paperDigit).transformStyle === 'preserve-3d'
+              );
+            }),
+          ),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
 
     const overflow = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
@@ -91,9 +92,12 @@ for (const study of studies) {
         }, minimumHeight),
       )
       .toBe(true);
-    const dimensions = await scoreboard.boundingBox();
-    expect(dimensions).toBeTruthy();
-    expect(dimensions!.width).toBeLessThanOrEqual(study.width);
+    const dimensions = await scoreboard.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { width: rect.width, height: rect.height };
+    });
+    expect(dimensions.width).toBeLessThanOrEqual(study.width);
+    expect(dimensions.height).toBeGreaterThanOrEqual(minimumHeight);
 
     const screenshotPath = path.join(
       'test-results',
@@ -108,6 +112,8 @@ for (const study of studies) {
 }
 
 test('captures the live paper counter choreography', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Motion frames are captured once in Chromium.');
+
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.addInitScript(() => {
     const actualNow = Date.now.bind(Date);
@@ -168,7 +174,7 @@ test('captures the live paper counter choreography', async ({ page }, testInfo) 
     .locator('[data-paper-digit]')
     .last()
     .locator('[aria-hidden="true"]');
-  await expect(lastDigitFaces).toHaveCount(3, { timeout: 2_000 });
+  await expect(lastDigitFaces).toHaveCount(3, { timeout: 3_000 });
   await scoreboard.screenshot({
     path: path.join(frameDirectory, '01-lift.png'),
     animations: 'allow',
@@ -190,7 +196,7 @@ test('captures the live paper counter choreography', async ({ page }, testInfo) 
     'aria-label',
     `${targetToday} contributions today`,
   );
-  await expect(lastDigitFaces).toHaveCount(1, { timeout: 3_000 });
+  await expect(lastDigitFaces).toHaveCount(1, { timeout: 5_000 });
   await scoreboard.screenshot({
     path: path.join(frameDirectory, '04-settled.png'),
     animations: 'allow',
@@ -203,10 +209,9 @@ test('queues a newer activity value while paper leaves are still turning', async
     const actualNow = Date.now.bind(Date);
     let offset = 60 * 60 * 1_000;
     Date.now = () => actualNow() + offset;
-    (window as Window & { __advanceActivityClock: (milliseconds: number) => void }).__advanceActivityClock =
-      (milliseconds) => {
-        offset += milliseconds;
-      };
+    window.__advanceActivityClock = (milliseconds) => {
+      offset += milliseconds;
+    };
   });
 
   let releaseFirst!: () => void;
@@ -259,15 +264,13 @@ test('queues a newer activity value while paper leaves are still turning', async
     .locator('[data-paper-digit]')
     .last()
     .locator('[aria-hidden="true"]');
-  await expect(lastDigitFaces).toHaveCount(3, { timeout: 2_000 });
+  await expect(lastDigitFaces).toHaveCount(3, { timeout: 3_000 });
 
   const secondRequest = page.waitForRequest(
     (request) => new URL(request.url()).pathname === '/api/github-activity',
   );
   await page.evaluate(() => {
-    (
-      window as Window & { __advanceActivityClock: (milliseconds: number) => void }
-    ).__advanceActivityClock(31_000);
+    window.__advanceActivityClock(31_000);
     document.dispatchEvent(new Event('visibilitychange'));
   });
   await secondRequest;
@@ -275,7 +278,7 @@ test('queues a newer activity value while paper leaves are still turning', async
 
   await expect(counter).toHaveAttribute('aria-label', `${targets[1]} contributions today`);
   await expect(counter.locator('[data-paper-digit] [aria-hidden="true"]')).toHaveCount(4, {
-    timeout: 5_000,
+    timeout: 15_000,
   });
 });
 

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -21,8 +21,10 @@ function shiftedDigits(value: number, amount: number) {
 }
 
 function activityDays() {
+  const start = Date.UTC(2026, 5, 24);
+  const dayMilliseconds = 24 * 60 * 60 * 1_000;
   return Array.from({ length: 35 }, (_, index) => ({
-    date: `2026-07-${String(index + 1).padStart(2, '0')}`,
+    date: new Date(start + index * dayMilliseconds).toISOString().slice(0, 10),
     count: index % 7,
   }));
 }

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -85,19 +85,21 @@ for (const study of studies) {
 
     const minimumHeight = study.height <= 780 ? 232 : 248;
     await expect
-      .poll(async () =>
-        scoreboard.evaluate((element, expectedHeight) => {
-          const rect = element.getBoundingClientRect();
-          return rect.width > 0 && rect.height >= expectedHeight;
-        }, minimumHeight),
+      .poll(
+        () =>
+          scoreboard.evaluate(
+            (element, constraints) => {
+              const rect = element.getBoundingClientRect();
+              return {
+                heightReady: rect.height >= constraints.minimumHeight,
+                widthContained: rect.width > 0 && rect.width <= constraints.viewportWidth,
+              };
+            },
+            { minimumHeight, viewportWidth: study.width },
+          ),
+        { timeout: 10_000 },
       )
-      .toBe(true);
-    const dimensions = await scoreboard.evaluate((element) => {
-      const rect = element.getBoundingClientRect();
-      return { width: rect.width, height: rect.height };
-    });
-    expect(dimensions.width).toBeLessThanOrEqual(study.width);
-    expect(dimensions.height).toBeGreaterThanOrEqual(minimumHeight);
+      .toEqual({ heightReady: true, widthContained: true });
 
     const screenshotPath = path.join(
       'test-results',

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -8,6 +8,13 @@ const studies = [
   { theme: 'light', width: 1366, height: 768 },
   { theme: 'dark', width: 1440, height: 900 },
 ] as const;
+
+function hydratedScoreboard(page: Page) {
+  return page
+    .locator('[data-activity-scoreboard]:visible')
+    .filter({ hasText: /UTC reset \d{2}:\d{2}:\d{2}/ })
+    .last();
+}
 
 function shiftedDigits(value: number, amount: number) {
   return Number(
@@ -48,7 +55,7 @@ for (const study of studies) {
       await expect(root).toHaveClass(/light/);
     }
 
-    const scoreboard = page.locator('[data-activity-scoreboard]');
+    const scoreboard = hydratedScoreboard(page);
     const counter = scoreboard.locator('[data-paper-counter]');
     await expect(scoreboard).toBeVisible({ timeout: 15_000 });
     await expect(counter).toBeVisible();
@@ -150,7 +157,7 @@ test('captures the live paper counter choreography', async ({ page }, testInfo) 
   const response = await page.goto('/');
   expect(response?.ok()).toBe(true);
 
-  const scoreboard = page.locator('[data-activity-scoreboard]');
+  const scoreboard = hydratedScoreboard(page);
   const counter = scoreboard.locator('[data-paper-counter]');
   await expect(counter).toBeVisible({ timeout: 15_000 });
   await refreshRequest;
@@ -252,7 +259,7 @@ test('queues a newer activity value while paper leaves are still turning', async
   const response = await page.goto('/');
   expect(response?.ok()).toBe(true);
 
-  const counter = page.locator('[data-paper-counter]');
+  const counter = hydratedScoreboard(page).locator('[data-paper-counter]');
   await expect(counter).toBeVisible({ timeout: 15_000 });
   await firstRequest;
 
@@ -292,7 +299,7 @@ test('keeps the paper counter calm with reduced motion', async ({ page }) => {
   });
   await page.goto('/');
 
-  const scoreboard = page.locator('[data-activity-scoreboard]');
+  const scoreboard = hydratedScoreboard(page);
   const counter = scoreboard.locator('[data-paper-counter]');
   const digit = scoreboard.locator('[data-activity-digit]').first();
   await expect(digit).toBeVisible({ timeout: 15_000 });
@@ -311,7 +318,7 @@ test('keeps paper digits readable in forced colours', async ({ page }, testInfo)
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');
 
-  const digit = page.locator('[data-activity-digit]').first();
+  const digit = hydratedScoreboard(page).locator('[data-activity-digit]').first();
   await expect(digit).toBeVisible({ timeout: 15_000 });
   const style = await digit.evaluate((element) => {
     const computed = window.getComputedStyle(element);

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -282,12 +282,26 @@ test('homepage scorecard lifts under pointer movement', async ({ page }) => {
   await waitForHomeActivity(page);
 
   const scoreboard = page.locator('[data-activity-scoreboard]');
-  const before = await scoreboard.evaluate((element) => getComputedStyle(element).transform);
-  await scoreboard.hover();
+  const counter = scoreboard.locator('[data-paper-counter]');
+  await expect(scoreboard).toBeVisible();
+  await expect(counter).toHaveAttribute('data-reduced-motion', 'false');
+  const before = await scoreboard.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+
+  await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2, { steps: 6 });
 
   await expect
-    .poll(() => scoreboard.evaluate((element) => getComputedStyle(element).transform))
-    .not.toBe(before);
+    .poll(
+      () =>
+        scoreboard.evaluate((element, restingY) => {
+          const rect = element.getBoundingClientRect();
+          return restingY - rect.y;
+        }, before.y),
+      { timeout: 10_000 },
+    )
+    .toBeGreaterThan(2);
 });
 
 test('homepage scorecard remains planted with reduced motion', async ({ page }) => {
@@ -296,11 +310,25 @@ test('homepage scorecard remains planted with reduced motion', async ({ page }) 
   await waitForHomeActivity(page);
 
   const scoreboard = page.locator('[data-activity-scoreboard]');
-  const before = await scoreboard.evaluate((element) => getComputedStyle(element).transform);
-  await scoreboard.hover();
-  const after = await scoreboard.evaluate((element) => getComputedStyle(element).transform);
+  const counter = scoreboard.locator('[data-paper-counter]');
+  await expect(scoreboard).toBeVisible();
+  await expect(counter).toHaveAttribute('data-reduced-motion', 'true');
+  const before = await scoreboard.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
 
-  expect(after).toBe(before);
+  await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2, { steps: 6 });
+  await page.waitForTimeout(500);
+  const after = await scoreboard.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+
+  expect(Math.abs(after.x - before.x)).toBeLessThan(1);
+  expect(Math.abs(after.y - before.y)).toBeLessThan(1);
+  expect(Math.abs(after.width - before.width)).toBeLessThan(1);
+  expect(Math.abs(after.height - before.height)).toBeLessThan(1);
 });
 
 test('mobile gallery does not overflow horizontally', async ({ page }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -18,9 +18,18 @@ async function waitForClientHydration(page: Page) {
     .not.toContain('Local time --:--');
 }
 
+function hydratedHomeDashboard(page: Page) {
+  return page
+    .locator('[data-home-activity-dashboard]:visible')
+    .filter({ hasText: /UTC reset \d{2}:\d{2}:\d{2}/ })
+    .last();
+}
+
 async function waitForHomeActivity(page: Page) {
-  await expect(page.locator('[data-home-activity-dashboard]')).toBeVisible({ timeout: 15_000 });
-  await expect(page.locator('[data-contribution-week-grid]')).toBeVisible();
+  const dashboard = hydratedHomeDashboard(page);
+  await expect(dashboard).toBeVisible({ timeout: 15_000 });
+  await expect(dashboard.locator('[data-contribution-week-grid]')).toBeVisible();
+  return dashboard;
 }
 
 async function expectWheelScrollsDocument(page: Page, route: string, selector: string) {
@@ -80,45 +89,49 @@ test('homepage highlights three recent systems', async ({ page }) => {
 
 test('homepage counter uses UTC, 7D, and rolling-year instrument labels', async ({ page }) => {
   await page.goto('/');
-  await waitForHomeActivity(page);
+  const dashboard = await waitForHomeActivity(page);
 
-  await expect(page.getByText(/UTC reset \d{2}:\d{2}:\d{2}/)).toBeVisible();
-  await expect(page.getByText('7D', { exact: true })).toBeVisible();
-  await expect(page.getByText('1Y', { exact: true })).toBeVisible();
-  await expect(page.locator('[data-activity-digit] > span')).toHaveCount(4);
+  await expect(dashboard.getByText(/UTC reset \d{2}:\d{2}:\d{2}/)).toBeVisible();
+  await expect(dashboard.getByText('7D', { exact: true })).toBeVisible();
+  await expect(dashboard.getByText('1Y', { exact: true })).toBeVisible();
+  await expect(dashboard.locator('[data-activity-digit] > span')).toHaveCount(4);
 });
 
 test('homepage activity tooltip stays anchored through a pointer click', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto('/');
   await waitForClientHydration(page);
-  await waitForHomeActivity(page);
+  const dashboard = await waitForHomeActivity(page);
 
-  const grid = page.locator('[data-contribution-week-grid]');
+  const grid = dashboard.locator('[data-contribution-week-grid]');
   const cell = grid.getByRole('button').nth(8);
   await expect(cell).toBeVisible();
-  await expect.poll(async () => Boolean(await cell.boundingBox())).toBe(true);
 
   const label = await cell.getAttribute('aria-label');
   expect(label).toBeTruthy();
-  const cellBox = await cell.boundingBox();
-  expect(cellBox).toBeTruthy();
-  const x = cellBox!.x + cellBox!.width / 2;
-  const y = cellBox!.y + cellBox!.height / 2;
-  await page.mouse.move(x, y);
+  const cellBox = await cell.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+  const x = cellBox.x + cellBox.width / 2;
+  const y = cellBox.y + cellBox.height / 2;
+  await cell.hover();
 
   const tooltip = page.locator('div.fixed').filter({ hasText: label! });
-  await expect(tooltip).toBeVisible();
-  await expect.poll(async () => Boolean(await tooltip.boundingBox())).toBe(true);
-  const before = await tooltip.boundingBox();
-  expect(before).toBeTruthy();
+  await expect(tooltip).toBeVisible({ timeout: 10_000 });
+  const before = await tooltip.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y };
+  });
 
   await page.mouse.click(x, y);
-  await expect.poll(async () => Boolean(await tooltip.boundingBox())).toBe(true);
-  const after = await tooltip.boundingBox();
-  expect(after).toBeTruthy();
-  expect(Math.abs(after!.x - before!.x)).toBeLessThan(1);
-  expect(Math.abs(after!.y - before!.y)).toBeLessThan(1);
+  await expect(tooltip).toBeVisible();
+  const after = await tooltip.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y };
+  });
+  expect(Math.abs(after.x - before.x)).toBeLessThan(1);
+  expect(Math.abs(after.y - before.y)).toBeLessThan(1);
 });
 
 test('homepage shell covers the viewport with the document background', async ({ page }) => {
@@ -198,9 +211,9 @@ test('slow navigation keeps the current page visible behind a monotonic rail', a
 
   await page.goto('/');
   await waitForClientHydration(page);
-  await waitForHomeActivity(page);
+  const dashboard = await waitForHomeActivity(page);
 
-  const activity = page.locator('[data-contribution-week-grid]');
+  const activity = dashboard.locator('[data-contribution-week-grid]');
   const feedback = page.locator('[data-navigation-feedback]');
   await expect(activity).toBeVisible();
 
@@ -279,9 +292,9 @@ test('gallery wheel scrolls over the canvas', async ({ page }) => {
 test('homepage scorecard lifts under pointer movement', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'no-preference' });
   await page.goto('/');
-  await waitForHomeActivity(page);
+  const dashboard = await waitForHomeActivity(page);
 
-  const scoreboard = page.locator('[data-activity-scoreboard]');
+  const scoreboard = dashboard.locator('[data-activity-scoreboard]');
   const counter = scoreboard.locator('[data-paper-counter]');
   await expect(scoreboard).toBeVisible();
   await expect(counter).toHaveAttribute('data-reduced-motion', 'false');
@@ -290,8 +303,8 @@ test('homepage scorecard lifts under pointer movement', async ({ page }) => {
     return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
   });
 
-  await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2, { steps: 6 });
-
+  await scoreboard.hover({ force: true });
+  await expect.poll(() => scoreboard.evaluate((element) => element.matches(':hover'))).toBe(true);
   await expect
     .poll(
       () =>
@@ -307,9 +320,9 @@ test('homepage scorecard lifts under pointer movement', async ({ page }) => {
 test('homepage scorecard remains planted with reduced motion', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/');
-  await waitForHomeActivity(page);
+  const dashboard = await waitForHomeActivity(page);
 
-  const scoreboard = page.locator('[data-activity-scoreboard]');
+  const scoreboard = dashboard.locator('[data-activity-scoreboard]');
   const counter = scoreboard.locator('[data-paper-counter]');
   await expect(scoreboard).toBeVisible();
   await expect(counter).toHaveAttribute('data-reduced-motion', 'true');
@@ -318,7 +331,8 @@ test('homepage scorecard remains planted with reduced motion', async ({ page }) 
     return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
   });
 
-  await page.mouse.move(before.x + before.width / 2, before.y + before.height / 2, { steps: 6 });
+  await scoreboard.hover({ force: true });
+  await expect.poll(() => scoreboard.evaluate((element) => element.matches(':hover'))).toBe(true);
   await page.waitForTimeout(500);
   const after = await scoreboard.evaluate((element) => {
     const rect = element.getBoundingClientRect();

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -37,10 +37,12 @@ async function expectWheelScrollsDocument(page: Page, route: string, selector: s
   const response = await page.goto(route);
   expect(response?.ok()).toBe(true);
 
-  await expect(page.locator(selector).first()).toBeVisible({ timeout: 15_000 });
-  await page.evaluate((targetSelector) => {
-    document.querySelector(targetSelector)?.scrollIntoView({ block: 'center' });
-  }, selector);
+  const target =
+    route === '/'
+      ? hydratedHomeDashboard(page).locator(selector)
+      : page.locator(`${selector}:visible`).last();
+  await expect(target).toBeVisible({ timeout: 15_000 });
+  await target.scrollIntoViewIfNeeded();
 
   const scrollState = await page.evaluate(() => {
     const element = document.scrollingElement;
@@ -51,9 +53,13 @@ async function expectWheelScrollsDocument(page: Page, route: string, selector: s
   });
 
   expect(scrollState.max).toBeGreaterThan(0);
-  const box = await page.locator(selector).first().boundingBox();
-  expect(box).toBeTruthy();
-  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  const box = await target.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+  expect(box.width).toBeGreaterThan(0);
+  expect(box.height).toBeGreaterThan(0);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
   await page.mouse.wheel(0, 280);
 
   await expect

--- a/tests/e2e/test-window.d.ts
+++ b/tests/e2e/test-window.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    __advanceActivityClock: (milliseconds: number) => void;
+  }
+}


### PR DESCRIPTION
## Direction

Brings the approved paper-grid and layered counter work onto the current homepage rather than merging the stale stacked branches.

## Current-main preservation

The generated merge tree was inspected directly and keeps the homepage work that landed during this review:

- PaperCreature-based Scraplet;
- rolling-year `1Y` metric semantics;
- current activity refresh timeout and stale-response guards;
- whole-scorecard hover lift and metric movement;
- the mobile “Continue exploring” room shelf;
- current density and responsive layout.

## Counter motion

- replaces the black split-flap leaves with bound paper sheets;
- keeps digits readable from first paint;
- lifts the old sheet, swings the next sheet down in 3D and settles its ink;
- staggers updates right-to-left;
- coordinates the counter body, bindings and contact shadow;
- queues a newer digit value when it arrives during an active page turn;
- respects reduced motion and forced colours.

## Paper grid

Restores the 28px grid at 3.6% warm-ink alpha in light mode and 4.4% pale-lilac alpha in dark mode.

## Self-review corrections

The review went beyond the original visual branch:

- avoided overwriting homepage work from the stale stacked PRs;
- serialized rapid successive digit updates rather than overlapping leaf state;
- stopped superseded shared Motion controls;
- left contact-shadow opacity under theme CSS control, preventing a light-opacity override after dark-mode updates;
- kept current hover transforms on an outer wrapper so they compose with paper-leaf tilt;
- anchored browser interactions to the visible hydrated dashboard during the Suspense handoff;
- replaced brittle transform-string and stale-rectangle assertions with observable position and stable-locator checks;
- added a two-refresh browser regression proving the counter settles on the newest value with one resting face per digit.

## Visual review

Reviewed light and dark mobile/desktop captures in Chromium and WebKit plus the five-stage live refresh sequence:

- paper edges and ink remain legible in both themes;
- the grid stays behind card borders and type;
- digits remain present from initial paint through settling;
- old ink holds through lift/turn and new ink appears during landing;
- the counter stays contained at 390px;
- the final merge tree retains the newer mobile room shelf.

## Validation

[CI run 569](https://github.com/teamleaderleo/scrapbook/actions/runs/30369232814) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- **157 passed, three intentional skips, zero retries**.

Scoreboard appearance and motion evidence: `sha256:dac8bfcf167de0d9cd1389dcdf2f8852a15ff4818a65b327a64ee7d524a67ffd`.
Playwright log: `sha256:cbfbf144ae06cb848e38573d3db10709a33f4174a06e8e95381c198d8172cb5a`.

Ready to merge. Supersedes #445 and #464.