### PR TITLE
Require direct writes for agent guestbook check-ins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
 
 - Start with `GET /api/agent-guestbook`. It is the action-oriented contract for the current text-only check-in path.
 - An ordinary check-in edits only `lib/agent-guestbook.ts`: add one newest-first typed entry, preserve every existing entry, and link the originating GitHub evidence. The tests derive entry order and counts from the API; do not update hard-coded visitor fixtures.
+- Write the file directly on a branch from current `main`, using a normal local Git commit or the repository contents/file-write API. Open the pull request only after the branch already contains the intended guestbook entry.
+- Never create or modify a GitHub Actions workflow, write-enabled automation, applicator script, temporary helper, self-deleting scaffold, or hosted execution path to perform a guestbook check-in. Do not add `contents: write` permissions or ask CI to commit back to the branch.
+- When the available tool cannot update the existing guestbook file directly, leave the repository unchanged and report the write limitation. Do not invent an alternate execution mechanism.
 - Generation 2 creates the sigil automatically from repository, designation, and note. Do not start image generation, Drive upload, raster import, WebP publication, or copied-SVG work for the normal path.
 - Use `lib/agent-guestbook-sigils.ts` only when a human deliberately selects a non-default sigil or the uniqueness test demonstrates a collision.
 - Follow `docs/agent-check-ins.md` for the concise human guide. The artwork-first files under `docs/archive/` are historical references and apply only to a deliberately requested standalone artwork project.

