### PR TITLE
Replace the glossy scorecard sweep with paper light

### DIFF
--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -44,6 +44,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [finePointer, setFinePointer] = useState(false);
   const previousLatest = useRef(days.at(-1)?.date ?? '');
+  const sectionRef = useRef<HTMLElement | null>(null);
   const hideTimer = useRef<number | null>(null);
   const positionFrame = useRef<number | null>(null);
   const pendingPosition = useRef({ x: 12, y: 12 });
@@ -60,8 +61,6 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     return () => {
       if (hideTimer.current !== null) window.clearTimeout(hideTimer.current);
       if (positionFrame.current !== null) window.cancelAnimationFrame(positionFrame.current);
-      document.documentElement.style.removeProperty('--activity-tooltip-x');
-      document.documentElement.style.removeProperty('--activity-tooltip-y');
     };
   }, []);
 
@@ -93,8 +92,11 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     if (positionFrame.current !== null) return;
     positionFrame.current = window.requestAnimationFrame(() => {
       const { x, y } = pendingPosition.current;
-      document.documentElement.style.setProperty('--activity-tooltip-x', `${x}px`);
-      document.documentElement.style.setProperty('--activity-tooltip-y', `${y}px`);
+      const section = sectionRef.current;
+      if (section) {
+        section.style.setProperty('--activity-tooltip-x', `${x}px`);
+        section.style.setProperty('--activity-tooltip-y', `${y}px`);
+      }
       positionFrame.current = null;
     });
   };
@@ -115,6 +117,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
 
   return (
     <section
+      ref={sectionRef}
       className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-4 [@media(max-height:780px)]:p-3"
       data-home-activity-grid
     >

--- a/components/home/activity-scoreboard.module.css
+++ b/components/home/activity-scoreboard.module.css
@@ -19,25 +19,25 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: min(32rem, 78vw);
-  aspect-ratio: 1;
-  border-radius: 999px;
+  width: min(34rem, 82vw);
+  aspect-ratio: 2.35 / 1;
+  border-radius: 50%;
   background:
     radial-gradient(
-      circle,
-      rgb(var(--paper-raking-light) / 0.3) 0,
-      rgb(var(--paper-raking-light) / 0.13) 24%,
-      transparent 67%
+      ellipse at center,
+      rgb(var(--paper-raking-light) / 0.24) 0,
+      rgb(var(--paper-raking-light) / 0.1) 28%,
+      transparent 72%
     ),
     radial-gradient(
-      circle at 48% 52%,
-      transparent 0 43%,
-      rgb(var(--paper-raking-shadow) / 0.035) 69%,
-      transparent 76%
+      ellipse at 48% 52%,
+      transparent 0 48%,
+      rgb(var(--paper-raking-shadow) / 0.025) 72%,
+      transparent 80%
     );
-  filter: blur(7px);
+  filter: blur(10px);
   mix-blend-mode: soft-light;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%) rotate(-12deg);
 }
 
 .fibreField {
@@ -62,6 +62,7 @@
       transparent 0.86px
     );
   background-size: auto, 17px 19px, 23px 27px;
+  -webkit-mask-image: radial-gradient(circle at 50% 48%, black 0 33%, transparent 74%);
   mask-image: radial-gradient(circle at 50% 48%, black 0 33%, transparent 74%);
   opacity: 0;
   pointer-events: none;
