### PR TITLE
Polish navigation and gallery browsing

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -19,6 +19,9 @@ const contributionGuideUrl =
 const provenanceLinkClassName =
   'rounded-sm font-mono text-[9px] font-semibold uppercase tracking-[0.12em] opacity-65 underline decoration-current/35 underline-offset-4 transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
 
+const gallerySectionLinkClassName =
+  'inline-flex min-h-10 shrink-0 items-center rounded-full border border-border/70 bg-background/60 px-3 font-mono text-[9px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-[background-color,color,border-color] hover:border-foreground/20 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
 const arrivalTimes: Record<string, string> = {
   '2026-07-26-polling-possum-quarry': '2026-07-26T21:03:00Z',
   'fifth-drawer-scrapbook-pod': '2026-07-26T20:55:30Z',
@@ -75,9 +78,26 @@ function critterForVisit(visit: AgentVisit): PaperCritterKind {
   return 'dinosaur';
 }
 
+function critterAccentClassName(critter: PaperCritterKind) {
+  switch (critter) {
+    case 'possum':
+      return 'bg-[#b7a9bf] dark:bg-[#8f7c99]';
+    case 'sparrow':
+      return 'bg-[#c99e65] dark:bg-[#a77d49]';
+    case 'raccoon':
+      return 'bg-[#7d858d] dark:bg-[#9aa0a6]';
+    case 'moth':
+      return 'bg-[#9b87c3] dark:bg-[#b7a4d8]';
+    default:
+      return 'bg-[#aebaa0] dark:bg-[#89917e]';
+  }
+}
+
 const orderedAgentVisits = [...agentVisits].sort(
   (left, right) => Date.parse(arrivedAt(right)) - Date.parse(arrivedAt(left)),
 );
+
+const recentArrivalLinks = orderedAgentVisits.slice(0, 6);
 
 export default function GalleryPage() {
   return (
@@ -96,7 +116,10 @@ export default function GalleryPage() {
       />
 
       <div className="relative mx-auto w-full min-w-0 max-w-7xl px-4 py-5 sm:px-6 sm:py-8 lg:px-8">
-        <section className="grid min-w-0 max-w-full overflow-hidden rounded-[1.5rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.55fr)]">
+        <section
+          id="object-room"
+          className="grid min-w-0 max-w-full scroll-mt-20 overflow-hidden rounded-[1.5rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.13)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.38)] lg:grid-cols-[minmax(0,1.45fr)_minmax(20rem,0.55fr)]"
+        >
           <div className="relative min-h-[24rem] min-w-0 overflow-hidden bg-[#15161a] sm:min-h-[34rem]">
             <GalleryScene />
           </div>
@@ -139,9 +162,48 @@ export default function GalleryPage() {
           </div>
         </section>
 
-        <GuestbookArrivalShelf />
+        <nav
+          aria-label="Gallery map and recent arrivals"
+          className="mt-4 min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_12px_34px_rgba(24,24,26,0.08)] sm:p-4 dark:shadow-[0_14px_38px_rgba(0,0,0,0.24)]"
+          data-gallery-map
+        >
+          <div className="flex min-w-0 gap-2 overflow-x-auto pb-1">
+            <a href="#object-room" className={gallerySectionLinkClassName}>
+              Object room
+            </a>
+            <a href="#check-in-desk" className={gallerySectionLinkClassName}>
+              Check-in desk
+            </a>
+            <a href="#visitor-wall" className={gallerySectionLinkClassName}>
+              Visitor wall
+            </a>
+          </div>
+          <div className="mt-3 border-t border-dashed border-border/65 pt-3">
+            <p className="font-mono text-[8px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+              Jump to a recent arrival
+            </p>
+            <div className="-mx-1 mt-2 flex min-w-0 gap-2 overflow-x-auto px-1 pb-1">
+              {recentArrivalLinks.map((visit, index) => (
+                <a
+                  key={visit.id}
+                  href={`#visit-${visit.id}`}
+                  className="inline-flex min-h-9 shrink-0 items-center gap-2 rounded-xl border border-border/65 bg-background/45 px-2.5 text-xs text-muted-foreground transition-[background-color,color,border-color] hover:border-foreground/20 hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <span className="font-mono text-[8px] tabular-nums opacity-55" aria-hidden="true">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <span className="max-w-40 truncate font-medium">{visit.name}</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        </nav>
 
-        <section className="mt-5 min-w-0">
+        <div id="check-in-desk" className="scroll-mt-20">
+          <GuestbookArrivalShelf />
+        </div>
+
+        <section id="visitor-wall" className="mt-5 min-w-0 scroll-mt-20">
           <div className="flex items-end justify-between gap-4">
             <div>
               <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
@@ -155,7 +217,7 @@ export default function GalleryPage() {
           </div>
 
           <div className="mt-3 grid min-w-0 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {orderedAgentVisits.map((visit) => {
+            {orderedAgentVisits.map((visit, index) => {
               const displayNote = clearerNotes[visit.id] ?? visit.note;
               const critter = critterForVisit(visit);
               return (
@@ -164,19 +226,19 @@ export default function GalleryPage() {
                   key={visit.id}
                   data-agent-visit={visit.id}
                   data-arrived-at={arrivedAt(visit)}
-                  className="material-paper relative flex min-w-0 scroll-mt-20 flex-col overflow-hidden rounded-xl border p-4 transition-[transform,box-shadow] hover:-rotate-[0.12deg] hover:shadow-[0_12px_28px_rgba(42,36,29,0.14)]"
+                  data-paper-critter={critter}
+                  className="material-paper relative flex min-w-0 scroll-mt-24 flex-col overflow-hidden rounded-xl border p-4 pt-5 transition-[transform,box-shadow] hover:-rotate-[0.12deg] hover:shadow-[0_12px_28px_rgba(42,36,29,0.14)]"
                 >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <span className="flex h-36 w-full shrink-0 items-center justify-center rounded-xl border border-black/10 bg-white/25">
-                        <PaperCritter
-                          kind={critter}
-                          className="h-28 w-40 max-w-[80%]"
-                          label={`${visit.name} paper visitor`}
-                        />
-                      </span>
-                      <span className="sr-only">{visit.mark}</span>
-                    </div>
+                  <span
+                    className={`absolute inset-x-0 top-0 h-1.5 ${critterAccentClassName(critter)}`}
+                    aria-hidden="true"
+                  />
+
+                  <div className="flex min-w-0 items-start justify-between gap-3">
+                    <p className="min-w-0 truncate font-mono text-[8px] font-semibold uppercase tracking-[0.14em] opacity-55">
+                      Arrival {String(index + 1).padStart(2, '0')}
+                      {index === 0 ? ' · newest' : ''}
+                    </p>
                     <time
                       dateTime={arrivedAt(visit)}
                       className="shrink-0 text-right font-mono text-[8px] uppercase tracking-[0.09em] opacity-55"
@@ -185,10 +247,24 @@ export default function GalleryPage() {
                     </time>
                   </div>
 
-                  <p className="mt-2 truncate font-mono text-[9px] font-semibold uppercase tracking-[0.16em] opacity-60">
+                  <div className="mt-3 flex h-28 w-full items-center justify-center overflow-hidden rounded-xl border border-black/10 bg-white/25 sm:h-32">
+                    <span
+                      className="inline-flex"
+                      style={{ transform: `rotate(${index % 2 === 0 ? '-1.2deg' : '1.2deg'})` }}
+                    >
+                      <PaperCritter
+                        kind={critter}
+                        className="h-20 w-28 sm:h-24 sm:w-36"
+                        label={`${visit.name} paper visitor`}
+                      />
+                    </span>
+                    <span className="sr-only">{visit.mark}</span>
+                  </div>
+
+                  <p className="mt-3 truncate font-mono text-[9px] font-semibold uppercase tracking-[0.16em] opacity-60">
                     {visit.mark}
                   </p>
-                  <h3 className="mt-3 text-lg font-semibold">{visit.name}</h3>
+                  <h3 className="mt-2 text-lg font-semibold">{visit.name}</h3>
                   <p className="mt-2 text-sm leading-relaxed opacity-70">{displayNote}</p>
 
                   {visit.repository ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -135,7 +135,11 @@ async function HomeActivityContent() {
         </div>
       </section>
 
-      <nav aria-labelledby="explore-scrapbook-title" className="min-w-0" data-home-room-shelf>
+      <section
+        aria-labelledby="explore-scrapbook-title"
+        className="min-w-0 md:hidden"
+        data-home-room-shelf
+      >
         <div className="flex items-end justify-between gap-4 px-0.5">
           <div>
             <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
@@ -150,7 +154,7 @@ async function HomeActivityContent() {
           </span>
         </div>
 
-        <div className="-mx-4 mt-2.5 grid snap-x snap-mandatory grid-flow-col auto-cols-[minmax(16rem,82vw)] gap-2.5 overflow-x-auto px-4 pb-2 sm:mx-0 sm:grid-flow-row sm:grid-cols-2 sm:overflow-visible sm:px-0 sm:pb-0 xl:grid-cols-4">
+        <div className="-mx-4 mt-2.5 grid snap-x snap-mandatory grid-flow-col auto-cols-[minmax(16rem,82vw)] gap-2.5 overflow-x-auto px-4 pb-2">
           {scrapbookDestinations.map((destination, index) => (
             <Link
               key={destination.id}
@@ -183,7 +187,7 @@ async function HomeActivityContent() {
             </Link>
           ))}
         </div>
-      </nav>
+      </section>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,9 @@ import { ActivityDashboard } from '@/components/home/activity-dashboard';
 import { WindLiftCard } from '@/components/home/wind-lift-card';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import { getGitHubHomeData } from '@/lib/github-home';
-import { ArrowUpRight } from 'lucide-react';
+import { ArrowRight, ArrowUpRight } from 'lucide-react';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import { connection } from 'next/server';
 import { Suspense } from 'react';
 
@@ -16,6 +17,37 @@ export const metadata: Metadata = {
 const repositoryNoteOverrides: Record<string, string> = {
   smolrunner: 'Plans host work before changing anything and inspects unknown state first.',
 };
+
+const scrapbookDestinations = [
+  {
+    id: 'space',
+    href: '/space',
+    eyebrow: 'Clipping drawer',
+    label: 'Space',
+    description: 'Search notes, references, code, and review queues.',
+  },
+  {
+    id: 'journal',
+    href: '/journal',
+    eyebrow: 'Evidence ledger',
+    label: 'Journal',
+    description: 'Follow repository-backed records from the agent pod.',
+  },
+  {
+    id: 'gallery',
+    href: '/gallery',
+    eyebrow: 'Object room',
+    label: 'Gallery',
+    description: 'Play with the projected object and meet recent visitors.',
+  },
+  {
+    id: 'atelier',
+    href: '/atelier',
+    eyebrow: 'Worktable',
+    label: 'Atelier',
+    description: 'Try interface sketches and early navigation experiments.',
+  },
+] as const;
 
 function HomeActivityFallback() {
   return (
@@ -102,6 +134,56 @@ async function HomeActivityContent() {
           ))}
         </div>
       </section>
+
+      <nav aria-labelledby="explore-scrapbook-title" className="min-w-0" data-home-room-shelf>
+        <div className="flex items-end justify-between gap-4 px-0.5">
+          <div>
+            <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+              Continue exploring
+            </p>
+            <h2 id="explore-scrapbook-title" className="mt-1 text-lg font-semibold tracking-tight">
+              Pick a room in the scrapbook
+            </h2>
+          </div>
+          <span className="hidden font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground sm:block">
+            four useful stops
+          </span>
+        </div>
+
+        <div className="-mx-4 mt-2.5 grid snap-x snap-mandatory grid-flow-col auto-cols-[minmax(16rem,82vw)] gap-2.5 overflow-x-auto px-4 pb-2 sm:mx-0 sm:grid-flow-row sm:grid-cols-2 sm:overflow-visible sm:px-0 sm:pb-0 xl:grid-cols-4">
+          {scrapbookDestinations.map((destination, index) => (
+            <Link
+              key={destination.id}
+              href={destination.href}
+              prefetch
+              data-home-room-link={destination.id}
+              className="group relative min-w-0 snap-start overflow-hidden rounded-2xl border border-border/65 bg-card p-3.5 text-card-foreground shadow-[0_8px_20px_rgba(35,31,26,0.07)] transition-[border-color,background-color,box-shadow] hover:border-foreground/25 hover:bg-card/95 hover:shadow-[0_14px_30px_rgba(35,31,26,0.11)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:shadow-[0_8px_20px_rgba(0,0,0,0.22)] dark:hover:shadow-[0_16px_34px_rgba(0,0,0,0.32)]"
+            >
+              <span
+                aria-hidden="true"
+                className="absolute right-3 top-3 font-mono text-[9px] tabular-nums text-muted-foreground/45"
+              >
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <p className="pr-8 font-mono text-[8px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                {destination.eyebrow}
+              </p>
+              <h3 className="mt-2 text-base font-semibold tracking-tight">{destination.label}</h3>
+              <p className="mt-1.5 min-h-10 text-sm leading-snug text-muted-foreground">
+                {destination.description}
+              </p>
+              <span className="mt-3 inline-flex items-center gap-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.13em] text-muted-foreground transition-colors group-hover:text-foreground">
+                Open room
+                <ArrowRight
+                  size={13}
+                  aria-hidden="true"
+                  className="transition-transform group-hover:translate-x-0.5 motion-reduce:transition-none"
+                />
+              </span>
+            </Link>
+          ))}
+        </div>
+      </nav>
     </div>
   );
 }

--- a/components/site-atlas.tsx
+++ b/components/site-atlas.tsx
@@ -7,11 +7,13 @@ import {
   getActiveNavigationItem,
   isNavigationItemActive,
   siteNavigationGroups,
+  siteNavigationItems,
   type SiteNavigationItem,
 } from '@/lib/site-navigation';
 import * as Dialog from '@radix-ui/react-dialog';
 import {
   Activity,
+  ArrowRight,
   Brain,
   Clock3,
   Compass,
@@ -36,6 +38,24 @@ import { toast } from 'sonner';
 
 const triggerBase =
   'inline-flex h-11 min-w-[44px] shrink-0 items-center justify-center gap-1.5 rounded-full border border-border/70 bg-card px-3 text-xs font-semibold text-foreground shadow-[0_3px_10px_rgba(20,20,24,0.08)] transition-[background-color,box-shadow] hover:bg-muted hover:shadow-[0_6px_14px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none dark:shadow-[0_4px_12px_rgba(0,0,0,0.28)]';
+
+const nextStopByItemId: Record<string, string> = {
+  home: 'space',
+  space: 'journal',
+  journal: 'gallery',
+  gallery: 'atelier',
+  blog: 'journal',
+  atelier: 'activity-lab',
+  time: 'space',
+  proxy: 'home',
+  'activity-lab': 'sigil-lab',
+  'sigil-lab': 'gallery',
+};
+
+function recommendedNextStop(activeItem?: SiteNavigationItem) {
+  const nextId = activeItem ? nextStopByItemId[activeItem.id] : 'home';
+  return siteNavigationItems.find((item) => item.id === nextId && !item.external);
+}
 
 function ItemIcon({ id }: { id: string }) {
   const className = 'h-4 w-4';
@@ -92,13 +112,13 @@ function AtlasLink({
       aria-current={active ? 'page' : undefined}
       data-site-atlas-link={item.id}
       data-active={active ? 'true' : undefined}
-      className={`group relative flex min-h-[92px] min-w-0 items-start gap-3 overflow-hidden rounded-[1rem] border p-3 text-left transition-[background-color,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none ${
+      className={`group relative flex min-h-[82px] min-w-0 items-start gap-2.5 overflow-hidden rounded-[1rem] border p-2.5 text-left transition-[background-color,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none sm:min-h-[92px] sm:gap-3 sm:p-3 ${
         active
           ? 'border-foreground/30 bg-foreground/[0.075] shadow-[inset_3px_0_0_currentColor]'
           : 'border-border/70 bg-background/55 hover:border-foreground/25 hover:bg-muted/70'
       }`}
     >
-      <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-card text-foreground shadow-sm">
+      <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-card text-foreground shadow-sm sm:h-9 sm:w-9">
         <ItemIcon id={item.id} />
       </span>
       <span className="min-w-0 flex-1">
@@ -113,7 +133,7 @@ function AtlasLink({
             <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
           ) : null}
         </span>
-        <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
+        <span className="mt-1 block text-xs leading-snug text-muted-foreground sm:leading-relaxed">
           {item.description}
         </span>
         {item.external ? <span className="sr-only"> Opens in a new tab.</span> : null}
@@ -191,6 +211,7 @@ export function SiteAtlas({
 }) {
   const pathname = usePathname() || '/';
   const activeItem = getActiveNavigationItem(pathname);
+  const nextStop = recommendedNextStop(activeItem);
 
   return (
     <Dialog.Root>
@@ -216,7 +237,7 @@ export function SiteAtlas({
           className="fixed inset-0 z-[80] flex min-w-0 flex-col overflow-hidden bg-background text-foreground shadow-2xl outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none sm:inset-4 sm:mx-auto sm:max-w-5xl sm:rounded-[1.5rem] sm:border sm:border-border/70"
           data-site-atlas
         >
-          <header className="flex shrink-0 items-start gap-4 border-b border-border/70 bg-card/90 px-4 pb-4 pt-[max(1rem,env(safe-area-inset-top))] sm:px-6 sm:pt-4">
+          <header className="flex shrink-0 items-start gap-3 border-b border-border/70 bg-card/90 px-4 pb-4 pt-[max(1rem,env(safe-area-inset-top))] sm:gap-4 sm:px-6 sm:pt-4">
             <div className="min-w-0 flex-1">
               <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                 Current place · {activeItem?.label ?? 'Unmapped route'}
@@ -228,6 +249,25 @@ export function SiteAtlas({
                 Navigate the main places, focused tools, inspectable experiments, and external
                 connections without guessing what is hidden in a menu.
               </Dialog.Description>
+              {nextStop ? (
+                <Dialog.Close asChild>
+                  <Link
+                    href={nextStop.href}
+                    prefetch
+                    data-site-atlas-next-stop={nextStop.id}
+                    className="mt-3 inline-flex max-w-full items-center gap-2 rounded-full border border-border/70 bg-background/65 px-3 py-2 text-left transition-[background-color,border-color] hover:border-foreground/20 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <span className="min-w-0 truncate text-xs">
+                      <span className="font-mono text-[8px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">
+                        Suggested next
+                      </span>{' '}
+                      <span className="font-semibold text-foreground">{nextStop.label}</span>
+                    </span>
+                    <ArrowRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  </Link>
+                </Dialog.Close>
+              ) : null}
             </div>
             <Dialog.Close asChild>
               <button
@@ -245,7 +285,7 @@ export function SiteAtlas({
             className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pb-6"
             data-site-atlas-scroll
           >
-            <div className="grid gap-5 lg:grid-cols-2 lg:gap-6">
+            <div className="grid gap-4 lg:grid-cols-2 lg:gap-6">
               {siteNavigationGroups.map((group) => (
                 <section
                   key={group.id}


### PR DESCRIPTION
## What changed

- adds a guided room shelf to the homepage so the main internal destinations are directly discoverable
- adds a compact Gallery map with section links and recent-arrival jump links
- tightens visitor-card hierarchy and gives each paper critter a clearer visual accent
- adds a contextual suggested-next-stop link to the Site Atlas
- reduces Atlas card height on smaller screens to make the menu quicker to scan

## Why

The visual regression screenshots showed three usability gaps: internal destinations were easy to miss outside the Atlas, the mobile Gallery became a long undifferentiated stream, and the Atlas listed routes without helping people choose a next step.

## Validation

CI requested for lint, typecheck, unit tests, production build, and browser regressions.