### PR TITLE
Turn activity days into tactile paper marks

### DIFF
--- a/components/home/activity-grid.module.css
+++ b/components/home/activity-grid.module.css
@@ -1,0 +1,180 @@
+.paperMark {
+  --paper-mark-angle: 0deg;
+  --paper-mark-shift-x: 0px;
+  --paper-mark-shift-y: 0px;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-radius: 0.34rem 0.42rem 0.37rem 0.31rem;
+  color: hsl(var(--foreground));
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.28),
+    inset 0 -1px 0 hsl(var(--foreground) / 0.045),
+    0 2px 5px rgb(62 49 34 / 0.08);
+  transform: translate(var(--paper-mark-shift-x), var(--paper-mark-shift-y))
+    rotate(var(--paper-mark-angle));
+  transform-origin: 50% 58%;
+  transition:
+    transform 180ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    filter 160ms ease-out,
+    box-shadow 180ms ease-out;
+  will-change: transform;
+}
+
+.paperMark::before,
+.paperMark::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.paperMark::before {
+  z-index: 1;
+  background:
+    repeating-linear-gradient(
+      104deg,
+      transparent 0 7px,
+      hsl(var(--foreground) / 0.032) 7px 8px,
+      transparent 8px 13px
+    ),
+    radial-gradient(
+      circle at 23% 24%,
+      hsl(var(--foreground) / 0.08) 0 0.45px,
+      transparent 0.75px
+    ),
+    radial-gradient(
+      circle at 71% 68%,
+      hsl(var(--foreground) / 0.055) 0 0.4px,
+      transparent 0.7px
+    );
+  background-size: auto, 9px 11px, 13px 15px;
+  mix-blend-mode: multiply;
+  opacity: 0.42;
+}
+
+.paperMark::after {
+  z-index: 2;
+  inset: -18%;
+  border-radius: 46% 54% 49% 51%;
+  background:
+    radial-gradient(
+      circle at 49% 52%,
+      hsl(var(--foreground) / 0.15) 0 5%,
+      hsl(var(--foreground) / 0.075) 18%,
+      transparent 58%
+    );
+  filter: blur(1.5px);
+  opacity: 0;
+  transform: scale(0.38) rotate(-7deg);
+  transition:
+    opacity 150ms ease-out,
+    transform 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.paperMark:hover,
+.paperMark:focus-visible {
+  z-index: 10;
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.34),
+    inset 0 -1px 0 hsl(var(--foreground) / 0.055),
+    0 9px 17px rgb(58 45 31 / 0.16);
+  transform: translate(var(--paper-mark-shift-x), calc(var(--paper-mark-shift-y) - 0.2rem))
+    rotate(calc(var(--paper-mark-angle) * 0.34)) scale(1.085);
+}
+
+.paperMark:hover::after,
+.paperMark:focus-visible::after {
+  opacity: 0.23;
+  transform: scale(1) rotate(0deg);
+}
+
+.paperMark[aria-pressed='true'] {
+  box-shadow:
+    inset 0 1px 2px hsl(var(--foreground) / 0.08),
+    inset 0 -1px 0 rgb(255 255 255 / 0.2),
+    0 3px 7px rgb(58 45 31 / 0.09);
+}
+
+.paperMark[aria-pressed='true']::after {
+  opacity: 0.12;
+  transform: scale(0.82) rotate(2deg);
+}
+
+.paperMark[aria-pressed='true']:hover::after,
+.paperMark[aria-pressed='true']:focus-visible::after {
+  opacity: 0.26;
+  transform: scale(1) rotate(0deg);
+}
+
+:global(.dark) .paperMark {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.075),
+    inset 0 -1px 0 rgb(0 0 0 / 0.2),
+    0 3px 7px rgb(0 0 0 / 0.22);
+}
+
+:global(.dark) .paperMark::before {
+  mix-blend-mode: screen;
+  opacity: 0.28;
+}
+
+:global(.dark) .paperMark::after {
+  background:
+    radial-gradient(
+      circle at 49% 52%,
+      hsl(var(--foreground) / 0.18) 0 5%,
+      hsl(var(--foreground) / 0.075) 19%,
+      transparent 59%
+    );
+  mix-blend-mode: screen;
+}
+
+:global(.dark) .paperMark:hover,
+:global(.dark) .paperMark:focus-visible {
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.1),
+    inset 0 -1px 0 rgb(0 0 0 / 0.22),
+    0 10px 20px rgb(0 0 0 / 0.38);
+}
+
+:global(.dark) .paperMark[aria-pressed='true'] {
+  box-shadow:
+    inset 0 1px 3px rgb(0 0 0 / 0.28),
+    inset 0 -1px 0 rgb(255 255 255 / 0.045),
+    0 3px 8px rgb(0 0 0 / 0.24);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .paperMark,
+  .paperMark::after {
+    transition: none;
+  }
+
+  .paperMark:hover,
+  .paperMark:focus-visible {
+    transform: translate(var(--paper-mark-shift-x), var(--paper-mark-shift-y))
+      rotate(var(--paper-mark-angle));
+  }
+}
+
+@media (forced-colors: active) {
+  .paperMark {
+    border: 1px solid CanvasText;
+    background: Canvas;
+    color: CanvasText;
+    box-shadow: none;
+    forced-color-adjust: auto;
+  }
+
+  .paperMark::before,
+  .paperMark::after {
+    display: none;
+  }
+
+  .paperMark:hover,
+  .paperMark:focus-visible,
+  .paperMark[aria-pressed='true'] {
+    box-shadow: none;
+  }
+}