@@ -76,20 +77,20 @@
 .paperCurl {
   position: absolute;
   z-index: 8;
-  bottom: -0.08rem;
-  left: -0.08rem;
-  width: 4.1rem;
-  height: 4.1rem;
-  clip-path: polygon(0 24%, 76% 100%, 0 100%);
+  bottom: -0.06rem;
+  left: -0.06rem;
+  width: 3rem;
+  height: 3rem;
+  clip-path: polygon(0 50%, 50% 100%, 0 100%);
   background:
     linear-gradient(
       36deg,
-      rgb(var(--paper-raking-shadow) / 0.16) 0 5%,
-      rgb(var(--paper-raking-light) / 0.96) 17%,
-      rgb(var(--paper-raking-light) / 0.58) 54%,
-      transparent 55%
+      rgb(var(--paper-raking-shadow) / 0.12) 0 5%,
+      rgb(var(--paper-raking-light) / 0.78) 18%,
+      rgb(var(--paper-raking-light) / 0.36) 50%,
+      transparent 51%
     );
-  filter: drop-shadow(5px -5px 7px rgb(var(--paper-raking-shadow) / 0.13));
+  filter: drop-shadow(3px -3px 5px rgb(var(--paper-raking-shadow) / 0.09));
   opacity: 0;
   pointer-events: none;
   transform-origin: 0 100%;
@@ -100,12 +101,12 @@
 .paperCurl::after {
   content: '';
   position: absolute;
-  bottom: 0.2rem;
-  left: 0.18rem;
-  width: 68%;
+  bottom: 0.16rem;
+  left: 0.14rem;
+  width: 58%;
   height: 1px;
-  background: rgb(var(--paper-fibre-ink) / 0.14);
-  box-shadow: 0 -0.42rem 0 rgb(var(--paper-fibre-ink) / 0.05);
+  background: rgb(var(--paper-fibre-ink) / 0.11);
+  box-shadow: 0 -0.32rem 0 rgb(var(--paper-fibre-ink) / 0.035);
   transform: rotate(35deg);
   transform-origin: left center;
 }
@@ -313,19 +314,19 @@
 
 :global(.dark) .rakingLight {
   mix-blend-mode: screen;
-  opacity: 0.68;
+  opacity: 0.5;
 }
 
 :global(.dark) .paperCurl {
   background:
     linear-gradient(
       36deg,
-      rgb(0 0 0 / 0.4) 0 6%,
-      rgb(var(--paper-raking-light) / 0.16) 19%,
-      rgb(var(--paper-raking-light) / 0.08) 54%,
-      transparent 55%
+      rgb(0 0 0 / 0.18) 0 6%,
+      rgb(var(--paper-raking-light) / 0.12) 19%,
+      rgb(var(--paper-raking-light) / 0.05) 50%,
+      transparent 51%
     );
-  filter: drop-shadow(5px -5px 8px rgb(0 0 0 / 0.34));
+  filter: drop-shadow(3px -3px 6px rgb(0 0 0 / 0.2));
 }
 
 :global(.dark) .counter::before {
@@ -375,12 +376,12 @@
   }
 
   .fibreField {
-    opacity: 0.12;
+    opacity: 0.08;
     transition: none;
   }
 
   .scorecard:hover .fibreField {
-    opacity: 0.12;
+    opacity: 0.08;
   }
 }
 

