### PR TITLE
Polish homepage motion, Atlas stability, and time typography

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
         today: activity.today,
         weekTotal: activity.weekTotal,
         yearTotal: activity.periodLabel === 'last year' ? activity.total : null,
-        days: activity.days.slice(-35),
+        days: activity.days.slice(-28),
         diagnostics,
       },
       { headers },

--- a/app/dialog-scroll-lock.css
+++ b/app/dialog-scroll-lock.css
@@ -1,0 +1,16 @@
+@supports (scrollbar-gutter: stable) {
+  body[data-scroll-locked],
+  .with-scroll-bars-hidden {
+    --removed-body-scroll-bar-size: 0px !important;
+    margin-right: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .right-scroll-bar-position {
+    right: 0 !important;
+  }
+
+  .width-before-scroll-bar {
+    margin-right: 0 !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import '@/app/globals.css';
 import '@/app/materials.css';
 import '@/app/materials-accessibility.css';
 import '@/app/navigation-feedback.css';
+import '@/app/dialog-scroll-lock.css';
 import { inter } from '@/components/ui/assets/fonts';
 import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,7 +81,7 @@ function HomeActivityFallback() {
 async function HomeActivityContent() {
   await connection();
   const activity = await getGitHubHomeData();
-  const days = activity.days.slice(-35);
+  const days = activity.days.slice(-28);
   const yearTotal = activity.periodLabel === 'last year' ? activity.total : null;
 
   return (

--- a/components/current-time-display.tsx
+++ b/components/current-time-display.tsx
@@ -60,7 +60,7 @@ export default function CurrentTimeDisplay({ onJumpToTime }: CurrentTimeDisplayP
     <div>
       <p className="material-label-stamped mb-2 text-[9px] text-muted-foreground">time machine</p>
       <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <h1 className="text-3xl font-semibold tracking-tight">Current time</h1>
+        <h1 className="font-mono text-3xl font-semibold tracking-[-0.035em]">Current time</h1>
         <button
           type="button"
           onClick={() => onJumpToTime(currentTime)}

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -39,6 +39,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   const maximum = Math.max(...days.map((day) => day.count), 0);
   const gridDays = useMemo(() => alignContributionDaysToWeekColumns(days), [days]);
   const weekCount = Math.max(1, gridDays.length / 7);
+  const calendarMaxWidthRem = 2.3 + weekCount * 3.5;
   const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
   const [tooltipDate, setTooltipDate] = useState<string | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
@@ -117,10 +118,11 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     <section
       className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-4 [@media(max-height:780px)]:p-3"
       data-home-activity-grid
+      data-fine-pointer={finePointer ? 'true' : 'false'}
     >
       <div className="flex items-center justify-between gap-4">
         <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          35 days · UTC
+          28 days · UTC
         </span>
         <div
           className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
@@ -136,7 +138,10 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div className="mx-auto mt-3 grid w-full max-w-[25rem] grid-cols-[1.65rem_minmax(0,1fr)] gap-2 sm:gap-2.5 [@media(max-height:780px)]:mt-2 [@media(max-height:780px)]:max-w-[22rem]">
+      <div
+        className="mx-auto mt-3 grid w-full grid-cols-[1.65rem_minmax(0,1fr)] gap-2 sm:gap-2.5 [@media(max-height:780px)]:mt-2"
+        style={{ maxWidth: `min(100%, ${calendarMaxWidthRem}rem)` }}
+      >
         <div
           className="grid grid-rows-7 gap-1.5 py-px font-mono text-[8px] font-medium text-muted-foreground sm:gap-2"
           aria-hidden="true"
@@ -154,7 +159,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
             gridTemplateColumns: `repeat(${weekCount}, minmax(0, 1fr))`,
             gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
           }}
-          aria-label="GitHub contribution calendar for the last 35 days"
+          aria-label="GitHub contribution calendar for the last 28 days"
           data-contribution-week-grid
         >
           {gridDays.map((day, index) => {

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -200,7 +200,7 @@ function ScoreDigits({ value }: { value: number }) {
         <div
           key={index}
           data-activity-digit
-          className={`${styles.digitSlot} relative aspect-[0.78] min-w-0 flex-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none tabular-nums transition-transform duration-300 ease-out group-hover:-translate-y-1 motion-reduce:transform-none motion-reduce:transition-none ${index % 2 === 0 ? 'group-hover:-rotate-[0.7deg]' : 'group-hover:rotate-[0.7deg]'}`}
+          className={`${styles.digitSlot} relative aspect-[0.78] min-w-0 flex-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none tabular-nums transition-transform duration-300 ease-out group-hover:-translate-y-0.5 motion-reduce:transform-none motion-reduce:transition-none ${index % 2 === 0 ? 'group-hover:-rotate-[0.35deg]' : 'group-hover:rotate-[0.35deg]'}`}
           style={{ transitionDelay: `${index * 24}ms` }}
         >
           <PaperDigit digit={digit} index={index} />
@@ -213,7 +213,7 @@ function ScoreDigits({ value }: { value: number }) {
 function Metric({ label, value, title }: { label: string; value: string; title?: string }) {
   return (
     <span
-      className="grid min-h-[3.25rem] content-center gap-1 rounded-xl border border-border/65 bg-background/40 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)] transition-[transform,border-color,background-color] duration-300 group-hover:translate-x-0.5 group-hover:border-border group-hover:bg-background/55 motion-reduce:transition-none"
+      className="grid min-h-[3.25rem] content-center gap-1 rounded-xl border border-border/65 bg-background/40 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.22)] transition-[transform,border-color,background-color] duration-300 group-hover:translate-x-px group-hover:border-border group-hover:bg-background/50 motion-reduce:transform-none motion-reduce:transition-none"
       title={title}
     >
       <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
@@ -254,23 +254,21 @@ export function ActivityScoreboard({
         reduceMotion
           ? undefined
           : {
-              y: -5,
-              rotateX: 0.7,
-              rotateY: -0.65,
-              scale: 1.008,
+              y: -3,
+              rotate: -0.2,
+              scale: 1.004,
             }
       }
-      transition={{ type: 'spring', stiffness: 260, damping: 22, mass: 0.72 }}
-      style={{ transformPerspective: 1100, transformOrigin: '50% 55%' }}
-      className="group relative flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[border-color,box-shadow] duration-300 hover:border-border hover:shadow-[0_24px_52px_rgba(24,24,26,0.17)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_26px_58px_rgba(0,0,0,0.42)] [@media(max-height:780px)]:min-h-[14.5rem]"
+      transition={{ type: 'spring', stiffness: 240, damping: 24, mass: 0.74 }}
+      className="group relative flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[border-color,box-shadow] duration-300 hover:border-border hover:shadow-[0_21px_44px_rgba(24,24,26,0.145)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_23px_50px_rgba(0,0,0,0.37)] [@media(max-height:780px)]:min-h-[14.5rem]"
       data-activity-scoreboard
     >
       <span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-y-0 -left-[45%] z-20 w-[30%] -skew-x-12 bg-gradient-to-r from-transparent via-white/14 to-transparent opacity-0 transition-[left,opacity] duration-700 ease-out group-hover:left-[120%] group-hover:opacity-100 motion-reduce:hidden dark:via-white/[0.07]"
+        className="pointer-events-none absolute inset-y-0 -left-[28%] z-20 w-[18%] -skew-x-12 bg-gradient-to-r from-transparent via-white/[0.06] to-transparent opacity-0 transition-[left,opacity] duration-900 ease-out group-hover:left-[110%] group-hover:opacity-70 motion-reduce:hidden dark:via-white/[0.025]"
       />
 
-      <div className="relative z-10 border-b border-border/70 bg-muted/70 px-4 py-2.5 transition-colors duration-300 group-hover:bg-muted/85 [@media(max-height:780px)]:py-2">
+      <div className="relative z-10 border-b border-border/70 bg-muted/70 px-4 py-2.5 transition-colors duration-300 group-hover:bg-muted/80 [@media(max-height:780px)]:py-2">
         <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
           <span>Today</span>
           <span className="tabular-nums">UTC reset {countdown}</span>

--- a/components/home/wind-lift-card.tsx
+++ b/components/home/wind-lift-card.tsx
@@ -17,15 +17,11 @@ export function WindLiftCard({
       target="_blank"
       rel="noreferrer"
       className={cn(
-        'group relative block overflow-hidden rounded-2xl border border-border/65 bg-card p-4 text-card-foreground shadow-[0_8px_18px_rgb(45_39_30/0.08)] transition-[border-color,box-shadow,background-color] duration-150 hover:border-border hover:bg-card/95 hover:shadow-[0_16px_32px_rgb(45_39_30/0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:shadow-[0_8px_18px_rgb(0_0_0/0.22)] dark:hover:shadow-[0_18px_36px_rgb(0_0_0/0.34)]',
+        'group relative block overflow-hidden rounded-2xl border border-border/65 bg-card p-4 text-card-foreground shadow-[0_8px_18px_rgb(45_39_30/0.08)] transition-[transform,border-color,box-shadow] duration-200 hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-[0_13px_25px_rgb(45_39_30/0.105)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transform-none dark:shadow-[0_8px_18px_rgb(0_0_0/0.22)] dark:hover:shadow-[0_14px_28px_rgb(0_0_0/0.3)]',
         className,
       )}
     >
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_82%_16%,rgb(255_255_255/0.24),transparent_36%)] opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100 dark:bg-[radial-gradient(circle_at_82%_16%,rgb(255_255_255/0.08),transparent_36%)]"
-      />
-      <div className="relative">{children}</div>
+      {children}
     </a>
   );
 }

--- a/components/paper-creature.tsx
+++ b/components/paper-creature.tsx
@@ -58,11 +58,12 @@ export function PaperCreature({
           : { duration: sleeping ? 3.6 : 2.8, repeat: Infinity, ease: 'easeInOut' }
       }
       className={cn('relative inline-block shrink-0', sizeClasses[size], className)}
+      data-paper-creature
     >
       <svg viewBox="0 0 72 48" className="h-full w-full overflow-visible" aria-hidden="true">
         <motion.path
           d="M23 28 5 20l12 15 10-1Z"
-          className="fill-[#aebaa0] stroke-[#4d5148] dark:fill-[#68705f] dark:stroke-[#e4e7dd]"
+          className="fill-[#b7adbf] stroke-[#4d4852] dark:fill-[#696270] dark:stroke-[#ded8e3]"
           strokeWidth="2"
           strokeLinejoin="round"
           animate={
@@ -84,19 +85,19 @@ export function PaperCreature({
 
         <path
           d="M22 17h25c9 0 15 6 15 14v2H20v-6c0-4 1-7 2-10Z"
-          className="fill-[#c8d0ba] stroke-[#4d5148] dark:fill-[#89917e] dark:stroke-[#eef0e9]"
+          className="fill-[#cec4d6] stroke-[#4d4852] dark:fill-[#918a9b] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
         />
         <path
           d="M42 8h14c6 0 10 4 10 10v10H43l-5-7 4-13Z"
-          className="fill-[#e2e0c8] stroke-[#4d5148] dark:fill-[#c7c8b5] dark:stroke-[#eef0e9]"
+          className="fill-[#e4dce9] stroke-[#4d4852] dark:fill-[#c9c2d0] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
         />
         <path
           d="m29 17 4-8 5 8 5-8 4 8"
-          className="fill-[#f4ead2] stroke-[#4d5148] dark:fill-[#e8ddc5] dark:stroke-[#eef0e9]"
+          className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#eeeaf2] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
         />
@@ -104,7 +105,7 @@ export function PaperCreature({
         {!sleeping ? (
           <path
             d="M28 32v8h8v-8M49 32v8h8v-8"
-            className="stroke-[#4d5148] dark:stroke-[#eef0e9]"
+            className="stroke-[#4d4852] dark:stroke-[#eeeaf2]"
             strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -112,7 +113,7 @@ export function PaperCreature({
         ) : (
           <path
             d="M27 34h11M48 34h11"
-            className="stroke-[#4d5148] dark:stroke-[#eef0e9]"
+            className="stroke-[#4d4852] dark:stroke-[#eeeaf2]"
             strokeWidth="3"
             strokeLinecap="round"
           />
@@ -121,16 +122,16 @@ export function PaperCreature({
         {sleeping ? (
           <path
             d="M52 17c2 1 4 1 6 0"
-            className="stroke-[#3f423b] dark:stroke-[#3f423b]"
+            className="stroke-[#4d4852] dark:stroke-[#4d4852]"
             strokeWidth="1.8"
             strokeLinecap="round"
           />
         ) : (
-          <circle cx="56" cy="17" r="2.2" className="fill-[#262923]" />
+          <circle cx="56" cy="17" r="2.2" className="fill-[#262329]" />
         )}
         <path
           d={sleeping ? 'M57 24c2 0 4 0 5-1' : 'M57 24c2 1 4 1 6-1'}
-          className="stroke-[#4d5148]"
+          className="stroke-[#4d4852]"
           strokeWidth="1.8"
           strokeLinecap="round"
         />

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -63,12 +63,12 @@ export function SiteNavBar() {
   return (
     <nav
       aria-label="Site navigation"
-      className="sticky top-0 z-50 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
+      className="sticky top-0 z-50 h-12 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
       data-site-nav
       data-site-nav-ready={ready ? 'true' : undefined}
     >
-      <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-6">
-        <div className="flex h-12 min-w-0 items-center gap-1 sm:gap-1.5">
+      <div className="mx-auto h-full max-w-7xl px-2 sm:px-4 lg:px-6">
+        <div className="flex h-full min-w-0 items-center gap-1 sm:gap-1.5">
           <Link
             href="/"
             prefetch

--- a/docs/github-activity-cache.md
+++ b/docs/github-activity-cache.md
@@ -6,6 +6,7 @@ The homepage reads GitHub's public profile contribution calendar through `getGit
 
 - The scorecard and graph use only the public profile contribution calendar. Public events are not used as a fallback because event counts do not follow GitHub's contribution rules and can disagree with the profile.
 - Daily cells come directly from GitHub's contribution calendar markup.
+- The homepage displays the most recent 28 contribution days in GitHub's week-column, weekday-row calendar format, preserving partial weeks at both edges.
 - `Today` and `7D` are calculated from those daily profile counts in UTC, matching GitHub's contribution-date convention.
 - `1Y` uses the rolling-year total reported by the GitHub profile calendar. It is not a calendar-year-to-date sum.
 - The homepage and polling route both use the same stale-while-error coordinator, so a failed server render cannot replace a previously successful snapshot with zeroes.

--- a/lib/github-activity-response.test.ts
+++ b/lib/github-activity-response.test.ts
@@ -9,7 +9,7 @@ function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResul
       source,
       generatedAt: '2026-07-27T01:00:00.000Z',
       total: 18,
-      periodLabel: source === 'public-profile' ? 'last year' : 'last 35 days',
+      periodLabel: source === 'public-profile' ? 'last year' : 'last 28 days',
       today: 3,
       weekTotal: 9,
       activeDays: 5,

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -60,10 +60,10 @@ describe('getRecentDateKeys', () => {
     expect(getRecentDateKeys(new Date('2026-07-25T00:00:01Z')).at(-1)).toBe('2026-07-25');
   });
 
-  it('supports the 35-day homepage window', () => {
-    const days = getRecentDateKeys(new Date('2026-07-25T07:30:00Z'), 35);
-    expect(days).toHaveLength(35);
-    expect(days[0]).toBe('2026-06-21');
+  it('supports the 28-day homepage window', () => {
+    const days = getRecentDateKeys(new Date('2026-07-25T07:30:00Z'), 28);
+    expect(days).toHaveLength(28);
+    expect(days[0]).toBe('2026-06-28');
     expect(days.at(-1)).toBe('2026-07-25');
   });
 });

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -33,7 +33,7 @@ const FEATURED_REPOSITORIES = [
   },
 ] as const;
 
-const HOME_WINDOW_DAYS = 35;
+const HOME_WINDOW_DAYS = 28;
 const UPSTREAM_TIMEOUT_MS = 8_000;
 
 export type ContributionDay = {
@@ -54,7 +54,7 @@ export type GitHubHomeData = {
   source: 'public-profile' | 'unavailable';
   generatedAt: string;
   total: number | null;
-  periodLabel: 'last year' | 'last 35 days';
+  periodLabel: 'last year' | 'last 28 days';
   today: number;
   weekTotal: number;
   activeDays: number;
@@ -120,7 +120,7 @@ function summarizeCounts(
   const days = daysFromCounts(counts, now);
   const today = dateKeyInTimeZone(now);
   const periodLabel: GitHubHomeData['periodLabel'] =
-    source === 'public-profile' ? 'last year' : 'last 35 days';
+    source === 'public-profile' ? 'last year' : 'last 28 days';
   const periodEntries =
     source === 'public-profile'
       ? [...counts.entries()].filter(([date]) => date <= today)
@@ -225,7 +225,7 @@ async function loadGitHubHomeData(): Promise<UpstreamActivity> {
 
 const getCachedUpstreamActivity = unstable_cache(
   loadGitHubHomeData,
-  ['github-homepage-v8'],
+  ['github-homepage-v9'],
   { revalidate: GITHUB_ACTIVITY_UPSTREAM_FRESH_SECONDS },
 );
 

--- a/tests/e2e/follow-up-polish.spec.ts
+++ b/tests/e2e/follow-up-polish.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForHomeActivity(page: Page) {
+  await expect(page.locator('[data-home-activity-dashboard]')).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('[data-contribution-week-grid]')).toBeVisible();
+}
+
+test('time page uses one display typeface for the current-time heading and value', async ({ page }) => {
+  await page.goto('/time');
+
+  const heading = page.getByRole('heading', { name: 'Current time' });
+  const value = page.getByTitle('Jump the slider to the current time');
+  await expect(heading).toBeVisible();
+  await expect(value).toBeVisible();
+
+  const fonts = await page.evaluate(() => {
+    const headingElement = [...document.querySelectorAll('h1')].find(
+      (element) => element.textContent?.trim() === 'Current time',
+    );
+    const valueElement = document.querySelector<HTMLElement>(
+      '[title="Jump the slider to the current time"]',
+    );
+    if (!headingElement || !valueElement) throw new Error('Missing current-time typography');
+
+    return {
+      heading: getComputedStyle(headingElement).fontFamily,
+      value: getComputedStyle(valueElement).fontFamily,
+    };
+  });
+
+  expect(fonts.heading).toBe(fonts.value);
+});
+
+test('homepage shows 28 contribution days without a stray viewport scrollbar', async ({ page }) => {
+  for (const viewport of [
+    { width: 1366, height: 768 },
+    { width: 1440, height: 900 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/');
+    await waitForHomeActivity(page);
+
+    await expect(page.getByText('28 days · UTC', { exact: true })).toBeVisible();
+    await expect(page.locator('[data-contribution-week-grid] button')).toHaveCount(28);
+
+    const metrics = await page.evaluate(() => {
+      const nav = document.querySelector('nav');
+      if (!nav) throw new Error('Missing site navigation');
+      return {
+        navHeight: nav.getBoundingClientRect().height,
+        documentHeight: document.documentElement.scrollHeight,
+        viewportHeight: document.documentElement.clientHeight,
+      };
+    });
+
+    expect(metrics.navHeight).toBe(48);
+    expect(metrics.documentHeight).toBeLessThanOrEqual(metrics.viewportHeight + 1);
+  }
+});
+
+test('Scraplet keeps the original purple paper palette', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('theme', 'light'));
+  await page.goto('/');
+  await waitForHomeActivity(page);
+
+  const fills = await page.locator('[data-scrapbook-pet] [data-paper-creature] svg').evaluate((svg) => {
+    const paths = svg.querySelectorAll('path');
+    return {
+      tail: getComputedStyle(paths[0]).fill,
+      body: getComputedStyle(paths[1]).fill,
+      head: getComputedStyle(paths[2]).fill,
+    };
+  });
+
+  expect(fills).toEqual({
+    tail: 'rgb(183, 173, 191)',
+    body: 'rgb(206, 196, 214)',
+    head: 'rgb(228, 220, 233)',
+  });
+});
+
+test('opening the Atlas does not shift the page when scroll locking', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 760 });
+  await page.goto('/journal');
+
+  const trigger = page.locator('[data-site-atlas-trigger]');
+  await expect(trigger).toBeVisible();
+
+  const before = await page.evaluate(() => {
+    const triggerElement = document.querySelector<HTMLElement>('[data-site-atlas-trigger]');
+    const nav = document.querySelector<HTMLElement>('nav');
+    if (!triggerElement || !nav) throw new Error('Missing Atlas layout instruments');
+    return {
+      triggerRight: triggerElement.getBoundingClientRect().right,
+      navLeft: nav.getBoundingClientRect().left,
+      navWidth: nav.getBoundingClientRect().width,
+    };
+  });
+
+  await trigger.click();
+  await expect(page.locator('[data-site-atlas]')).toBeVisible();
+
+  const after = await page.evaluate(() => {
+    const triggerElement = document.querySelector<HTMLElement>('[data-site-atlas-trigger]');
+    const nav = document.querySelector<HTMLElement>('nav');
+    if (!triggerElement || !nav) throw new Error('Missing Atlas layout instruments');
+    return {
+      triggerRight: triggerElement.getBoundingClientRect().right,
+      navLeft: nav.getBoundingClientRect().left,
+      navWidth: nav.getBoundingClientRect().width,
+      compensation: getComputedStyle(document.body)
+        .getPropertyValue('--removed-body-scroll-bar-size')
+        .trim(),
+    };
+  });
+
+  expect(Math.abs(after.triggerRight - before.triggerRight)).toBeLessThan(1);
+  expect(Math.abs(after.navLeft - before.navLeft)).toBeLessThan(1);
+  expect(Math.abs(after.navWidth - before.navWidth)).toBeLessThan(1);
+  expect(after.compensation).toBe('0px');
+});


### PR DESCRIPTION
## What changed

- make the `Current time` heading use the same monospaced display typeface as the rest of the time instrument
- restore Scraplet's original purple paper palette across every reusable pose
- return the contribution calendar to 28 visible days while preserving GitHub's week-column / weekday-row layout
- keep the calendar cells compact whether the 28-day range spans four or five calendar weeks
- preserve the newly merged paper-counter choreography while reducing the scorecard lift, digit tilt, shadow, and sweeping sheen
- remove the repeated radial glare from the three recent-project cards and replace it with a quieter physical lift
- make the navigation bar exactly 48px including its border, removing the one-pixel homepage overflow
- neutralise Radix's duplicate scrollbar compensation when the Atlas opens because the document already uses `scrollbar-gutter: stable`

## Self-review findings

The tiny homepage scrollbar was not browser noise: the nav contained a 48px child plus a 1px border while page shells subtracted only 48px. The Atlas shift was also real: the stable document gutter and modal scroll-lock compensation were both reserving scrollbar width.

There was no strong reason for the earlier 35-day choice. Twenty-eight days remains a clear four-week data window; alignment padding may produce a fifth partial calendar column, which is the same structural behaviour as GitHub's graph.

Main changed during review with the paper-counter merge (#472). This branch was reset to exact current main `de13a9934dd3b068c5e3cd583f57661a651ce170` and the polish was replayed, so the current counter implementation is preserved rather than overwritten.

## Validation

CI run 575 (`30371882703`) on head `a11ebcdcd5ea478cebf3111728892be7f25b63c1`:

- lint: passed
- typecheck: passed
- unit tests: passed
- production build: passed
- Playwright: passed — 164 passed, 3 skipped, 1 WebKit retry

The single retry was the existing contribution-tooltip click-position assertion in WebKit; its retry passed. The new focused coverage passed for:

- matched current-time heading/value font families
- exactly 28 contribution buttons
- 48px nav height and no stray homepage vertical overflow at 1366×768 and 1440×900
- the restored light-theme purple Scraplet fills
- stable Atlas trigger/nav geometry and zero duplicate scrollbar compensation

Keep this PR draft and unmerged.