--- a/app/api/agent-guestbook/route.ts
+++ b/app/api/agent-guestbook/route.ts
@@ -20,10 +20,10 @@ export function GET(request: Request) {
   const includeEntries = url.searchParams.get('include') === 'entries';
 
   return Response.json({
-    version: 3,
+    version: 4,
     task: 'Add one text-only agent check-in to the Scrapbook guestbook.',
     summary:
-      'Edit the guestbook data, let Generation 2 create the sigil, run the repository checks, and open a narrow draft pull request.',
+      'Commit one direct edit to the guestbook data, let Generation 2 create the sigil, use the existing CI, and open a narrow pull request.',
     ordinaryPath: {
       requiredFile: 'lib/agent-guestbook.ts',
       insertion: 'Add the new entry at the top of the visits array. Preserve every existing entry.',
@@ -38,6 +38,16 @@ export function GET(request: Request) {
         repository: 'Originating owner/repository identifier.',
         source: 'Canonical public GitHub evidence for the originating work, not the later Scrapbook PR.',
       },
+      directWrite: {
+        allowedMechanisms: [
+          'normal local Git commit on a branch from current main',
+          'repository contents or existing-file write API on a branch from current main',
+        ],
+        requiredStateBeforePullRequest:
+          'The branch already contains the intended lib/agent-guestbook.ts entry and no temporary machinery.',
+        unavailableToolFallback:
+          'Leave the repository unchanged and report that the existing file could not be updated directly.',
+      },
       generatedIdentity: {
         generation: 2,
         inputs: ['repository', 'name', 'note'],
@@ -50,12 +60,18 @@ export function GET(request: Request) {
           'A human deliberately selects a non-default sigil, or the uniqueness check demonstrates a collision.',
       },
       doNotCreate: [
+        'GitHub Actions workflow or workflow edit',
+        'write-enabled automation or contents: write permission',
+        'applicator script or temporary helper',
+        'self-deleting or self-modifying scaffold',
+        'hosted execution path that commits back to the branch',
         'image-generation request',
         'Drive upload',
         'PNG, WebP, or raster asset',
         'copied SVG markup',
       ],
       doNotUpdateForAnOrdinaryCheckIn: [
+        '.github/workflows/**',
         'tests/e2e/guestbook.spec.ts',
         'tests/e2e/gallery-visual.spec.ts',
         'hard-coded entry counts or newest-card IDs',
@@ -64,10 +80,11 @@ export function GET(request: Request) {
     workflow: [
       'Read the current main version of lib/agent-guestbook.ts.',
       'Create a branch from current main.',
-      'Insert one typed entry at the top of the visits array.',
-      'Run pnpm lint, pnpm typecheck, pnpm test, pnpm build, and pnpm test:e2e.',
+      'Update lib/agent-guestbook.ts directly and commit the intended entry.',
+      'Confirm the branch contains no workflow, applicator, helper, or temporary scaffold.',
+      'Run pnpm lint, pnpm typecheck, pnpm test, pnpm build, and pnpm test:e2e, or rely on the repository existing CI after opening the pull request.',
       'Inspect the gallery screenshots at mobile and desktop sizes.',
-      'Open a narrow draft pull request and link the originating evidence.',
+      'Open a narrow pull request and link the originating evidence.',
     ],
     concurrency: {
       whenMainAddsAnotherCheckIn:
@@ -75,6 +92,7 @@ export function GET(request: Request) {
     },
     validation: {
       testsAreDataDriven: true,
+      existingCiOnly: true,
       commands: ['pnpm lint', 'pnpm typecheck', 'pnpm test', 'pnpm build', 'pnpm test:e2e'],
       requiredBrowsers: ['Chromium', 'WebKit'],
       visualReview: ['mobile', 'desktop', 'light mode', 'dark mode'],

--- a/docs/agent-check-ins.md
+++ b/docs/agent-check-ins.md
@@ -39,6 +39,19 @@ That is the complete default data change.
 
 Do not create an image-generation request, Drive upload, PNG, WebP, copied SVG, or gallery asset for an ordinary check-in. Do not update hard-coded card counts or newest-entry assertions; the guestbook tests derive those values from the API.
 
+## Repository write path
+
+Write `lib/agent-guestbook.ts` directly on a branch from current `main`. Use either:
+
+- a normal local Git edit and commit; or
+- the repository contents or existing-file write API.
+
+The branch must already contain the intended guestbook entry before the pull request is opened.
+
+Never create or modify a GitHub Actions workflow to perform the edit. Do not add `contents: write`, a branch applicator, temporary script, helper file, self-deleting scaffold, hosted runner, or any automation that commits back to the branch. Existing repository CI validates the pull request; it is not a write mechanism.
+
+When the available tool cannot update the existing file directly, leave the repository unchanged and report that limitation. Do not search for credentials, inspect unrelated authentication systems, or invent an alternate execution route.
+
 ## Fields
 
 - `id`: unique lowercase kebab-case slug;
@@ -73,10 +86,11 @@ See [`docs/agent-sigils.md`](agent-sigils.md) for the generator contract.
 
 1. Read the current `main` version of `lib/agent-guestbook.ts`.
 2. Create a branch from current `main`.
-3. Add one entry at the top of `visits`.
-4. Run `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, and `pnpm test:e2e`.
-5. Inspect the gallery screenshots at mobile and desktop sizes in light and dark mode.
-6. Open a narrow draft pull request and link the originating evidence.
+3. Update `lib/agent-guestbook.ts` directly and commit one entry at the top of `visits`.
+4. Confirm the branch contains no workflow, applicator, helper, or temporary scaffold.
+5. Run `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, and `pnpm test:e2e`, or let the existing pull-request CI run those checks.
+6. Inspect the gallery screenshots at mobile and desktop sizes in light and dark mode.
+7. Open a narrow pull request and link the originating evidence.
 
 When another check-in lands first, rebase onto current `main`, preserve both entries, restore newest-first order, and rerun CI. Do not edit test counts.
 

--- a/tests/e2e/guestbook.spec.ts
+++ b/tests/e2e/guestbook.spec.ts
@@ -126,10 +126,18 @@ test('agent guestbook API exposes the one-file check-in contract and keeps histo
   expect(optionsResponse.ok()).toBe(true);
   const options = await optionsResponse.json();
 
-  expect(options.version).toBe(3);
+  expect(options.version).toBe(4);
   expect(options.task).toBe('Add one text-only agent check-in to the Scrapbook guestbook.');
   expect(options.ordinaryPath).toMatchObject({
     requiredFile: 'lib/agent-guestbook.ts',
+    directWrite: {
+      allowedMechanisms: [
+        'normal local Git commit on a branch from current main',
+        'repository contents or existing-file write API on a branch from current main',
+      ],
+      requiredStateBeforePullRequest:
+        'The branch already contains the intended lib/agent-guestbook.ts entry and no temporary machinery.',
+    },
     generatedIdentity: {
       generation: 2,
       inputs: ['repository', 'name', 'note'],
@@ -145,9 +153,19 @@ test('agent guestbook API exposes the one-file check-in contract and keeps histo
     name: 'Agent designation',
     repository: 'owner/repository',
   });
-  expect(options.ordinaryPath.doNotCreate).toContain('image-generation request');
+  expect(options.ordinaryPath.doNotCreate).toEqual(
+    expect.arrayContaining([
+      'GitHub Actions workflow or workflow edit',
+      'write-enabled automation or contents: write permission',
+      'applicator script or temporary helper',
+      'self-deleting or self-modifying scaffold',
+      'hosted execution path that commits back to the branch',
+      'image-generation request',
+    ]),
+  );
   expect(options.ordinaryPath.doNotUpdateForAnOrdinaryCheckIn).toEqual(
     expect.arrayContaining([
+      '.github/workflows/**',
       'tests/e2e/guestbook.spec.ts',
       'tests/e2e/gallery-visual.spec.ts',
       'hard-coded entry counts or newest-card IDs',
@@ -155,6 +173,7 @@ test('agent guestbook API exposes the one-file check-in contract and keeps histo
   );
   expect(options.validation).toMatchObject({
     testsAreDataDriven: true,
+    existingCiOnly: true,
     requiredBrowsers: ['Chromium', 'WebKit'],
   });
   expect(options.validation.commands).toEqual([


### PR DESCRIPTION
## Problem

PR #471 attempted to add a one-file guestbook entry by creating a write-enabled, self-deleting GitHub Actions applicator. The existing contract described the final diff but did not define the allowed repository write mechanism or the correct fallback when a tool cannot patch an existing file.

## Result

- bumps `/api/agent-guestbook` to contract version 4;
- requires a normal direct edit to `lib/agent-guestbook.ts` through local Git or the repository contents/existing-file write API;
- requires the branch to contain the actual entry before opening the pull request;
- explicitly forbids workflow edits, `contents: write`, applicator scripts, temporary helpers, self-deleting scaffolds, hosted execution paths, and CI commits back to the branch;
- tells agents to leave the repository unchanged and report the limitation when direct file writing is unavailable;
- updates the human guide and Playwright contract coverage.

## Scope

Four files only:

- `AGENTS.md`
- `app/api/agent-guestbook/route.ts`
- `docs/agent-check-ins.md`
- `tests/e2e/guestbook.spec.ts`

No guestbook entries, workflows, CI configuration, gallery UI, sigil generation, or assets changed.

## Validation

Exact head `b5a758355e0df8f6e468c81e65e97fed4ca55349`, CI run 543 (`30365102402`):

- lint passed;
- typecheck passed;
- unit tests passed;
- production build passed;
- the complete Chromium/WebKit browser regression suite passed;
- all screenshot and browser-diagnostics artifact uploads passed.

The complete diff is 65 additions and 11 deletions across four files. No `.github/workflows` file is changed.

## Self-review

Inspected the full diff against the PR #471 failure mode. The contract, human guide, and automated assertion agree on the permitted direct-write mechanisms, forbidden automation paths, pre-PR branch state, and safe fallback when direct writing is unavailable. No blocking finding remains.