--- a/components/home/activity-grid.module.css
+++ b/components/home/activity-grid.module.css
@@ -1,5 +1,6 @@
 .paperMark {
   --paper-mark-angle: 0deg;
+  --paper-mark-hover-angle: 0deg;
   --paper-mark-shift-x: 0px;
   --paper-mark-shift-y: 0px;
   position: relative;
@@ -80,7 +81,7 @@
     inset 0 -1px 0 hsl(var(--foreground) / 0.055),
     0 9px 17px rgb(58 45 31 / 0.16);
   transform: translate(var(--paper-mark-shift-x), calc(var(--paper-mark-shift-y) - 0.2rem))
-    rotate(calc(var(--paper-mark-angle) * 0.34)) scale(1.085);
+    rotate(var(--paper-mark-hover-angle)) scale(1.085);
 }
 
 .paperMark:hover::after,

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { alignContributionDaysToWeekColumns } from '@/lib/github-activity-utils';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
+import styles from './activity-grid.module.css';
 
 export type ActivityGridDay = {
   date: string;
@@ -9,6 +10,14 @@ export type ActivityGridDay = {
 };
 
 const WEEKDAY_LABELS = ['Sun', '', 'Tue', '', 'Thu', '', 'Sat'] as const;
+const PAPER_MARK_ANGLES = [-1.15, 0.58, -0.42, 0.92, 0.18, -0.74, 0.46] as const;
+const PAPER_MARK_SHIFTS = [
+  [-0.35, 0.15],
+  [0.2, -0.2],
+  [0.35, 0.25],
+  [-0.15, -0.1],
+  [0.1, 0.3],
+] as const;
 
 function formatDay(date: string): string {
   return new Intl.DateTimeFormat('en-GB', {
@@ -159,6 +168,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
           }}
           aria-label="GitHub contribution calendar for the last 35 days"
           data-contribution-week-grid
+          data-paper-activity-grid
         >
           {gridDays.map((day, index) => {
             const gridColumn = Math.floor(index / 7) + 1;
@@ -178,17 +188,26 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
             const label = labelForDay(day, unit);
             const isSelected = day.date === selected?.date;
             const isLatest = day.date === days.at(-1)?.date;
-            const tilt = index % 2 === 0 ? 'hover:rotate-[1.5deg]' : 'hover:-rotate-[1.5deg]';
+            const angle = PAPER_MARK_ANGLES[index % PAPER_MARK_ANGLES.length];
+            const [shiftX, shiftY] = PAPER_MARK_SHIFTS[index % PAPER_MARK_SHIFTS.length];
+            const markStyle = {
+              gridColumn,
+              gridRow,
+              '--paper-mark-angle': `${angle}deg`,
+              '--paper-mark-shift-x': `${shiftX}px`,
+              '--paper-mark-shift-y': `${shiftY}px`,
+            } as CSSProperties;
 
             return (
               <button
                 key={day.date}
                 type="button"
-                className={`relative aspect-square min-w-0 rounded-[0.38rem] transition-[transform,filter,box-shadow] duration-150 ease-out will-change-transform hover:z-10 hover:-translate-y-1 hover:scale-[1.12] hover:shadow-[0_14px_24px_rgba(35,31,26,0.2)] focus-visible:z-10 focus-visible:-translate-y-1 focus-visible:scale-[1.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:shadow-[0_16px_28px_rgba(0,0,0,0.44)] ${tilt} ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
-                style={{ gridColumn, gridRow }}
+                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
+                style={markStyle}
                 aria-label={label}
                 aria-pressed={isSelected}
                 data-contribution-date={day.date}
+                data-paper-activity-mark
                 onPointerEnter={(event) => {
                   setSelectedDate(day.date);
                   showTooltip(day.date, event.clientX, event.clientY);

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -194,6 +194,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
               gridColumn,
               gridRow,
               '--paper-mark-angle': `${angle}deg`,
+              '--paper-mark-hover-angle': `${angle * 0.34}deg`,
               '--paper-mark-shift-x': `${shiftX}px`,
               '--paper-mark-shift-y': `${shiftY}px`,
             } as CSSProperties;

--- a/tests/e2e/activity-paper-marks.spec.ts
+++ b/tests/e2e/activity-paper-marks.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+function hydratedActivitySection(page: Page) {
+  return page
+    .locator('[data-home-activity-dashboard]:visible')
+    .filter({ hasText: /UTC reset \d{2}:\d{2}:\d{2}/ })
+    .last()
+    .locator('[data-home-activity-grid]');
+}
+
+for (const theme of ['light', 'dark'] as const) {
+  test(`activity days behave like paper marks in ${theme} mode`, async ({ page }, testInfo) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.setViewportSize({ width: 1280, height: 760 });
+    await page.addInitScript((selectedTheme) => {
+      window.localStorage.setItem('theme', selectedTheme);
+    }, theme);
+
+    const response = await page.goto('/');
+    expect(response?.ok()).toBe(true);
+
+    const section = hydratedActivitySection(page);
+    const grid = section.locator('[data-paper-activity-grid]');
+    const marks = grid.locator('[data-paper-activity-mark]');
+    await expect(section).toBeVisible({ timeout: 15_000 });
+    await expect(grid).toBeVisible();
+    await expect(marks).toHaveCount(35);
+
+    const mark = marks.nth(8);
+    const resting = await mark.evaluate((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    });
+    expect(resting.width).toBeGreaterThan(20);
+    expect(resting.height).toBeGreaterThan(20);
+
+    await mark.hover();
+    await expect(mark).toHaveAttribute('aria-pressed', 'true');
+    await expect
+      .poll(() =>
+        mark.evaluate((element) => Number(getComputedStyle(element, '::after').opacity)),
+      )
+      .toBeGreaterThan(0.2);
+    await expect
+      .poll(() =>
+        mark.evaluate((element, restingY) => {
+          const rect = element.getBoundingClientRect();
+          return restingY - rect.y;
+        }, resting.y),
+      )
+      .toBeGreaterThan(1.5);
+
+    const directory = path.join(
+      'test-results',
+      'homepage-density',
+      'activity-paper-marks',
+      theme,
+      testInfo.project.name,
+    );
+    await mkdir(directory, { recursive: true });
+    await section.screenshot({
+      path: path.join(directory, 'hover.png'),
+      animations: 'allow',
+    });
+  });
+}
+
+test('activity paper marks stay planted with reduced motion', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    window.localStorage.setItem('theme', 'system');
+  });
+  await page.goto('/');
+
+  const section = hydratedActivitySection(page);
+  const mark = section.locator('[data-paper-activity-mark]').nth(8);
+  await expect(mark).toBeVisible({ timeout: 15_000 });
+  const before = await mark.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+
+  await mark.hover({ force: true });
+  await page.waitForTimeout(250);
+  const after = await mark.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+
+  expect(Math.abs(after.x - before.x)).toBeLessThan(0.75);
+  expect(Math.abs(after.y - before.y)).toBeLessThan(0.75);
+  expect(Math.abs(after.width - before.width)).toBeLessThan(0.75);
+  expect(Math.abs(after.height - before.height)).toBeLessThan(0.75);
+  await expect
+    .poll(() => mark.evaluate((element) => getComputedStyle(element).transitionDuration))
+    .toBe('0s');
+});
+
+test('forced colours removes paper mark decoration', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Forced-colour emulation is checked in Chromium.');
+
+  await page.emulateMedia({ forcedColors: 'active' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const section = hydratedActivitySection(page);
+  const mark = section.locator('[data-paper-activity-mark]').nth(8);
+  await expect(mark).toBeVisible({ timeout: 15_000 });
+  const decoration = await mark.evaluate((element) => ({
+    before: getComputedStyle(element, '::before').display,
+    after: getComputedStyle(element, '::after').display,
+    border: getComputedStyle(element).borderStyle,
+  }));
+
+  expect(decoration.before).toBe('none');
+  expect(decoration.after).toBe('none');
+  expect(decoration.border).not.toBe('none');
+});


### PR DESCRIPTION
## Direction

Makes the 35-day activity grid feel assembled from small pressed or pasted paper marks while preserving the existing data, colour scale and footprint.

## Paper marks

- gives each day a deterministic slight angle and sub-pixel placement offset;
- adds faint paper fibres and edge depth without changing the contribution palette;
- replaces the larger tile-like hover with a smaller lift and scale;
- reveals a restrained ink bloom while a day is inspected;
- keeps the selected day gently pressed after pointer, keyboard or click selection;
- preserves the latest-day outline, tooltip, focus ring and mobile selected-day label.

## Self-review corrections

- replaced unsupported CSS angle multiplication with an explicit per-cell hover-angle variable before CI;
- kept the variation deterministic so refreshes do not shuffle the visual arrangement;
- left every information-bearing colour, label and selection semantic untouched;
- scoped the new treatment to a CSS module rather than widening the homepage motion vocabulary.

## Accessibility and motion

- reduced motion keeps the static paper variation and removes hover displacement;
- forced colours removes fibres and ink decoration, restores a system border and keeps selection semantics;
- no information is encoded only by texture or motion.

## Behaviour fence

- no data fetching, refresh cadence, dates, labels or selection logic changes;
- no grid dimensions or breakpoint changes;
- no new dependency.

## Visual review

Reviewed hovered activity sections in light and dark mode with Chromium and WebKit plus full-page density captures:

- the grid remains quiet at normal homepage scale;
- slight angles and fibre detail read as paper pieces in the close view;
- the ink bloom stays inside the inspected mark;
- dark mode remains muted rather than luminous;
- selected/latest outlines and tooltips remain clear;
- no layout shift or overflow appeared.

## Validation

[CI run 579](https://github.com/teamleaderleo/scrapbook/actions/runs/30374235048) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- **171 passed, five intentional skips, zero retries**.

Homepage and paper-mark evidence: `sha256:d3541c02ed630d75656a61e76dce1f9ab96bbbffcfd6645794faa8aaf524d3e4`.
Playwright log: `sha256:66a052905756a23abefbb02ebb4e88c7172a77e59806f681ba3f3169d1eeac13`.

Ready to merge.