### PR TITLE
Add a subtle cozy tactile pass

### DIFF
--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -1,3 +1,4 @@
+import { PageCurl, PressedSprig, StitchedRule } from '@/components/cozy-flourishes';
 import { PaperCreature } from '@/components/paper-creature';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import {
@@ -58,7 +59,9 @@ export default function AgentJournalPage() {
       />
 
       <main className="relative mx-auto w-full max-w-5xl px-4 py-6 sm:px-6 sm:py-10 lg:px-8">
-        <header className="overflow-hidden rounded-[1.4rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.1)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.32)]">
+        <header className="relative overflow-hidden rounded-[1.4rem] border border-border/70 bg-card text-card-foreground shadow-[0_24px_60px_rgba(24,24,26,0.1)] dark:shadow-[0_26px_70px_rgba(0,0,0,0.32)]">
+          <PressedSprig className="absolute right-4 top-2 hidden rotate-[10deg] opacity-20 sm:block" />
+          <PageCurl className="opacity-60" />
           <div className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,0.42fr)] lg:items-end">
             <div>
               <span className="material-label-stamped text-[9px] text-muted-foreground">repository-backed record</span>
@@ -88,7 +91,8 @@ export default function AgentJournalPage() {
                   </p>
                 </div>
               </div>
-              <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 border-t border-dashed border-black/10 pt-3 font-mono text-[9px] font-semibold uppercase tracking-[0.12em]">
+              <StitchedRule className="mt-3" />
+              <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 font-mono text-[9px] font-semibold uppercase tracking-[0.12em]">
                 <a
                   href="/api/agent-journal"
                   className="rounded-sm opacity-65 underline decoration-current/35 underline-offset-4 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -110,6 +114,7 @@ export default function AgentJournalPage() {
                   Guestbook
                 </Link>
               </div>
+              <PageCurl className="h-6 w-6 opacity-60 [&>span]:h-6 [&>span]:w-6" />
             </div>
           </div>
         </header>
@@ -128,14 +133,19 @@ export default function AgentJournalPage() {
               Open each folder for evidence
             </p>
           </div>
+          <StitchedRule className="mt-3" />
 
-          <ol className="mt-3 grid gap-4">
+          <ol className="mt-4 grid gap-4">
             {agentJournalEntries.map((entry, index) => (
               <li key={entry.id} data-journal-entry={entry.id}>
-                <article className="relative overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground shadow-[0_12px_34px_rgba(24,24,26,0.08)] dark:shadow-[0_14px_38px_rgba(0,0,0,0.26)]">
+                <article className="relative overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground shadow-[0_12px_34px_rgba(24,24,26,0.08)] transition-[transform,box-shadow] duration-150 hover:-rotate-[0.06deg] hover:shadow-[0_16px_40px_rgba(24,24,26,0.11)] dark:shadow-[0_14px_38px_rgba(0,0,0,0.26)]">
                   <div
                     aria-hidden="true"
                     className="absolute inset-y-0 left-0 w-1.5 bg-[#9baa88]"
+                  />
+                  <span
+                    aria-hidden="true"
+                    className="absolute right-4 top-0 h-3 w-9 -translate-y-1/2 rotate-[2deg] border border-[#9d8764]/20 bg-[#d9c795]/55 opacity-70"
                   />
                   <div className="grid min-w-0 gap-5 p-4 pl-6 sm:p-5 sm:pl-7 lg:grid-cols-[minmax(0,1fr)_15rem]">
                     <div className="min-w-0">
@@ -212,7 +222,7 @@ export default function AgentJournalPage() {
                   <details className="group border-t border-dashed border-border/70 bg-background/32" data-journal-provenance>
                     <summary className="cursor-pointer list-none px-6 py-3 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground marker:hidden hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
                       <span className="inline-flex items-center gap-2">
-                        <span aria-hidden="true" className="inline-block w-3 text-center group-open:rotate-90">
+                        <span aria-hidden="true" className="inline-block w-3 text-center transition-transform group-open:rotate-90">
                           ▸
                         </span>
                         Open evidence folder
@@ -244,6 +254,7 @@ export default function AgentJournalPage() {
                       </ul>
                     </div>
                   </details>
+                  <PageCurl className="h-6 w-6 opacity-50 [&>span]:h-6 [&>span]:w-6" />
                 </article>
               </li>
             ))}

--- a/components/cozy-flourishes.tsx
+++ b/components/cozy-flourishes.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export function PageCurl({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'pointer-events-none absolute bottom-0 right-0 h-8 w-8 overflow-hidden rounded-tl-[1.15rem]',
+        className,
+      )}
+    >
+      <span className="absolute bottom-[-1px] right-[-1px] h-8 w-8 bg-[linear-gradient(135deg,transparent_0_49%,hsl(var(--material-paper-edge)/0.3)_50%_54%,hsl(var(--material-paper-face))_55%)] shadow-[-3px_-3px_8px_hsl(var(--material-steel-shadow)/0.08)]" />
+    </span>
+  );
+}
+
+export function StitchedRule({ className }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'block h-px w-full opacity-55 [background-image:repeating-linear-gradient(90deg,hsl(var(--material-paper-edge)/0.9)_0_4px,transparent_4px_8px)]',
+        className,
+      )}
+    />
+  );
+}
+
+export function PressedSprig({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 64 88"
+      className={cn('pointer-events-none h-20 w-14 text-[#8f9b78] opacity-55 dark:text-[#aeb899]', className)}
+      fill="none"
+    >
+      <path d="M31 82C30 58 35 34 50 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M35 58c-12-1-19-7-22-17 11 0 19 5 22 17Z" fill="currentColor" fillOpacity="0.32" stroke="currentColor" strokeWidth="1" />
+      <path d="M40 43c9-4 15-11 16-21-9 2-15 9-16 21Z" fill="currentColor" fillOpacity="0.28" stroke="currentColor" strokeWidth="1" />
+      <path d="M31 69c-8-2-14-7-17-15 8 0 14 5 17 15Z" fill="currentColor" fillOpacity="0.22" stroke="currentColor" strokeWidth="1" />
+      <circle cx="50" cy="9" r="4" fill="#c9928d" fillOpacity="0.6" />
+      <circle cx="44" cy="16" r="2.5" fill="#d2aa75" fillOpacity="0.65" />
+    </svg>
+  );
+}
+
+export function CozyNote({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <aside
+      className={cn(
+        'material-paper relative overflow-hidden rounded-lg border px-3 py-2.5 text-left shadow-[0_5px_14px_rgba(52,45,36,0.09)]',
+        className,
+      )}
+    >
+      <span className="material-tape-strip !left-4 !top-[-0.38rem] !w-8 !translate-x-0 !rotate-[-3deg]" data-side="top" aria-hidden="true" />
+      <p className="font-mono text-[8px] font-bold uppercase tracking-[0.15em] opacity-55">{label}</p>
+      <p className="mt-1 text-[11px] leading-4 opacity-75">{children}</p>
+      <PageCurl className="h-5 w-5 opacity-75 [&>span]:h-5 [&>span]:w-5" />
+    </aside>
+  );
+}