--- a/components/home/activity-scoreboard.module.css
+++ b/components/home/activity-scoreboard.module.css
@@ -1,3 +1,115 @@
+.scorecard {
+  --paper-raking-light: 255 252 244;
+  --paper-raking-shadow: 72 57 38;
+  --paper-fibre-ink: 78 65 48;
+}
+
+.rakingLightAnchor {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+  will-change: transform, opacity;
+}
+
+.rakingLight {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: min(32rem, 78vw);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background:
+    radial-gradient(
+      circle,
+      rgb(var(--paper-raking-light) / 0.3) 0,
+      rgb(var(--paper-raking-light) / 0.13) 24%,
+      transparent 67%
+    ),
+    radial-gradient(
+      circle at 48% 52%,
+      transparent 0 43%,
+      rgb(var(--paper-raking-shadow) / 0.035) 69%,
+      transparent 76%
+    );
+  filter: blur(7px);
+  mix-blend-mode: soft-light;
+  transform: translate(-50%, -50%);
+}
+
+.fibreField {
+  position: absolute;
+  z-index: 2;
+  inset: -5%;
+  background:
+    repeating-linear-gradient(
+      103deg,
+      transparent 0 17px,
+      rgb(var(--paper-fibre-ink) / 0.028) 17px 18px,
+      transparent 18px 31px
+    ),
+    radial-gradient(
+      circle at 18% 22%,
+      rgb(var(--paper-fibre-ink) / 0.05) 0 0.65px,
+      transparent 0.9px
+    ),
+    radial-gradient(
+      circle at 71% 64%,
+      rgb(var(--paper-fibre-ink) / 0.04) 0 0.6px,
+      transparent 0.86px
+    );
+  background-size: auto, 17px 19px, 23px 27px;
+  mask-image: radial-gradient(circle at 50% 48%, black 0 33%, transparent 74%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms ease-out;
+  will-change: transform, opacity;
+}
+
+.scorecard:hover .fibreField {
+  opacity: 0.72;
+}
+
+.paperCurl {
+  position: absolute;
+  z-index: 8;
+  bottom: -0.08rem;
+  left: -0.08rem;
+  width: 4.1rem;
+  height: 4.1rem;
+  clip-path: polygon(0 24%, 76% 100%, 0 100%);
+  background:
+    linear-gradient(
+      36deg,
+      rgb(var(--paper-raking-shadow) / 0.16) 0 5%,
+      rgb(var(--paper-raking-light) / 0.96) 17%,
+      rgb(var(--paper-raking-light) / 0.58) 54%,
+      transparent 55%
+    );
+  filter: drop-shadow(5px -5px 7px rgb(var(--paper-raking-shadow) / 0.13));
+  opacity: 0;
+  pointer-events: none;
+  transform-origin: 0 100%;
+  transform-style: preserve-3d;
+  will-change: transform, opacity;
+}
+
+.paperCurl::after {
+  content: '';
+  position: absolute;
+  bottom: 0.2rem;
+  left: 0.18rem;
+  width: 68%;
+  height: 1px;
+  background: rgb(var(--paper-fibre-ink) / 0.14);
+  box-shadow: 0 -0.42rem 0 rgb(var(--paper-fibre-ink) / 0.05);
+  transform: rotate(35deg);
+  transform-origin: left center;
+}
+
 .counter {
   position: relative;
   isolation: isolate;
@@ -193,6 +305,29 @@
   will-change: transform, opacity;
 }
 
+:global(.dark) .scorecard {
+  --paper-raking-light: 230 224 238;
+  --paper-raking-shadow: 0 0 0;
+  --paper-fibre-ink: 222 215 230;
+}
+
+:global(.dark) .rakingLight {
+  mix-blend-mode: screen;
+  opacity: 0.68;
+}
+
+:global(.dark) .paperCurl {
+  background:
+    linear-gradient(
+      36deg,
+      rgb(0 0 0 / 0.4) 0 6%,
+      rgb(var(--paper-raking-light) / 0.16) 19%,
+      rgb(var(--paper-raking-light) / 0.08) 54%,
+      transparent 55%
+    );
+  filter: drop-shadow(5px -5px 8px rgb(0 0 0 / 0.34));
+}
+
 :global(.dark) .counter::before {
   background: hsl(var(--border) / 0.9);
   box-shadow:
@@ -233,7 +368,26 @@
     0 2px 5px rgb(0 0 0 / 0.28);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .rakingLightAnchor,
+  .paperCurl {
+    display: none;
+  }
+
+  .fibreField {
+    opacity: 0.12;
+    transition: none;
+  }
+
+  .scorecard:hover .fibreField {
+    opacity: 0.12;
+  }
+}
+
 @media (forced-colors: active) {
+  .rakingLightAnchor,
+  .fibreField,
+  .paperCurl,
   .counter::before,
   .counterShadow,
   .digit::before,

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,8 +1,21 @@
 'use client';
 
 import { ScrapbookPet } from '@/components/home/scrapbook-pet';
-import { motion, useAnimate, useReducedMotion } from 'framer-motion';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  motion,
+  useAnimate,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+} from 'framer-motion';
+import {
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import styles from './activity-scoreboard.module.css';
 
 function countdownToUtcMidnight() {
@@ -239,6 +252,27 @@ export function ActivityScoreboard({
 }) {
   const reduceMotion = useReducedMotion();
   const [countdown, setCountdown] = useState('--:--:--');
+  const pointerX = useMotionValue(0);
+  const pointerY = useMotionValue(0);
+  const lightOpacity = useMotionValue(0);
+  const fibreX = useMotionValue(0);
+  const fibreY = useMotionValue(0);
+  const curlProgress = useMotionValue(0);
+  const smoothPointerX = useSpring(pointerX, { stiffness: 240, damping: 30, mass: 0.55 });
+  const smoothPointerY = useSpring(pointerY, { stiffness: 240, damping: 30, mass: 0.55 });
+  const smoothLightOpacity = useSpring(lightOpacity, {
+    stiffness: 240,
+    damping: 30,
+    mass: 0.5,
+  });
+  const smoothFibreX = useSpring(fibreX, { stiffness: 210, damping: 28, mass: 0.58 });
+  const smoothFibreY = useSpring(fibreY, { stiffness: 210, damping: 28, mass: 0.58 });
+  const smoothCurl = useSpring(curlProgress, { stiffness: 260, damping: 24, mass: 0.48 });
+  const curlOpacity = useTransform(smoothCurl, [0, 0.12, 1], [0, 0.18, 0.96]);
+  const curlScale = useTransform(smoothCurl, [0, 1], [0.74, 1.08]);
+  const curlRotate = useTransform(smoothCurl, [0, 1], [-8, 5]);
+  const curlX = useTransform(smoothCurl, [0, 1], [-8, 0]);
+  const curlY = useTransform(smoothCurl, [0, 1], [8, -1]);
 
   useEffect(() => {
     const update = () => setCountdown(countdownToUtcMidnight());
@@ -246,6 +280,33 @@ export function ActivityScoreboard({
     const interval = window.setInterval(update, 1000);
     return () => window.clearInterval(interval);
   }, []);
+
+  const movePaperLight = (event: ReactPointerEvent<HTMLElement>) => {
+    if (reduceMotion || event.pointerType === 'touch') return;
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+
+    const x = Math.min(rect.width, Math.max(0, event.clientX - rect.left));
+    const y = Math.min(rect.height, Math.max(0, event.clientY - rect.top));
+    const horizontal = x / rect.width;
+    const vertical = y / rect.height;
+    const curlDistance = Math.hypot(horizontal, 1 - vertical);
+
+    pointerX.set(x);
+    pointerY.set(y);
+    lightOpacity.set(1);
+    fibreX.set((horizontal - 0.5) * 9);
+    fibreY.set((vertical - 0.5) * 6);
+    curlProgress.set(Math.max(0, 1 - curlDistance / 0.85));
+  };
+
+  const settlePaperLight = () => {
+    lightOpacity.set(0);
+    fibreX.set(0);
+    fibreY.set(0);
+    curlProgress.set(0);
+  };
 
   return (
     <motion.section
@@ -262,12 +323,39 @@ export function ActivityScoreboard({
       }
       transition={{ type: 'spring', stiffness: 260, damping: 22, mass: 0.72 }}
       style={{ transformPerspective: 1100, transformOrigin: '50% 55%' }}
-      className="group relative flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[border-color,box-shadow] duration-300 hover:border-border hover:shadow-[0_24px_52px_rgba(24,24,26,0.17)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_26px_58px_rgba(0,0,0,0.42)] [@media(max-height:780px)]:min-h-[14.5rem]"
+      onPointerMove={movePaperLight}
+      onPointerLeave={settlePaperLight}
+      onPointerCancel={settlePaperLight}
+      className={`${styles.scorecard} group relative flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[border-color,box-shadow] duration-300 hover:border-border hover:shadow-[0_24px_52px_rgba(24,24,26,0.17)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_26px_58px_rgba(0,0,0,0.42)] [@media(max-height:780px)]:min-h-[14.5rem]`}
       data-activity-scoreboard
+      data-paper-light-motion={reduceMotion ? 'reduced' : 'full'}
     >
-      <span
+      <motion.span
         aria-hidden="true"
-        className="pointer-events-none absolute inset-y-0 -left-[45%] z-20 w-[30%] -skew-x-12 bg-gradient-to-r from-transparent via-white/14 to-transparent opacity-0 transition-[left,opacity] duration-700 ease-out group-hover:left-[120%] group-hover:opacity-100 motion-reduce:hidden dark:via-white/[0.07]"
+        className={styles.rakingLightAnchor}
+        style={{ x: smoothPointerX, y: smoothPointerY, opacity: smoothLightOpacity }}
+        data-paper-raking-light
+      >
+        <span className={styles.rakingLight} />
+      </motion.span>
+      <motion.span
+        aria-hidden="true"
+        className={styles.fibreField}
+        style={{ x: smoothFibreX, y: smoothFibreY }}
+        data-paper-fibres
+      />
+      <motion.span
+        aria-hidden="true"
+        className={styles.paperCurl}
+        style={{
+          x: curlX,
+          y: curlY,
+          scale: curlScale,
+          rotateZ: curlRotate,
+          opacity: curlOpacity,
+          transformPerspective: 620,
+        }}
+        data-paper-curl
       />
 
       <div className="relative z-10 border-b border-border/70 bg-muted/70 px-4 py-2.5 transition-colors duration-300 group-hover:bg-muted/85 [@media(max-height:780px)]:py-2">

--- a/tests/e2e/paper-raking-light.spec.ts
+++ b/tests/e2e/paper-raking-light.spec.ts
@@ -97,26 +97,15 @@ test('reduced motion keeps a static paper texture without tracking the pointer',
   await expect(scoreboard).toHaveAttribute('data-paper-light-motion', 'reduced');
   await scoreboard.hover({ force: true });
 
-  const decoration = await page.evaluate(() => {
-    const lightElement = document.querySelector<HTMLElement>('[data-paper-raking-light]');
-    const fibreElement = document.querySelector<HTMLElement>('[data-paper-fibres]');
-    const curlElement = document.querySelector<HTMLElement>('[data-paper-curl]');
-    if (!lightElement || !fibreElement || !curlElement) {
-      throw new Error('Missing paper-light decoration');
-    }
-    return {
-      lightDisplay: getComputedStyle(lightElement).display,
-      fibreOpacity: Number(getComputedStyle(fibreElement).opacity),
-      curlDisplay: getComputedStyle(curlElement).display,
-    };
-  });
+  const decoration = {
+    lightDisplay: await light.evaluate((element) => getComputedStyle(element).display),
+    fibreOpacity: await fibres.evaluate((element) => Number(getComputedStyle(element).opacity)),
+    curlDisplay: await curl.evaluate((element) => getComputedStyle(element).display),
+  };
 
   expect(decoration.lightDisplay).toBe('none');
-  expect(decoration.fibreOpacity).toBeCloseTo(0.12, 2);
+  expect(decoration.fibreOpacity).toBeCloseTo(0.08, 2);
   expect(decoration.curlDisplay).toBe('none');
-  await expect(light).toBeAttached();
-  await expect(fibres).toBeAttached();
-  await expect(curl).toBeAttached();
 });
 
 test('forced colours removes paper-light decoration', async ({ page }, testInfo) => {

--- a/tests/e2e/paper-raking-light.spec.ts
+++ b/tests/e2e/paper-raking-light.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+function hydratedScoreboard(page: Page) {
+  return page
+    .locator('[data-activity-scoreboard]:visible')
+    .filter({ hasText: /UTC reset \d{2}:\d{2}:\d{2}/ })
+    .last();
+}
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`paper raking light follows the pointer in ${theme} mode`, async ({ page }, testInfo) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.setViewportSize({ width: 1280, height: 760 });
+    await page.addInitScript((selectedTheme) => {
+      window.localStorage.setItem('theme', selectedTheme);
+    }, theme);
+
+    const response = await page.goto('/');
+    expect(response?.ok()).toBe(true);
+
+    const scoreboard = hydratedScoreboard(page);
+    const light = scoreboard.locator('[data-paper-raking-light]');
+    const fibres = scoreboard.locator('[data-paper-fibres]');
+    const curl = scoreboard.locator('[data-paper-curl]');
+    await expect(scoreboard).toBeVisible({ timeout: 15_000 });
+    await expect(scoreboard).toHaveAttribute('data-paper-light-motion', 'full');
+    await expect(light).toBeAttached();
+    await expect(fibres).toBeAttached();
+    await expect(curl).toBeAttached();
+
+    const card = await scoreboard.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    });
+
+    await page.mouse.move(card.x + card.width * 0.16, card.y + card.height * 0.82, {
+      steps: 8,
+    });
+    await expect
+      .poll(() => light.evaluate((element) => Number(getComputedStyle(element).opacity)))
+      .toBeGreaterThan(0.55);
+    await expect
+      .poll(() => fibres.evaluate((element) => Number(getComputedStyle(element).opacity)))
+      .toBeGreaterThan(0.5);
+    await expect
+      .poll(() => curl.evaluate((element) => Number(getComputedStyle(element).opacity)))
+      .toBeGreaterThan(0.25);
+
+    const firstLightTransform = await light.evaluate((element) => getComputedStyle(element).transform);
+    const firstCurlOpacity = await curl.evaluate((element) => Number(getComputedStyle(element).opacity));
+
+    const screenshotDirectory = path.join(
+      'test-results',
+      'scoreboard-appearance',
+      'raking-light',
+      theme,
+      testInfo.project.name,
+    );
+    await mkdir(screenshotDirectory, { recursive: true });
+    await scoreboard.screenshot({
+      path: path.join(screenshotDirectory, 'lower-left.png'),
+      animations: 'allow',
+    });
+
+    await page.mouse.move(card.x + card.width * 0.82, card.y + card.height * 0.24, {
+      steps: 10,
+    });
+    await expect
+      .poll(() => light.evaluate((element) => getComputedStyle(element).transform))
+      .not.toBe(firstLightTransform);
+    await expect
+      .poll(() => curl.evaluate((element) => Number(getComputedStyle(element).opacity)))
+      .toBeLessThan(firstCurlOpacity * 0.5);
+
+    await scoreboard.screenshot({
+      path: path.join(screenshotDirectory, 'upper-right.png'),
+      animations: 'allow',
+    });
+  });
+}
+
+test('reduced motion keeps a static paper texture without tracking the pointer', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    window.localStorage.setItem('theme', 'system');
+  });
+  await page.goto('/');
+
+  const scoreboard = hydratedScoreboard(page);
+  const light = scoreboard.locator('[data-paper-raking-light]');
+  const fibres = scoreboard.locator('[data-paper-fibres]');
+  const curl = scoreboard.locator('[data-paper-curl]');
+  await expect(scoreboard).toBeVisible({ timeout: 15_000 });
+  await expect(scoreboard).toHaveAttribute('data-paper-light-motion', 'reduced');
+  await scoreboard.hover({ force: true });
+
+  const decoration = await page.evaluate(() => {
+    const lightElement = document.querySelector<HTMLElement>('[data-paper-raking-light]');
+    const fibreElement = document.querySelector<HTMLElement>('[data-paper-fibres]');
+    const curlElement = document.querySelector<HTMLElement>('[data-paper-curl]');
+    if (!lightElement || !fibreElement || !curlElement) {
+      throw new Error('Missing paper-light decoration');
+    }
+    return {
+      lightDisplay: getComputedStyle(lightElement).display,
+      fibreOpacity: Number(getComputedStyle(fibreElement).opacity),
+      curlDisplay: getComputedStyle(curlElement).display,
+    };
+  });
+
+  expect(decoration.lightDisplay).toBe('none');
+  expect(decoration.fibreOpacity).toBeCloseTo(0.12, 2);
+  expect(decoration.curlDisplay).toBe('none');
+  await expect(light).toBeAttached();
+  await expect(fibres).toBeAttached();
+  await expect(curl).toBeAttached();
+});
+
+test('forced colours removes paper-light decoration', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Forced-colour emulation is checked in Chromium.');
+
+  await page.emulateMedia({ forcedColors: 'active' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const scoreboard = hydratedScoreboard(page);
+  await expect(scoreboard).toBeVisible({ timeout: 15_000 });
+  for (const selector of ['[data-paper-raking-light]', '[data-paper-fibres]', '[data-paper-curl]']) {
+    await expect
+      .poll(() => scoreboard.locator(selector).evaluate((element) => getComputedStyle(element).display))
+      .toBe('none');
+  }
+});


### PR DESCRIPTION
## Direction

Replaces the scorecard’s broad diagonal glossy sweep with a paper-native pointer response.

## Motion system

Uses Motion values and springs already available in the repository:

- pointer coordinates update Motion values without React rerenders;
- independent springs smooth raking-light position and intensity;
- a second spring pair drifts the revealed paper fibres by a few pixels;
- bottom-left proximity drives a small curled-paper edge;
- the existing card lift and paper-counter turns remain unchanged.

## Visual treatment

- a broad low-angle light follows the pointer beneath the content;
- fibres become visible where the card is being examined;
- the lower-left edge curls only near the pointer and stays deliberately small;
- light and dark themes use separate paper-light, fibre and shadow values;
- reduced motion keeps only a static faint fibre texture;
- forced colours removes all decoration.

## Self-review corrections

- changed the first circular highlight into a wider ellipse after the capture read like a flashlight;
- reduced the first dark curl after it read like lifted vinyl;
- added the WebKit mask prefix so the fibre reveal agrees across engines;
- anchored visual assertions to the hydrated scorecard;
- fixed a real Suspense ownership bug in the activity tooltip: coordinate variables now live on each grid section rather than `document.documentElement`, so a departing grid cannot erase the active grid’s position.

## Behaviour fence

- no activity data, refresh, layout, content or navigation changes;
- no new dependency;
- no pointer state stored in React;
- no effect for touch pointers;
- the paper counter and Scraplet behaviour remain intact.

## Visual review

Reviewed lower-left and upper-right pointer positions in light and dark mode with Chromium and WebKit:

- the light remains broad and quiet rather than spotlight-like;
- fibres stay behind digits, metrics and borders;
- the curl reads as a small paper edge rather than a separate object;
- dark mode keeps the effect visible without becoming luminous;
- reduced-motion and forced-colour fallbacks remain clean.

## Validation

[CI run 577](https://github.com/teamleaderleo/scrapbook/actions/runs/30373105835) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- **164 passed, four intentional skips, zero retries**.

Scoreboard appearance evidence: `sha256:18c8522060985e4798518c56daac0831ac3cf5b7646d1cb07d16eea0fecf34f4`.
Playwright log: `sha256:bc56f2db41e603246464cf8b918ed35fd8f12f11cf2e6e66a220b97389de8b2a`.

Ready to merge.