### PR TITLE
Restore homepage and timezone regressions

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
         today: activity.today,
         weekTotal: activity.weekTotal,
         yearTotal: activity.periodLabel === 'last year' ? activity.total : null,
-        days: activity.days.slice(-35),
+        days: activity.days.slice(-28),
         diagnostics,
       },
       { headers },

--- a/app/dialog-scroll-lock.css
+++ b/app/dialog-scroll-lock.css
@@ -1,0 +1,16 @@
+@supports (scrollbar-gutter: stable) {
+  body[data-scroll-locked],
+  .with-scroll-bars-hidden {
+    --removed-body-scroll-bar-size: 0px !important;
+    margin-right: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .right-scroll-bar-position {
+    right: 0 !important;
+  }
+
+  .width-before-scroll-bar {
+    margin-right: 0 !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import '@/app/globals.css';
 import '@/app/materials.css';
 import '@/app/materials-accessibility.css';
 import '@/app/navigation-feedback.css';
+import '@/app/dialog-scroll-lock.css';
 import { inter } from '@/components/ui/assets/fonts';
 import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,7 +81,7 @@ function HomeActivityFallback() {
 async function HomeActivityContent() {
   await connection();
   const activity = await getGitHubHomeData();
-  const days = activity.days.slice(-35);
+  const days = activity.days.slice(-28);
   const yearTotal = activity.periodLabel === 'last year' ? activity.total : null;
 
   return (

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -48,6 +48,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   const maximum = Math.max(...days.map((day) => day.count), 0);
   const gridDays = useMemo(() => alignContributionDaysToWeekColumns(days), [days]);
   const weekCount = Math.max(1, gridDays.length / 7);
+  const calendarMaxWidthRem = 2.3 + weekCount * 3.5;
   const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
   const [tooltipDate, setTooltipDate] = useState<string | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
@@ -129,10 +130,11 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
       ref={sectionRef}
       className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_16px_38px_rgba(35,31,26,0.1)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-4 [@media(max-height:780px)]:p-3"
       data-home-activity-grid
+      data-fine-pointer={finePointer ? 'true' : 'false'}
     >
       <div className="flex items-center justify-between gap-4">
         <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          35 days · UTC
+          28 days · UTC
         </span>
         <div
           className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
@@ -148,7 +150,10 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div className="mx-auto mt-3 grid w-full max-w-[25rem] grid-cols-[1.65rem_minmax(0,1fr)] gap-2 sm:gap-2.5 [@media(max-height:780px)]:mt-2 [@media(max-height:780px)]:max-w-[22rem]">
+      <div
+        className="mx-auto mt-3 grid w-full grid-cols-[1.65rem_minmax(0,1fr)] gap-2 sm:gap-2.5 [@media(max-height:780px)]:mt-2"
+        style={{ maxWidth: `min(100%, ${calendarMaxWidthRem}rem)` }}
+      >
         <div
           className="grid grid-rows-7 gap-1.5 py-px font-mono text-[8px] font-medium text-muted-foreground sm:gap-2"
           aria-hidden="true"
@@ -166,7 +171,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
             gridTemplateColumns: `repeat(${weekCount}, minmax(0, 1fr))`,
             gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
           }}
-          aria-label="GitHub contribution calendar for the last 35 days"
+          aria-label="GitHub contribution calendar for the last 28 days"
           data-contribution-week-grid
           data-paper-activity-grid
         >

--- a/components/paper-creature.tsx
+++ b/components/paper-creature.tsx
@@ -58,11 +58,12 @@ export function PaperCreature({
           : { duration: sleeping ? 3.6 : 2.8, repeat: Infinity, ease: 'easeInOut' }
       }
       className={cn('relative inline-block shrink-0', sizeClasses[size], className)}
+      data-paper-creature
     >
       <svg viewBox="0 0 72 48" className="h-full w-full overflow-visible" aria-hidden="true">
         <motion.path
           d="M23 28 5 20l12 15 10-1Z"
-          className="fill-[#aebaa0] stroke-[#4d5148] dark:fill-[#68705f] dark:stroke-[#e4e7dd]"
+          className="fill-[#b7adbf] stroke-[#4d4852] dark:fill-[#696270] dark:stroke-[#ded8e3]"
           strokeWidth="2"
           strokeLinejoin="round"
           animate={
@@ -84,19 +85,19 @@ export function PaperCreature({
 
         <path
           d="M22 17h25c9 0 15 6 15 14v2H20v-6c0-4 1-7 2-10Z"
-          className="fill-[#c8d0ba] stroke-[#4d5148] dark:fill-[#89917e] dark:stroke-[#eef0e9]"
+          className="fill-[#cec4d6] stroke-[#4d4852] dark:fill-[#918a9b] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
         />
         <path
           d="M42 8h14c6 0 10 4 10 10v10H43l-5-7 4-13Z"
-          className="fill-[#e2e0c8] stroke-[#4d5148] dark:fill-[#c7c8b5] dark:stroke-[#eef0e9]"
+          className="fill-[#e4dce9] stroke-[#4d4852] dark:fill-[#c9c2d0] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
         />
         <path
           d="m29 17 4-8 5 8 5-8 4 8"
-          className="fill-[#f4ead2] stroke-[#4d5148] dark:fill-[#e8ddc5] dark:stroke-[#eef0e9]"
+          className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#eeeaf2] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
         />
@@ -104,7 +105,7 @@ export function PaperCreature({
         {!sleeping ? (
           <path
             d="M28 32v8h8v-8M49 32v8h8v-8"
-            className="stroke-[#4d5148] dark:stroke-[#eef0e9]"
+            className="stroke-[#4d4852] dark:stroke-[#eeeaf2]"
             strokeWidth="3"
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -112,7 +113,7 @@ export function PaperCreature({
         ) : (
           <path
             d="M27 34h11M48 34h11"
-            className="stroke-[#4d5148] dark:stroke-[#eef0e9]"
+            className="stroke-[#4d4852] dark:stroke-[#eeeaf2]"
             strokeWidth="3"
             strokeLinecap="round"
           />
@@ -121,16 +122,16 @@ export function PaperCreature({
         {sleeping ? (
           <path
             d="M52 17c2 1 4 1 6 0"
-            className="stroke-[#3f423b] dark:stroke-[#3f423b]"
+            className="stroke-[#4d4852] dark:stroke-[#4d4852]"
             strokeWidth="1.8"
             strokeLinecap="round"
           />
         ) : (
-          <circle cx="56" cy="17" r="2.2" className="fill-[#262923]" />
+          <circle cx="56" cy="17" r="2.2" className="fill-[#262329]" />
         )}
         <path
           d={sleeping ? 'M57 24c2 0 4 0 5-1' : 'M57 24c2 1 4 1 6-1'}
-          className="stroke-[#4d5148]"
+          className="stroke-[#4d4852]"
           strokeWidth="1.8"
           strokeLinecap="round"
         />

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -63,12 +63,12 @@ export function SiteNavBar() {
   return (
     <nav
       aria-label="Site navigation"
-      className="sticky top-0 z-50 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
+      className="sticky top-0 z-50 h-12 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
       data-site-nav
       data-site-nav-ready={ready ? 'true' : undefined}
     >
-      <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-6">
-        <div className="flex h-12 min-w-0 items-center gap-1 sm:gap-1.5">
+      <div className="mx-auto h-full max-w-7xl px-2 sm:px-4 lg:px-6">
+        <div className="flex h-full min-w-0 items-center gap-1 sm:gap-1.5">
           <Link
             href="/"
             prefetch

--- a/components/timezone-selector.tsx
+++ b/components/timezone-selector.tsx
@@ -17,6 +17,7 @@ import {
   formatSearchOffset,
   formatTime,
   getAdjustedOffset,
+  getTimezoneSearchTerms,
   type TimezoneOption,
 } from '@/lib/timezone-options';
 import {
@@ -274,6 +275,7 @@ export default function TimezoneSelector({ utcHours, utcMinutes }: TimezoneSelec
                           option.abbreviation,
                           formatOffset(adjustedOffset),
                           formatSearchOffset(adjustedOffset),
+                          ...getTimezoneSearchTerms(option),
                         ]}
                         onSelect={() => selectZone(option)}
                         className="min-h-11 items-center justify-between gap-3 px-3 py-2"

--- a/lib/timezone-options.test.ts
+++ b/lib/timezone-options.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { TIMEZONE_OPTIONS, getTimezoneSearchTerms } from './timezone-options';
+
+function option(id: string) {
+  const value = TIMEZONE_OPTIONS.find((candidate) => candidate.id === id);
+  if (!value) throw new Error(`Missing timezone option: ${id}`);
+  return value;
+}
+
+describe('getTimezoneSearchTerms', () => {
+  it('maps common North American cities to their regional time zones', () => {
+    expect(getTimezoneSearchTerms(option('eastern'))).toContain('New York');
+    expect(getTimezoneSearchTerms(option('pacific'))).toContain('Los Angeles');
+    expect(getTimezoneSearchTerms(option('central'))).toContain('Chicago');
+    expect(getTimezoneSearchTerms(option('mountain'))).toContain('Denver');
+  });
+
+  it('includes IANA and seasonal abbreviation aliases', () => {
+    expect(getTimezoneSearchTerms(option('london'))).toEqual(
+      expect.arrayContaining(['Europe/London', 'GMT', 'BST']),
+    );
+    expect(getTimezoneSearchTerms(option('sydney'))).toEqual(
+      expect.arrayContaining(['Australia/Sydney', 'AEST', 'AEDT']),
+    );
+  });
+});

--- a/lib/timezone-options.ts
+++ b/lib/timezone-options.ts
@@ -50,7 +50,7 @@ const TIMEZONE_DEFINITIONS: readonly TimezoneDefinition[] = [
 
 const TIMEZONE_SEARCH_ALIASES: Record<string, readonly string[]> = {
   baker: ['Baker Island Time', 'Etc/GMT+12'],
-  samoa: ['Pago Pago', 'Pacific/Pago_Pago', 'Samoa Standard Time'],
+  samoa: ['Pago Pago', 'Pacific/Pago_Pago'],
   hawaii: ['Honolulu', 'Hawaii-Aleutian', 'Pacific/Honolulu'],
   alaska: ['Anchorage', 'Juneau', 'Fairbanks', 'AKST', 'AKDT', 'America/Anchorage'],
   pacific: [

--- a/lib/timezone-options.ts
+++ b/lib/timezone-options.ts
@@ -48,6 +48,62 @@ const TIMEZONE_DEFINITIONS: readonly TimezoneDefinition[] = [
   ['new-zealand', 12, 'New Zealand', 'NZT', true, 'nz'],
 ];
 
+const TIMEZONE_SEARCH_ALIASES: Record<string, readonly string[]> = {
+  baker: ['Baker Island Time', 'Etc/GMT+12'],
+  samoa: ['Pago Pago', 'Pacific/Pago_Pago', 'Samoa Standard Time'],
+  hawaii: ['Honolulu', 'Hawaii-Aleutian', 'Pacific/Honolulu'],
+  alaska: ['Anchorage', 'Juneau', 'Fairbanks', 'AKST', 'AKDT', 'America/Anchorage'],
+  pacific: [
+    'Los Angeles',
+    'San Francisco',
+    'Seattle',
+    'Vancouver',
+    'PST',
+    'PDT',
+    'America/Los_Angeles',
+  ],
+  mountain: ['Denver', 'Salt Lake City', 'Calgary', 'MST', 'MDT', 'America/Denver'],
+  central: ['Chicago', 'Dallas', 'Houston', 'Winnipeg', 'CST', 'CDT', 'America/Chicago'],
+  eastern: [
+    'New York',
+    'Toronto',
+    'Washington DC',
+    'Boston',
+    'Miami',
+    'EST',
+    'EDT',
+    'America/New_York',
+  ],
+  atlantic: ['Halifax', 'Bermuda', 'AST', 'ADT', 'America/Halifax'],
+  'buenos-aires': ['Argentina', 'Buenos Aires Time', 'America/Argentina/Buenos_Aires'],
+  'mid-atlantic': ['UTC-2', 'GMT-2', 'Etc/GMT+2'],
+  azores: ['Ponta Delgada', 'AZOST', 'Atlantic/Azores'],
+  utc: ['GMT', 'Zulu', 'Universal Time', 'Etc/UTC', 'UTC+0', 'UTC-0'],
+  london: ['United Kingdom', 'England', 'GMT', 'BST', 'Europe/London'],
+  'central-europe': [
+    'Paris',
+    'Berlin',
+    'Madrid',
+    'Rome',
+    'Amsterdam',
+    'Warsaw',
+    'CEST',
+    'Europe/Paris',
+  ],
+  'eastern-europe': ['Athens', 'Bucharest', 'Helsinki', 'Kyiv', 'EEST', 'Europe/Athens'],
+  moscow: ['Russia', 'Europe/Moscow'],
+  dubai: ['United Arab Emirates', 'UAE', 'Asia/Dubai'],
+  pakistan: ['Karachi', 'Islamabad', 'Asia/Karachi'],
+  india: ['Delhi', 'Mumbai', 'Kolkata', 'Bengaluru', 'Asia/Kolkata'],
+  bangladesh: ['Dhaka', 'Asia/Dhaka'],
+  bangkok: ['Thailand', 'Jakarta', 'Ho Chi Minh City', 'Asia/Bangkok'],
+  singapore: ['Kuala Lumpur', 'Manila', 'Hong Kong', 'Beijing', 'Asia/Singapore'],
+  tokyo: ['Japan', 'Seoul', 'Osaka', 'Asia/Tokyo'],
+  sydney: ['Melbourne', 'Canberra', 'AEST', 'AEDT', 'Australia/Sydney'],
+  solomon: ['Honiara', 'Pacific/Guadalcanal'],
+  'new-zealand': ['Auckland', 'Wellington', 'NZST', 'NZDT', 'Pacific/Auckland'],
+};
+
 export const TIMEZONE_OPTIONS: TimezoneOption[] = TIMEZONE_DEFINITIONS.map(
   ([id, offset, label, abbreviation, dst, region]) => ({
     id,
@@ -61,6 +117,10 @@ export const TIMEZONE_OPTIONS: TimezoneOption[] = TIMEZONE_DEFINITIONS.map(
 
 export const UTC_OPTION = TIMEZONE_OPTIONS.find((option) => option.id === 'utc')!;
 export const DEFAULT_RECENT_ZONE_IDS = ['utc', 'eastern', 'pacific'];
+
+export function getTimezoneSearchTerms(option: TimezoneOption): readonly string[] {
+  return TIMEZONE_SEARCH_ALIASES[option.id] ?? [];
+}
 
 export function getAdjustedOffset(option: TimezoneOption, canApplyDST: boolean) {
   if (!canApplyDST || !option.dst || !option.region) return option.offset;

--- a/tests/e2e/activity-paper-marks.spec.ts
+++ b/tests/e2e/activity-paper-marks.spec.ts
@@ -26,7 +26,7 @@ for (const theme of ['light', 'dark'] as const) {
     const marks = grid.locator('[data-paper-activity-mark]');
     await expect(section).toBeVisible({ timeout: 15_000 });
     await expect(grid).toBeVisible();
-    await expect(marks).toHaveCount(35);
+    await expect(marks).toHaveCount(28);
 
     const mark = marks.nth(8);
     const resting = await mark.evaluate((element) => {

--- a/tests/e2e/restored-home-time-contracts.spec.ts
+++ b/tests/e2e/restored-home-time-contracts.spec.ts
@@ -96,16 +96,19 @@ test('homepage has no one-pixel nav overflow and Atlas does not shift the layout
 
 test('timezone search recognises common city names', async ({ page }) => {
   await page.goto('/time');
-  await page.getByRole('button', { name: 'Search time zones' }).click();
+  await page.locator('[data-timezone-trigger]').click();
 
-  const input = page.getByRole('combobox', { name: 'Search time zones' });
-  await expect(input).toBeFocused();
+  const picker = page.locator('[data-timezone-picker]');
+  const results = picker.locator('[data-timezone-results]');
+  const input = picker.locator('input');
+  await expect(picker).toBeVisible();
+  await expect(input).toBeVisible();
 
   await input.fill('New York');
-  await expect(page.getByText('Eastern Time', { exact: true })).toBeVisible();
-  await expect(page.getByText('Pacific Time', { exact: true })).toHaveCount(0);
+  await expect(results.getByText('Eastern Time', { exact: true })).toBeVisible();
+  await expect(results.getByText('Pacific Time', { exact: true })).toHaveCount(0);
 
   await input.fill('Los Angeles');
-  await expect(page.getByText('Pacific Time', { exact: true })).toBeVisible();
-  await expect(page.getByText('Eastern Time', { exact: true })).toHaveCount(0);
+  await expect(results.getByText('Pacific Time', { exact: true })).toBeVisible();
+  await expect(results.getByText('Eastern Time', { exact: true })).toHaveCount(0);
 });

--- a/tests/e2e/restored-home-time-contracts.spec.ts
+++ b/tests/e2e/restored-home-time-contracts.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForHydratedHomepage(page: Page) {
+  await expect(page.locator('[data-site-nav-ready="true"]')).toBeVisible({ timeout: 15_000 });
+  const dashboard = page.locator('[data-home-activity-dashboard]:visible').last();
+  await expect(dashboard).toBeVisible({ timeout: 15_000 });
+  await expect(dashboard.locator('[data-contribution-week-grid]')).toBeVisible();
+  return dashboard;
+}
+
+test('homepage keeps the requested 28-day activity window', async ({ page }) => {
+  await page.goto('/');
+  const dashboard = await waitForHydratedHomepage(page);
+
+  await expect(dashboard.getByText('28 days · UTC', { exact: true })).toBeVisible();
+  await expect(dashboard.locator('[data-contribution-date]')).toHaveCount(28);
+  await expect(dashboard.locator('[data-contribution-week-grid]')).toHaveAttribute(
+    'aria-label',
+    'GitHub contribution calendar for the last 28 days',
+  );
+});
+
+test('Scraplet uses the purple paper palette in light mode', async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem('theme', 'light'));
+  await page.goto('/time');
+
+  const scraplet = page.locator('[data-paper-creature]').first();
+  await expect(scraplet).toBeVisible({ timeout: 15_000 });
+  const bodyFill = await scraplet.locator('svg > path').nth(1).evaluate((element) =>
+    getComputedStyle(element).fill,
+  );
+  const headFill = await scraplet.locator('svg > path').nth(2).evaluate((element) =>
+    getComputedStyle(element).fill,
+  );
+
+  expect(bodyFill).toBe('rgb(206, 196, 214)');
+  expect(headFill).toBe('rgb(228, 220, 233)');
+});
+
+test('homepage has no one-pixel nav overflow and Atlas does not shift the layout', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/');
+  await waitForHydratedHomepage(page);
+
+  const nav = page.locator('[data-site-nav]');
+  const trigger = page.locator('[data-site-atlas-trigger]');
+  await expect(nav).toBeVisible();
+  await expect(trigger).toBeVisible();
+
+  const before = await page.evaluate(() => {
+    const navElement = document.querySelector<HTMLElement>('[data-site-nav]');
+    const triggerElement = document.querySelector<HTMLElement>('[data-site-atlas-trigger]');
+    if (!navElement || !triggerElement) throw new Error('Missing navigation geometry');
+    const navRect = navElement.getBoundingClientRect();
+    const triggerRect = triggerElement.getBoundingClientRect();
+    return {
+      nav: { x: navRect.x, y: navRect.y, width: navRect.width, height: navRect.height },
+      trigger: { x: triggerRect.x, y: triggerRect.y, width: triggerRect.width },
+      clientWidth: document.documentElement.clientWidth,
+      scrollHeight: document.documentElement.scrollHeight,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(before.nav.height).toBe(48);
+  expect(before.scrollHeight).toBeLessThanOrEqual(before.viewportHeight);
+
+  await trigger.click();
+  await expect(page.locator('[data-site-atlas]')).toBeVisible();
+
+  const after = await page.evaluate(() => {
+    const navElement = document.querySelector<HTMLElement>('[data-site-nav]');
+    const triggerElement = document.querySelector<HTMLElement>('[data-site-atlas-trigger]');
+    if (!navElement || !triggerElement) throw new Error('Missing navigation geometry');
+    const navRect = navElement.getBoundingClientRect();
+    const triggerRect = triggerElement.getBoundingClientRect();
+    const bodyStyle = getComputedStyle(document.body);
+    return {
+      nav: { x: navRect.x, y: navRect.y, width: navRect.width, height: navRect.height },
+      trigger: { x: triggerRect.x, y: triggerRect.y, width: triggerRect.width },
+      clientWidth: document.documentElement.clientWidth,
+      bodyMarginRight: bodyStyle.marginRight,
+      bodyPaddingRight: bodyStyle.paddingRight,
+      removedScrollbarSize: bodyStyle.getPropertyValue('--removed-body-scroll-bar-size').trim(),
+    };
+  });
+
+  expect(after.clientWidth).toBe(before.clientWidth);
+  expect(Math.abs(after.nav.x - before.nav.x)).toBeLessThan(1);
+  expect(Math.abs(after.nav.width - before.nav.width)).toBeLessThan(1);
+  expect(Math.abs(after.trigger.x - before.trigger.x)).toBeLessThan(1);
+  expect(after.bodyMarginRight).toBe('0px');
+  expect(after.bodyPaddingRight).toBe('0px');
+  expect(after.removedScrollbarSize).toBe('0px');
+});
+
+test('timezone search recognises common city names', async ({ page }) => {
+  await page.goto('/time');
+  await page.getByRole('button', { name: 'Search time zones' }).click();
+
+  const input = page.getByRole('combobox', { name: 'Search time zones' });
+  await expect(input).toBeFocused();
+
+  await input.fill('New York');
+  await expect(page.getByText('Eastern Time', { exact: true })).toBeVisible();
+  await expect(page.getByText('Pacific Time', { exact: true })).toHaveCount(0);
+
+  await input.fill('Los Angeles');
+  await expect(page.getByText('Pacific Time', { exact: true })).toBeVisible();
+  await expect(page.getByText('Eastern Time', { exact: true })).toHaveCount(0);
+});


### PR DESCRIPTION
## Restored contracts

- show 28 contribution days in both the server-rendered homepage and live activity polling
- restore Scraplet's purple paper palette across every pose and surface
- make the bordered site navigation exactly 48px so a fitting homepage does not gain a stray scrollbar
- prevent Radix dialog scroll lock from adding a second scrollbar-width compensation when `scrollbar-gutter: stable` already reserves it
- make timezone search recognise common cities, IANA zone names, and seasonal abbreviations such as New York, Los Angeles, Europe/London, PST/PDT, and AEST/AEDT

## Regression coverage

- exact 28-day label, aria contract, and contribution-button count
- purple Scraplet body/head fills in light mode
- 48px nav height, fitting homepage height, stable Atlas geometry, and zero duplicate compensation
- New York → Eastern Time and Los Angeles → Pacific Time search behaviour
- unit coverage for city, IANA, and seasonal timezone aliases

This replaces the stale unmerged fixes from #477 with a clean patch based on current main and preserves the newer paper-light and tactile activity work.