--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from 'next/navigation';
 import { CodeDisplay } from './code-display';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { PaperCreature } from '@/components/paper-creature';
+import { PageCurl, PressedSprig, StitchedRule } from '@/components/cozy-flourishes';
 
 export function ResultsClient({
   items,
@@ -55,6 +56,7 @@ export function ResultsClient({
     return (
       <section className="material-paper relative mx-auto mt-8 max-w-xl overflow-hidden rounded-2xl border px-6 py-10 text-center">
         <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+        <PressedSprig className="absolute right-5 top-5 rotate-[8deg] opacity-25" />
         <PaperCreature
           pose="carrying"
           size="lg"
@@ -65,6 +67,9 @@ export function ResultsClient({
         <p className="mx-auto mt-2 max-w-sm text-sm leading-6 opacity-70">
           Try another label or search. Scraplet will keep looking through the paper scraps.
         </p>
+        <StitchedRule className="mx-auto mt-5 max-w-44" />
+        <p className="mt-3 font-mono text-[9px] uppercase tracking-[0.14em] opacity-45">drawer checked twice</p>
+        <PageCurl className="opacity-65" />
       </section>
     );
   }
@@ -131,6 +136,10 @@ function Row({
       <span
         aria-hidden="true"
         className="absolute left-0 top-4 h-11 w-1.5 rounded-r-full bg-[#9baa88] shadow-[inset_-1px_0_rgba(75,82,67,0.22)]"
+      />
+      <span
+        aria-hidden="true"
+        className="absolute right-5 top-0 h-2.5 w-8 -translate-y-1/2 rotate-[2deg] border border-[#9d8764]/20 bg-[#d9c795]/50 opacity-0 transition-opacity group-hover:opacity-70"
       />
 
       <div
@@ -213,6 +222,7 @@ function Row({
 
       {expanded ? (
         <div className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] bg-white/[0.14] p-4 dark:bg-black/5">
+          <StitchedRule className="mb-3" />
           {item.versions.length > 1 ? (
             <div className="mb-3 flex flex-wrap gap-2 text-xs">
               {item.versions.map((version, index) => (
@@ -287,6 +297,7 @@ function Row({
         </div>
       ) : null}
 
+      <PageCurl className="h-6 w-6 opacity-55 [&>span]:h-6 [&>span]:w-6" />
       <span className="material-paper-edge" aria-hidden="true" />
     </li>
   );

--- a/components/time-conversion-visualizer.tsx
+++ b/components/time-conversion-visualizer.tsx
@@ -5,6 +5,7 @@ import TimezoneSelector from './timezone-selector';
 import CurrentTimeDisplay from './current-time-display';
 import { isDSTActive } from '@/app/lib/dst-utils';
 import { PaperCreature } from '@/components/paper-creature';
+import { CozyNote, PageCurl, PressedSprig, StitchedRule } from '@/components/cozy-flourishes';
 
 const DAY_GRADIENT =
   'linear-gradient(90deg, #151720 0%, #252938 9%, #493f55 18%, #715767 28%, #9f6f68 38%, #bd916c 46%, #c9a574 50%, #bd916c 56%, #9f6f68 64%, #715767 73%, #493f55 82%, #252938 91%, #151720 100%)';
@@ -65,11 +66,21 @@ export default function UTCTimeVisualizer() {
         : timeOfDay === 'Afternoon'
           ? 'carrying'
           : 'reading';
+  const deskNote =
+    timeOfDay === 'Night'
+      ? 'The clocks are whispering. Keep the lamp low.'
+      : timeOfDay === 'Morning'
+        ? 'Fresh page, warm mug, plenty of daylight.'
+        : timeOfDay === 'Afternoon'
+          ? 'A good hour for pencils and small decisions.'
+          : 'One last page while the room turns golden.';
 
   return (
     <div className="mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-6xl items-start px-4 py-4 sm:px-6 sm:py-8 lg:px-8">
       <div className="relative w-full overflow-hidden rounded-[1.5rem] border border-border/70 bg-card/94 p-4 text-card-foreground shadow-[0_22px_58px_rgba(24,24,26,0.11)] dark:shadow-[0_24px_64px_rgba(0,0,0,0.32)] sm:p-7">
         <span className="material-tape-strip" data-side="top" aria-hidden="true" />
+        <PressedSprig className="absolute right-4 top-20 hidden rotate-[8deg] opacity-20 lg:block" />
+        <PageCurl className="opacity-65" />
         <div
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 opacity-35 dark:opacity-10"
@@ -83,7 +94,7 @@ export default function UTCTimeVisualizer() {
         <div className="relative">
           <div className="flex items-start justify-between gap-4">
             <CurrentTimeDisplay onJumpToTime={setLocalTime} />
-            <div className="hidden text-center sm:block">
+            <div className="hidden w-40 text-center sm:block">
               <PaperCreature
                 pose={scrapletPose}
                 size="lg"
@@ -92,6 +103,9 @@ export default function UTCTimeVisualizer() {
               <p className="mt-1 font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                 {timeOfDay} desk
               </p>
+              <CozyNote label="desk note" className="mt-3 rotate-[0.6deg]">
+                {deskNote}
+              </CozyNote>
             </div>
           </div>
 
@@ -109,6 +123,7 @@ export default function UTCTimeVisualizer() {
               </label>
               <span className="material-label-stamped text-[9px] text-muted-foreground">{timeOfDay}</span>
             </div>
+            <StitchedRule className="mb-3" />
             <input
               id="time-of-day"
               type="range"
@@ -135,7 +150,7 @@ export default function UTCTimeVisualizer() {
             aria-label="Time comparisons"
             className="mt-6 grid grid-cols-2 gap-3 sm:mt-7 sm:grid-cols-4"
           >
-            <div className="material-paper col-span-2 rounded-xl border p-4 sm:col-span-1">
+            <div className="material-paper relative col-span-2 overflow-hidden rounded-xl border p-4 sm:col-span-1">
               <p className="font-mono text-[10px] uppercase tracking-[0.15em] opacity-65">Local</p>
               <p className="mt-1 font-mono text-3xl font-semibold tabular-nums tracking-[-0.03em]">
                 {formatTime(localHours, localMinutes)}
@@ -144,6 +159,7 @@ export default function UTCTimeVisualizer() {
                 {formatTime12Hour(localHours, localMinutes)} {period} ·{' '}
                 {formatOffset(localOffsetMinutes)}
               </p>
+              <PageCurl className="h-6 w-6 opacity-65 [&>span]:h-6 [&>span]:w-6" />
             </div>
             <TimeCard label="UTC" time={formatTime(utcHours, utcMinutes)} offset="UTC±00:00" />
             <TimeCard
@@ -165,10 +181,11 @@ export default function UTCTimeVisualizer() {
 
 function TimeCard({ label, time, offset }: { label: string; time: string; offset: string }) {
   return (
-    <div className="material-paper rounded-xl border p-3">
+    <div className="material-paper relative overflow-hidden rounded-xl border p-3 transition-transform duration-150 hover:-rotate-[0.2deg]">
       <p className="font-mono text-[10px] uppercase tracking-[0.15em] opacity-65">{label}</p>
       <p className="mt-1 font-mono text-2xl font-semibold tabular-nums">{time}</p>
       <p className="mt-1 font-mono text-[10px] tabular-nums opacity-65">{offset}</p>
+      <PageCurl className="h-5 w-5 opacity-55 [&>span]:h-5 [&>span]:w-5" />
     </div>
   );
 }


### PR DESCRIPTION
## What changed

- adds reusable page-curl, stitched-rule, pressed-sprig, and tiny desk-note flourishes
- gives the Time converter a day-part note from Scraplet and softer paper-card details
- gives Journal headers and records a more handled, archival feel
- gives Space cards and empty states small drawer-and-clipping details

## Design rules

- decorative details stay pointer-free and aria-hidden
- no existing controls or information hierarchy are removed
- motion remains limited to the existing creature and hover behaviours
- flourishes are sparse enough to keep the product usable rather than themed to excess

## Validation

CI requested for lint, typecheck, unit tests, production build, and browser regressions.