### PR TITLE
Combine quiet lattice geometry with cohesive Generation 3 palettes

### DIFF
--- a/app/sigil-lab/page.tsx
+++ b/app/sigil-lab/page.tsx
@@ -1,4 +1,5 @@
 import { AgentSigilLab } from '@/components/labs/agent-sigil-lab';
+import { Generation3SigilLab } from '@/components/labs/generation-3-sigil-lab';
 import { KumikoSigilLab } from '@/components/labs/kumiko-sigil-lab';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { ArrowLeft } from 'lucide-react';
@@ -37,13 +38,13 @@ export default function AgentSigilLabPage() {
             Back to gallery
           </Link>
           <p className="mt-6 font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Issues #435 and #447 · identity generation reference
+            Issues #435, #443, #447, and #448 · identity generation reference
           </p>
           <h1 className="mt-3 text-balance text-3xl font-semibold tracking-tight sm:text-4xl">
             Generative sigils for agents
           </h1>
           <p className="mx-auto mt-4 max-w-2xl text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
-            The lab compares the current layered identity system with quieter construction-graph experiments. Stable inputs and explicit variants always produce the same SVG; experimental lineages stay here until their full populations are reviewed.
+            The lab compares the current layered identity system with quieter construction graphs, reviewed colour worlds, and their combined Generation 3 population. Stable inputs and explicit variants always produce the same SVG; experimental lineages stay here until their full populations are approved.
           </p>
         </header>
 
@@ -55,12 +56,16 @@ export default function AgentSigilLabPage() {
           <KumikoSigilLab />
         </div>
 
+        <div className="mt-5">
+          <Generation3SigilLab />
+        </div>
+
         <aside className="mx-auto mt-5 max-w-4xl rounded-[1.25rem] border border-border/70 bg-card p-4 text-sm leading-relaxed text-muted-foreground shadow-[0_16px_38px_rgba(35,31,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.24)] sm:p-5">
           <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-foreground">
             Generation contract
           </p>
           <p className="mt-2">
-            The guestbook still uses Generation 2. The Kumiko-informed lattice is a separate Generation 3 experiment with no production integration, and it must pass population-level monochrome, small-size, light/dark, and cross-browser review before becoming selectable.
+            The guestbook still uses Generation 2. Generation 3 geometry, palettes, and the combined renderer remain isolated experiments. They must pass population-level monochrome, colour-density, compact-size, light/dark, and cross-browser review before becoming selectable.
           </p>
         </aside>
       </main>

--- a/components/agent-generation-3-sigil.tsx
+++ b/components/agent-generation-3-sigil.tsx
@@ -1,0 +1,153 @@
+import {
+  createAgentGeneration3SigilRecipe,
+  type AgentGeneration3SigilInput,
+  type AgentGeneration3SigilRecipe,
+  type AgentGeneration3Surface,
+} from '@/lib/agent-generation-3-sigils';
+import type { Generation3PaletteRole } from '@/lib/agent-sigil-generation-3-palettes';
+import type { CSSProperties } from 'react';
+
+export type AgentGeneration3SigilProps = AgentGeneration3SigilInput & {
+  recipe?: AgentGeneration3SigilRecipe;
+  size?: number;
+  className?: string;
+  label?: string | null;
+  surface?: AgentGeneration3Surface | 'auto';
+  compact?: boolean;
+};
+
+type PaletteVariableStyle = CSSProperties & Record<`--g3-${string}`, string>;
+
+const automaticSurfaceClass = [
+  '[--g3-dominant:var(--g3-dominant-light)]',
+  '[--g3-support:var(--g3-support-light)]',
+  '[--g3-highlight:var(--g3-highlight-light)]',
+  '[--g3-neutral:var(--g3-neutral-light)]',
+  'dark:[--g3-dominant:var(--g3-dominant-dark)]',
+  'dark:[--g3-support:var(--g3-support-dark)]',
+  'dark:[--g3-highlight:var(--g3-highlight-dark)]',
+  'dark:[--g3-neutral:var(--g3-neutral-dark)]',
+].join(' ');
+
+function paletteStyle(
+  recipe: AgentGeneration3SigilRecipe,
+  surface: AgentGeneration3Surface | 'auto',
+): PaletteVariableStyle {
+  if (surface !== 'auto') {
+    const roles = recipe.palette[surface];
+    return {
+      '--g3-dominant': roles.dominant,
+      '--g3-support': roles.support,
+      '--g3-highlight': roles.highlight,
+      '--g3-neutral': roles.neutral,
+    };
+  }
+
+  return {
+    '--g3-dominant': recipe.palette.light.dominant,
+    '--g3-support': recipe.palette.light.support,
+    '--g3-highlight': recipe.palette.light.highlight,
+    '--g3-neutral': recipe.palette.light.neutral,
+    '--g3-dominant-light': recipe.palette.light.dominant,
+    '--g3-support-light': recipe.palette.light.support,
+    '--g3-highlight-light': recipe.palette.light.highlight,
+    '--g3-neutral-light': recipe.palette.light.neutral,
+    '--g3-dominant-dark': recipe.palette.dark.dominant,
+    '--g3-support-dark': recipe.palette.dark.support,
+    '--g3-highlight-dark': recipe.palette.dark.highlight,
+    '--g3-neutral-dark': recipe.palette.dark.neutral,
+  };
+}
+
+function roleForStrut(
+  recipe: AgentGeneration3SigilRecipe,
+  index: number,
+): Generation3PaletteRole {
+  const strut = recipe.geometry.struts[index]!;
+  if (index === recipe.accentStrutIndex || strut.role === 'accent') return 'highlight';
+  return strut.role === 'primary' ? 'dominant' : 'support';
+}
+
+export default function AgentGeneration3Sigil({
+  recipe: providedRecipe,
+  size = 48,
+  className,
+  label,
+  surface = 'auto',
+  compact: compactOverride,
+  ...input
+}: AgentGeneration3SigilProps) {
+  const recipe = providedRecipe ?? createAgentGeneration3SigilRecipe(input);
+  const compact = compactOverride ?? size <= 24;
+  const accessibleLabel =
+    label === undefined
+      ? `${recipe.geometry.identity.designation} Generation 3 ${recipe.geometry.family} sigil ${recipe.fingerprint}`
+      : label;
+  const surfaceClass = surface === 'auto' ? automaticSurfaceClass : '';
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      className={`${surfaceClass} ${className ?? ''}`.trim()}
+      style={paletteStyle(recipe, surface)}
+      role={accessibleLabel ? 'img' : undefined}
+      aria-label={accessibleLabel ?? undefined}
+      aria-hidden={accessibleLabel === null ? true : undefined}
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      data-agent-generation-3={recipe.fingerprint}
+      data-generation-3-family={recipe.geometry.family}
+      data-generation-3-graph={recipe.geometry.graphFingerprint}
+      data-generation-3-geometry={recipe.layerFingerprints.geometry}
+      data-generation-3-accents={recipe.layerFingerprints.accents}
+      data-generation-3-palette={recipe.layerFingerprints.palette}
+      data-generation-3-palette-family={recipe.palette.familyId}
+      data-generation-3-palette-mode={recipe.palette.mode}
+      data-generation-3-palette-variant={recipe.palette.paletteVariant}
+      data-generation-3-compact={compact ? 'true' : 'false'}
+    >
+      {accessibleLabel ? <title>{accessibleLabel}</title> : null}
+      {recipe.geometry.struts.map((strut, index) => {
+        const role = roleForStrut(recipe, index);
+        if (compact && role === 'highlight') return null;
+        const from = recipe.geometry.nodes[strut.from]!;
+        const to = recipe.geometry.nodes[strut.to]!;
+        return (
+          <line
+            key={`strut-${index}`}
+            x1={from.x}
+            y1={from.y}
+            x2={to.x}
+            y2={to.y}
+            stroke={`var(--g3-${role})`}
+            strokeOpacity={strut.opacity}
+            strokeWidth={strut.width}
+            data-generation-3-role={role}
+          />
+        );
+      })}
+      {recipe.geometry.joints.map((joint, index) => {
+        const accent = index === recipe.accentJointIndex;
+        if (compact && accent) return null;
+        const point = recipe.geometry.nodes[joint.node]!;
+        const role: Generation3PaletteRole = accent ? 'highlight' : 'support';
+        return (
+          <circle
+            key={`joint-${index}`}
+            cx={point.x}
+            cy={point.y}
+            r={joint.radius}
+            fill={`var(--g3-${role})`}
+            fillOpacity={joint.opacity}
+            stroke="var(--g3-neutral)"
+            strokeWidth={0.65}
+            data-generation-3-role={role}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/components/labs/generation-3-sigil-lab.tsx
+++ b/components/labs/generation-3-sigil-lab.tsx
@@ -1,0 +1,360 @@
+import AgentGeneration3Sigil from '@/components/agent-generation-3-sigil';
+import {
+  createAgentGeneration3SigilRecipe,
+  createDistinctAgentGeneration3Population,
+  type AgentGeneration3SigilInput,
+} from '@/lib/agent-generation-3-sigils';
+import { agentKumikoFamilies } from '@/lib/agent-kumiko-sigils';
+
+const generation3Identities: AgentGeneration3SigilInput[] = [
+  {
+    scope: 'openai/codex',
+    designation: 'Testing review',
+    description: 'Found three actionable test findings in the current patch.',
+  },
+  {
+    scope: 'openai/codex',
+    designation: 'Change size',
+    description: 'Split a large patch below the repository review threshold.',
+  },
+  {
+    scope: 'openai/codex',
+    designation: 'Context review',
+    description: 'Checked the model-visible context for missing constraints.',
+  },
+  {
+    scope: 'openai/codex',
+    designation: 'Breaking changes',
+    description: 'Reviewed the public surface for compatibility changes.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing audit',
+    description: 'Verified the current browser and unit coverage before handoff.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Breaking Changes final',
+    description: 'Closed the last material documentation correction.',
+  },
+  {
+    scope: 'teamleaderleo/stensibly',
+    designation: 'Context audit',
+    description: 'Checked the active coordination lanes and their handoffs.',
+  },
+  {
+    scope: 'teamleaderleo/proofwake',
+    designation: 'Size review',
+    description: 'Measured a focused patch against the project review boundary.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 1 coordination',
+    description: 'Integrated clean work and kept acceptance-blocked work isolated.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 2 behaviour review',
+    description: 'Checked input behaviour and shortcut ownership.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 3 regression audit',
+    description: 'Reviewed the time control and browser regression surface.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 4 visual review',
+    description: 'Compared the shared visual language across current surfaces.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Agent 5 integration',
+    description: 'Reconciled the compact homepage and its browser evidence.',
+  },
+  {
+    scope: 'teamleaderleo/stensibly',
+    designation: 'Thread Compass',
+    description: 'Mapped four moving lanes and documented the next handoff.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Fifth Drawer',
+    description: 'Audited the crowded workbench and divided the next pass.',
+  },
+  {
+    scope: 'teamleaderleo/gh-tidy-branches',
+    designation: 'Release Raccoon',
+    description: 'Found the release metadata trap and verified installation.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Codex Routekeeper',
+    description: 'Kept old pages visible while routes warmed.',
+  },
+  {
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Mothbit Gallery Room',
+    description: 'Built the first draggable gallery scene without trapping scroll.',
+  },
+];
+
+const populationInputs = generation3Identities.map((identity, index) => ({
+  ...identity,
+  family: agentKumikoFamilies[index % agentKumikoFamilies.length],
+  complexity: 'quiet' as const,
+}));
+
+const populationRecipes = createDistinctAgentGeneration3Population(populationInputs, {
+  minimumOccupancyDistance: 8,
+});
+
+const densityIdentities: Array<AgentGeneration3SigilInput & { label: string }> = [
+  {
+    label: 'Testing review',
+    scope: 'openai/codex',
+    designation: 'Testing review',
+    description: 'Found three actionable test findings.',
+    family: 'triangular-brace',
+    complexity: 'quiet',
+  },
+  {
+    label: 'Context audit',
+    scope: 'teamleaderleo/stensibly',
+    designation: 'Context audit',
+    description: 'Checked the current coordination handoff.',
+    family: 'hex-cell',
+    complexity: 'quiet',
+  },
+  {
+    label: 'Release Raccoon',
+    scope: 'teamleaderleo/gh-tidy-branches',
+    designation: 'Release Raccoon',
+    description: 'Verified the release metadata path.',
+    family: 'diamond-weave',
+    complexity: 'quiet',
+  },
+  {
+    label: 'Thread Compass',
+    scope: 'teamleaderleo/stensibly',
+    designation: 'Thread Compass',
+    description: 'Mapped the next handoff.',
+    family: 'nested-joint',
+    complexity: 'quiet',
+  },
+];
+
+const descriptionExamples: Array<AgentGeneration3SigilInput & { label: string }> = [
+  {
+    label: 'Baseline',
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing review',
+    description: 'Found three actionable test findings.',
+    family: 'diamond-weave',
+    paletteMode: 'tri-colour',
+    complexity: 'quiet',
+  },
+  {
+    label: 'Assignment changed',
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing review',
+    description: 'Reviewed release documentation and compatibility notes.',
+    family: 'diamond-weave',
+    paletteMode: 'tri-colour',
+    complexity: 'quiet',
+  },
+  {
+    label: 'No assignment accent',
+    scope: 'teamleaderleo/scrapbook',
+    designation: 'Testing review',
+    family: 'diamond-weave',
+    paletteMode: 'tri-colour',
+    complexity: 'quiet',
+  },
+];
+
+export function Generation3SigilLab() {
+  return (
+    <div className="space-y-5" data-generation-3-combined-lab>
+      <section className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 shadow-[0_18px_42px_rgba(28,26,24,0.08)] dark:shadow-[0_18px_42px_rgba(0,0,0,0.24)] sm:p-5">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Issue #443 · combined Generation 3 experiment
+            </p>
+            <h2 className="mt-1 text-xl font-semibold tracking-tight">
+              Quiet lattices with cohesive colour roles
+            </h2>
+          </div>
+          <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+            Geometry and palette remain independent deterministic recipes. The combined mark
+            assigns one job to each colour role and keeps description-derived highlights
+            optional at compact sizes.
+          </p>
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {[
+            ['Dominant', 'Primary struts'],
+            ['Support', 'Secondary relations and normal joints'],
+            ['Highlight', 'At most one work-note event'],
+            ['Neutral', 'Joint outline and contrast'],
+          ].map(([role, use]) => (
+            <div key={role} className="rounded-xl border border-border/65 bg-background p-3">
+              <p className="font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                {role}
+              </p>
+              <p className="mt-1 text-sm">{use}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section
+        data-generation-3-population
+        className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5"
+      >
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Labels-hidden combined population
+            </p>
+            <h2 className="mt-1 text-lg font-semibold tracking-tight">
+              Colour enriches the graph without rebuilding it
+            </h2>
+          </div>
+          <p className="max-w-xl text-sm leading-relaxed text-muted-foreground">
+            Eighteen identities use quiet geometry, graph-distance selection, canonical
+            palette variants, and automatic light/dark role mappings.
+          </p>
+        </div>
+
+        <div className="mt-4 grid grid-cols-3 gap-2 sm:grid-cols-6 lg:grid-cols-9">
+          {populationRecipes.map((recipe, index) => (
+            <div
+              key={`${recipe.geometry.identity.scope}:${recipe.geometry.identity.designation}`}
+              data-generation-3-population-card
+              data-generation-3-population-graph={recipe.geometry.graphFingerprint}
+              data-generation-3-population-palette={recipe.palette.fingerprint}
+              className="grid aspect-square place-items-center rounded-xl border border-border/65 bg-background p-2"
+            >
+              <AgentGeneration3Sigil
+                {...populationInputs[index]!}
+                recipe={recipe}
+                size={58}
+                label={null}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+          Same graph · three colour densities
+        </p>
+        <h2 className="mt-1 text-lg font-semibold tracking-tight">
+          Monochrome, duotone, and tri-colour remain recognisably related
+        </h2>
+        <div className="mt-4 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-4">
+          {densityIdentities.map(({ label, ...input }) => (
+            <article
+              key={label}
+              data-generation-3-density-card
+              className="rounded-[1.1rem] border border-border/70 bg-background p-3"
+            >
+              <div className="grid grid-cols-3 gap-2">
+                <div className="grid place-items-center gap-1.5">
+                  <AgentGeneration3Sigil
+                    {...input}
+                    paletteMode="tri-colour"
+                    surface="monochrome"
+                    size={54}
+                  />
+                  <span className="font-mono text-[8px] uppercase tracking-[0.08em] text-muted-foreground">
+                    mono
+                  </span>
+                </div>
+                <div className="grid place-items-center gap-1.5">
+                  <AgentGeneration3Sigil {...input} paletteMode="duotone" size={54} />
+                  <span className="font-mono text-[8px] uppercase tracking-[0.08em] text-muted-foreground">
+                    duo
+                  </span>
+                </div>
+                <div className="grid place-items-center gap-1.5">
+                  <AgentGeneration3Sigil {...input} paletteMode="tri-colour" size={54} />
+                  <span className="font-mono text-[8px] uppercase tracking-[0.08em] text-muted-foreground">
+                    tri
+                  </span>
+                </div>
+              </div>
+              <p className="mt-2 truncate text-center text-xs font-medium">{label}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid min-w-0 gap-5 lg:grid-cols-2">
+        <div className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5">
+          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+            Description isolation
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight">
+            Work notes change highlights, not graph or colour world
+          </h2>
+          <div className="mt-4 grid grid-cols-3 gap-2.5">
+            {descriptionExamples.map(({ label, ...input }) => {
+              const recipe = createAgentGeneration3SigilRecipe(input);
+              return (
+                <div
+                  key={label}
+                  data-generation-3-description-example
+                  className="grid place-items-center rounded-xl border border-border/65 bg-background p-3 text-center"
+                >
+                  <AgentGeneration3Sigil {...input} recipe={recipe} size={68} />
+                  <span className="mt-2 text-xs font-medium">{label}</span>
+                  <span className="mt-1 font-mono text-[8px] uppercase tracking-[0.08em] text-muted-foreground">
+                    {recipe.layerFingerprints.geometry.slice(0, 4)} ·{' '}
+                    {recipe.layerFingerprints.palette.slice(0, 4)} ·{' '}
+                    {recipe.layerFingerprints.accents.slice(0, 4)}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <div
+          data-generation-3-small-sizes
+          className="rounded-[1.4rem] border border-border/70 bg-card/85 p-4 sm:p-5"
+        >
+          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+            Compact role reduction
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight">
+            The highlight disappears before the identity does
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            At 16 and 24 px, description-derived highlights are omitted. Dominant and support
+            relations retain the same graph, palette fingerprint, and overall identity.
+          </p>
+          <div className="mt-5 flex items-end justify-center gap-5 rounded-xl border border-border/65 bg-background px-4 py-5">
+            {[16, 24, 32, 48, 72].map((size) => (
+              <div key={size} className="grid place-items-center gap-1">
+                <AgentGeneration3Sigil
+                  scope="teamleaderleo/scrapbook"
+                  designation="Compact review"
+                  description="Highlight one reviewed joint."
+                  family="star-joint"
+                  paletteMode="tri-colour"
+                  size={size}
+                />
+                <span className="font-mono text-[8px] text-muted-foreground">{size}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/lib/agent-generation-3-sigils.test.ts
+++ b/lib/agent-generation-3-sigils.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAgentGeneration3SigilRecipe,
+  createDistinctAgentGeneration3Population,
+  generateAgentGeneration3Sigil,
+  renderAgentGeneration3SigilSvg,
+} from './agent-generation-3-sigils';
+import { agentKumikoFamilies, agentKumikoOccupancyDistance } from './agent-kumiko-sigils';
+
+const baseIdentity = {
+  scope: 'teamleaderleo/scrapbook',
+  designation: 'Testing review',
+  description: 'Found three actionable test findings.',
+  family: 'diamond-weave' as const,
+  complexity: 'quiet' as const,
+  paletteMode: 'tri-colour' as const,
+};
+
+describe('combined Generation 3 agent sigils', () => {
+  it('repeats the exact combined recipe for the same inputs', () => {
+    expect(createAgentGeneration3SigilRecipe(baseIdentity)).toEqual(
+      createAgentGeneration3SigilRecipe(baseIdentity),
+    );
+  });
+
+  it('keeps description edits inside the accent layer', () => {
+    const original = createAgentGeneration3SigilRecipe(baseIdentity);
+    const reassigned = createAgentGeneration3SigilRecipe({
+      ...baseIdentity,
+      description: 'Reviewed release documentation and compatibility notes.',
+    });
+
+    expect(reassigned.geometry.graphFingerprint).toBe(original.geometry.graphFingerprint);
+    expect(reassigned.geometry.occupancyDescriptor).toBe(
+      original.geometry.occupancyDescriptor,
+    );
+    expect(reassigned.palette).toEqual(original.palette);
+    expect(reassigned.layerFingerprints.geometry).toBe(
+      original.layerFingerprints.geometry,
+    );
+    expect(reassigned.layerFingerprints.palette).toBe(
+      original.layerFingerprints.palette,
+    );
+    expect(reassigned.layerFingerprints.accents).not.toBe(
+      original.layerFingerprints.accents,
+    );
+    expect(reassigned.fingerprint).not.toBe(original.fingerprint);
+  });
+
+  it('changes colour density without changing the construction graph', () => {
+    const duotone = createAgentGeneration3SigilRecipe({
+      ...baseIdentity,
+      paletteMode: 'duotone',
+    });
+    const triColour = createAgentGeneration3SigilRecipe(baseIdentity);
+
+    expect(duotone.geometry.graphFingerprint).toBe(
+      triColour.geometry.graphFingerprint,
+    );
+    expect(duotone.geometry.occupancyDescriptor).toBe(
+      triColour.geometry.occupancyDescriptor,
+    );
+    expect(duotone.layerFingerprints.palette).not.toBe(
+      triColour.layerFingerprints.palette,
+    );
+  });
+
+  it('keeps wrapped palette variants canonical in the combined identity', () => {
+    const first = createAgentGeneration3SigilRecipe({
+      ...baseIdentity,
+      paletteVariant: 0,
+    });
+    const wrapped = createAgentGeneration3SigilRecipe({
+      ...baseIdentity,
+      paletteVariant: 2,
+    });
+
+    expect(wrapped.palette).toEqual(first.palette);
+    expect(wrapped.palette.paletteVariant).toBe(0);
+    expect(wrapped.fingerprint).toBe(first.fingerprint);
+  });
+
+  it('builds a deterministic graph-separated population', () => {
+    const inputs = Array.from({ length: 18 }, (_, index) => ({
+      scope: `owner/project-${index % 7}`,
+      designation: `Agent designation ${index}`,
+      description: `Assignment ${index}`,
+      family: agentKumikoFamilies[index % agentKumikoFamilies.length],
+      complexity: 'quiet' as const,
+    }));
+    const first = createDistinctAgentGeneration3Population(inputs, {
+      minimumOccupancyDistance: 8,
+    });
+    const second = createDistinctAgentGeneration3Population(inputs, {
+      minimumOccupancyDistance: 8,
+    });
+
+    expect(first).toEqual(second);
+    expect(new Set(first.map((recipe) => recipe.geometry.graphFingerprint)).size).toBe(
+      first.length,
+    );
+
+    for (let left = 0; left < first.length; left += 1) {
+      for (let right = left + 1; right < first.length; right += 1) {
+        expect(
+          agentKumikoOccupancyDistance(
+            first[left]!.geometry.occupancyDescriptor,
+            first[right]!.geometry.occupancyDescriptor,
+          ),
+        ).toBeGreaterThanOrEqual(8);
+      }
+    }
+  });
+
+  it('drops the highlight role in compact SVG without changing identity', () => {
+    const recipe = createAgentGeneration3SigilRecipe(baseIdentity);
+    const full = renderAgentGeneration3SigilSvg(recipe, {
+      size: 48,
+      surface: 'dark',
+    });
+    const compact = renderAgentGeneration3SigilSvg(recipe, {
+      size: 24,
+      surface: 'dark',
+    });
+
+    expect(full).toContain('data-generation-3-role="highlight"');
+    expect(compact).not.toContain('data-generation-3-role="highlight"');
+    expect(compact).toContain('data-generation-3-role="dominant"');
+    expect(compact).toContain('data-generation-3-role="support"');
+    expect(createAgentGeneration3SigilRecipe(baseIdentity).fingerprint).toBe(
+      recipe.fingerprint,
+    );
+  });
+
+  it('renders bounded light, dark, and monochrome portable SVG', () => {
+    for (let index = 0; index < 96; index += 1) {
+      const input = {
+        scope: `owner/project-${index % 11}`,
+        designation: `Agent designation ${index}`,
+        description: `Assignment description ${index % 13}`,
+        variant: index % 7,
+        paletteVariant: index % 4,
+        paletteMode:
+          index % 3 === 0
+            ? ('duotone' as const)
+            : index % 2 === 0
+              ? ('tri-colour' as const)
+              : ('auto' as const),
+        family: agentKumikoFamilies[index % agentKumikoFamilies.length],
+        complexity: 'quiet' as const,
+      };
+      const generated = generateAgentGeneration3Sigil(input, {
+        size: index % 2 === 0 ? 24 : 72,
+        surface: index % 3 === 0 ? 'monochrome' : index % 2 === 0 ? 'dark' : 'light',
+      });
+
+      expect(generated.recipe.geometry.struts.length).toBeGreaterThanOrEqual(5);
+      expect(generated.svg.length).toBeLessThan(20_000);
+      expect(generated.svg).not.toContain('<script');
+      expect(generated.dataUri.startsWith('data:image/svg+xml,')).toBe(true);
+      expect(generated.accessibleLabel).toContain('Generation 3');
+    }
+  });
+});

--- a/lib/agent-generation-3-sigils.ts
+++ b/lib/agent-generation-3-sigils.ts
@@ -1,0 +1,242 @@
+import {
+  createAgentKumikoSigilRecipe,
+  createDistinctAgentKumikoPopulation,
+  type AgentKumikoSigilInput,
+  type AgentKumikoSigilRecipe,
+} from './agent-kumiko-sigils';
+import {
+  createGeneration3PaletteRecipe,
+  type Generation3PaletteRecipe,
+  type Generation3PaletteSelectionMode,
+  type Generation3PaletteRoles,
+} from './agent-sigil-generation-3-palettes';
+
+export const AGENT_GENERATION_3_COMBINED_RENDERER_VERSION = 1 as const;
+
+export type AgentGeneration3Surface = 'light' | 'dark' | 'monochrome';
+
+export type AgentGeneration3SigilInput = Omit<AgentKumikoSigilInput, 'palette'> & {
+  paletteMode?: Generation3PaletteSelectionMode;
+  paletteVariant?: number;
+};
+
+export type AgentGeneration3SigilRecipe = {
+  rendererVersion: typeof AGENT_GENERATION_3_COMBINED_RENDERER_VERSION;
+  generation: 3;
+  geometry: AgentKumikoSigilRecipe;
+  palette: Generation3PaletteRecipe;
+  accentStrutIndex: number;
+  accentJointIndex: number;
+  fingerprint: string;
+  layerFingerprints: {
+    geometry: string;
+    accents: string;
+    palette: string;
+  };
+};
+
+export type GeneratedAgentGeneration3Sigil = {
+  recipe: AgentGeneration3SigilRecipe;
+  svg: string;
+  dataUri: string;
+  accessibleLabel: string;
+};
+
+function hashString(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function fingerprint(value: string) {
+  return hashString(value).toString(16).padStart(8, '0');
+}
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function geometryInput(input: AgentGeneration3SigilInput): AgentKumikoSigilInput {
+  return {
+    scope: input.scope,
+    designation: input.designation,
+    description: input.description,
+    variant: input.variant,
+    complexity: input.complexity ?? 'quiet',
+    family: input.family,
+    palette: 'mono',
+  };
+}
+
+function baselineGeometryInput(input: AgentGeneration3SigilInput): AgentKumikoSigilInput {
+  return {
+    ...geometryInput(input),
+    description: undefined,
+  };
+}
+
+function locateAccentJoint(
+  geometry: AgentKumikoSigilRecipe,
+  baseline: AgentKumikoSigilRecipe,
+) {
+  if (!geometry.identity.description) return -1;
+  return geometry.joints.findIndex((joint, index) => {
+    const comparison = baseline.joints[index];
+    return (
+      comparison &&
+      (comparison.radius !== joint.radius || comparison.opacity !== joint.opacity)
+    );
+  });
+}
+
+function createRecipeFromGeometry(
+  input: AgentGeneration3SigilInput,
+  geometry: AgentKumikoSigilRecipe,
+): AgentGeneration3SigilRecipe {
+  const baseline = createAgentKumikoSigilRecipe({
+    ...baselineGeometryInput(input),
+    variant: geometry.variant,
+    family: geometry.family,
+  });
+  const palette = createGeneration3PaletteRecipe({
+    scope: geometry.identity.scope,
+    designation: geometry.identity.designation,
+    paletteMode: input.paletteMode,
+    paletteVariant: input.paletteVariant,
+  });
+  const accentStrutIndex = geometry.struts.findIndex((strut) => strut.role === 'accent');
+  const accentJointIndex = locateAccentJoint(geometry, baseline);
+  const combinedFingerprint = fingerprint(
+    [
+      'agent-generation-3',
+      AGENT_GENERATION_3_COMBINED_RENDERER_VERSION,
+      geometry.graphFingerprint,
+      geometry.layerFingerprints.accents,
+      palette.fingerprint,
+    ].join(':'),
+  );
+
+  return {
+    rendererVersion: AGENT_GENERATION_3_COMBINED_RENDERER_VERSION,
+    generation: 3,
+    geometry,
+    palette,
+    accentStrutIndex,
+    accentJointIndex,
+    fingerprint: combinedFingerprint,
+    layerFingerprints: {
+      geometry: geometry.graphFingerprint,
+      accents: geometry.layerFingerprints.accents,
+      palette: palette.fingerprint,
+    },
+  };
+}
+
+export function createAgentGeneration3SigilRecipe(
+  input: AgentGeneration3SigilInput,
+): AgentGeneration3SigilRecipe {
+  return createRecipeFromGeometry(
+    input,
+    createAgentKumikoSigilRecipe(geometryInput(input)),
+  );
+}
+
+export function createDistinctAgentGeneration3Population(
+  inputs: readonly AgentGeneration3SigilInput[],
+  options: { minimumOccupancyDistance?: number; maximumVariantAttempts?: number } = {},
+) {
+  const geometries = createDistinctAgentKumikoPopulation(
+    inputs.map(geometryInput),
+    options,
+  );
+
+  return geometries.map((geometry, index) =>
+    createRecipeFromGeometry(
+      {
+        ...inputs[index]!,
+        variant: geometry.variant,
+        family: geometry.family,
+      },
+      geometry,
+    ),
+  );
+}
+
+function roleForStrut(
+  recipe: AgentGeneration3SigilRecipe,
+  index: number,
+): keyof Generation3PaletteRoles {
+  const strut = recipe.geometry.struts[index]!;
+  if (index === recipe.accentStrutIndex || strut.role === 'accent') return 'highlight';
+  return strut.role === 'primary' ? 'dominant' : 'support';
+}
+
+export function renderAgentGeneration3SigilSvg(
+  recipe: AgentGeneration3SigilRecipe,
+  options: {
+    size?: number;
+    surface?: AgentGeneration3Surface;
+    compact?: boolean;
+    label?: string;
+  } = {},
+) {
+  const size = Math.max(1, Math.min(2048, Math.floor(options.size ?? 100)));
+  const surface = options.surface ?? 'light';
+  const compact = options.compact ?? size <= 24;
+  const roles = recipe.palette[surface];
+  const label =
+    options.label ??
+    `${recipe.geometry.identity.designation} Generation 3 ${recipe.geometry.family} sigil ${recipe.fingerprint}`;
+
+  const struts = recipe.geometry.struts
+    .map((strut, index) => {
+      const role = roleForStrut(recipe, index);
+      if (compact && role === 'highlight') return '';
+      const from = recipe.geometry.nodes[strut.from]!;
+      const to = recipe.geometry.nodes[strut.to]!;
+      return `<line x1="${from.x}" y1="${from.y}" x2="${to.x}" y2="${to.y}" stroke="${roles[role]}" stroke-opacity="${strut.opacity}" stroke-width="${strut.width}" data-generation-3-role="${role}"/>`;
+    })
+    .join('');
+
+  const joints = recipe.geometry.joints
+    .map((joint, index) => {
+      const accent = index === recipe.accentJointIndex;
+      if (compact && accent) return '';
+      const point = recipe.geometry.nodes[joint.node]!;
+      const role = accent ? 'highlight' : 'support';
+      return `<circle cx="${point.x}" cy="${point.y}" r="${joint.radius}" fill="${roles[role]}" fill-opacity="${joint.opacity}" stroke="${roles.neutral}" stroke-width="0.65" data-generation-3-role="${role}"/>`;
+    })
+    .join('');
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 100 100" role="img" aria-label="${escapeXml(label)}" fill="none" stroke-linecap="round" stroke-linejoin="round">${struts}${joints}</svg>`;
+}
+
+export function generateAgentGeneration3Sigil(
+  input: AgentGeneration3SigilInput,
+  options: {
+    size?: number;
+    surface?: AgentGeneration3Surface;
+    compact?: boolean;
+  } = {},
+): GeneratedAgentGeneration3Sigil {
+  const recipe = createAgentGeneration3SigilRecipe(input);
+  const accessibleLabel = `${recipe.geometry.identity.designation} Generation 3 ${recipe.geometry.family} sigil ${recipe.fingerprint}`;
+  const svg = renderAgentGeneration3SigilSvg(recipe, {
+    ...options,
+    label: accessibleLabel,
+  });
+  return {
+    recipe,
+    svg,
+    dataUri: `data:image/svg+xml,${encodeURIComponent(svg)}`,
+    accessibleLabel,
+  };
+}

--- a/tests/e2e/sigil-lab.spec.ts
+++ b/tests/e2e/sigil-lab.spec.ts
@@ -20,13 +20,13 @@ for (const variant of variants) {
   test(`sigil lab exposes layered generations and visual evidence in ${variant.theme} at ${variant.width}x${variant.height}`, async ({
     page,
   }, testInfo) => {
-    test.setTimeout(90_000);
+    test.setTimeout(120_000);
     await page.emulateMedia({ colorScheme: variant.theme });
     await page.setViewportSize({ width: variant.width, height: variant.height });
 
     const response = await page.goto('/sigil-lab', {
       waitUntil: 'domcontentloaded',
-      timeout: 60_000,
+      timeout: 90_000,
     });
     expect(response?.ok()).toBe(true);
     await expect(page.getByRole('heading', { name: 'Generative sigils for agents' })).toBeVisible();
@@ -35,6 +35,9 @@ for (const variant of variants) {
     ).toBeVisible();
     await expect(
       page.getByRole('heading', { name: 'Reviewed colour worlds before production geometry' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Quiet lattices with cohesive colour roles' }),
     ).toBeVisible();
 
     const cards = page.locator('[data-sigil-card]');
@@ -74,6 +77,7 @@ for (const variant of variants) {
     await expect(page.locator('[data-sigil-generation-example]')).toHaveCount(2);
     await expect(page.locator('[data-agent-sigil]')).toHaveCount(44);
     await expect(page.locator('[data-agent-kumiko]')).toHaveCount(41);
+    await expect(page.locator('[data-agent-generation-3]')).toHaveCount(38);
     await expectNoHorizontalOverflow(page);
 
     await page.screenshot({
@@ -81,7 +85,7 @@ for (const variant of variants) {
         `sigil-lab-${variant.theme}-${variant.width}x${variant.height}.png`,
       ),
       fullPage: true,
-      timeout: 60_000,
+      timeout: 90_000,
     });
   });
 }
@@ -170,7 +174,51 @@ test('Kumiko description edits change accents without changing the graph', async
   await expect(page.locator('[data-kumiko-debug-node]')).not.toHaveCount(0);
 });
 
-test('small layered and lattice sigils remain measurable and accessible', async ({ page }) => {
+test('combined Generation 3 population separates geometry, palette, and accents', async ({ page }) => {
+  await page.goto('/sigil-lab');
+
+  const population = page.locator('[data-generation-3-population-card]');
+  await expect(population).toHaveCount(18);
+  const populationMetadata = await population.evaluateAll((elements) =>
+    elements.map((element) => ({
+      graph: element.getAttribute('data-generation-3-population-graph'),
+      palette: element.getAttribute('data-generation-3-population-palette'),
+    })),
+  );
+  expect(populationMetadata.every((item) => item.graph && item.palette)).toBe(true);
+  expect(new Set(populationMetadata.map((item) => item.graph)).size).toBe(
+    populationMetadata.length,
+  );
+
+  const densityCards = page.locator('[data-generation-3-density-card]');
+  await expect(densityCards).toHaveCount(4);
+  for (const card of await densityCards.all()) {
+    const graphs = await card.locator('[data-agent-generation-3]').evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute('data-generation-3-graph')),
+    );
+    expect(graphs).toHaveLength(3);
+    expect(new Set(graphs).size).toBe(1);
+  }
+
+  const descriptions = page.locator(
+    '[data-generation-3-description-example] [data-agent-generation-3]',
+  );
+  await expect(descriptions).toHaveCount(3);
+  const layers = await descriptions.evaluateAll((elements) =>
+    elements.map((element) => ({
+      graph: element.getAttribute('data-generation-3-geometry'),
+      palette: element.getAttribute('data-generation-3-palette'),
+      accents: element.getAttribute('data-generation-3-accents'),
+    })),
+  );
+  expect(new Set(layers.map((layer) => layer.graph)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.palette)).size).toBe(1);
+  expect(new Set(layers.map((layer) => layer.accents)).size).toBe(3);
+});
+
+test('small layered, lattice, and combined sigils remain measurable and accessible', async ({
+  page,
+}) => {
   await page.goto('/sigil-lab');
 
   const layered = page.locator('[data-sigil-small-sizes] [data-agent-sigil]');
@@ -198,4 +246,34 @@ test('small layered and lattice sigils remain measurable and accessible', async 
   expect(kumikoSizes.map((size) => Math.round(size.width))).toEqual([16, 24, 32, 48, 72]);
   expect(kumikoSizes.every((size) => size.width === size.height)).toBe(true);
   expect(kumikoSizes.every((size) => size.label?.includes('Kumiko-informed'))).toBe(true);
+
+  const combined = page.locator(
+    '[data-generation-3-small-sizes] [data-agent-generation-3]',
+  );
+  await expect(combined).toHaveCount(5);
+  const combinedSizes = await combined.evaluateAll((elements) =>
+    elements.map((element) => {
+      const box = element.getBoundingClientRect();
+      return {
+        width: box.width,
+        height: box.height,
+        label: element.getAttribute('aria-label'),
+        compact: element.getAttribute('data-generation-3-compact'),
+        highlights: element.querySelectorAll('[data-generation-3-role="highlight"]').length,
+      };
+    }),
+  );
+
+  expect(combinedSizes.map((size) => Math.round(size.width))).toEqual([16, 24, 32, 48, 72]);
+  expect(combinedSizes.every((size) => size.width === size.height)).toBe(true);
+  expect(combinedSizes.every((size) => size.label?.includes('Generation 3'))).toBe(true);
+  expect(combinedSizes.map((size) => size.compact)).toEqual([
+    'true',
+    'true',
+    'false',
+    'false',
+    'false',
+  ]);
+  expect(combinedSizes.slice(0, 2).every((size) => size.highlights === 0)).toBe(true);
+  expect(combinedSizes.slice(2).every((size) => size.highlights > 0)).toBe(true);
 });


### PR DESCRIPTION
## Direction

Compose the merged Kumiko-informed geometry foundation (#461) with the merged semantic palette foundation (#466) inside the isolated sigil lab. Generation 1, Generation 2, and the production guestbook remain unchanged.

## Recipe composition

The combined identity preserves two independent canonical recipes:

```text
scope + designation + geometry variant -> construction graph
scope + designation + palette mode + palette variant -> colour world
description -> optional existing strut or joint highlight
```

The combined fingerprint represents the resolved geometry, accent layer, and palette. Palette changes do not rebuild the graph; description changes do not rebuild or recolour it.

## Semantic rendering

- `dominant` -> primary struts;
- `support` -> secondary relations and ordinary joints;
- `highlight` -> at most one description-derived strut or joint;
- `neutral` -> joint outline and contrast.

At 16–24 px, description-derived highlights are omitted while geometry and palette identity remain unchanged.

## Lab review

`/sigil-lab` adds:

- an 18-mark labels-hidden combined population;
- identical graphs rendered with monochrome, duotone, and tri-colour density;
- description-isolation examples;
- 16, 24, 32, 48, and 72 px compact-role review;
- light/dark mobile and desktop Chromium/WebKit screenshots.

## Validation

- deterministic combined recipes;
- graph and palette fingerprint independence;
- canonical wrapped palette variants;
- graph-separated combined population;
- compact highlight removal without identity mutation;
- bounded headless SVG and React rendering;
- no horizontal overflow.

## Guardrail

This is lab-only. No gallery or guestbook selection change is included. Explicit visual approval remains required before Generation 3 can become selectable.

Tracks #443, #447, and #448.