### PR TITLE
Use GitHub's supported contribution calendar

### DIFF
--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -19,7 +19,7 @@ type ActivitySnapshot = {
 };
 
 type LiveActivityResponse = {
-  source: 'public-profile';
+  source: 'github-graphql' | 'public-profile';
   today: number;
   weekTotal: number;
   yearTotal: number | null;

--- a/docs/github-activity-cache.md
+++ b/docs/github-activity-cache.md
@@ -1,15 +1,25 @@
 # GitHub activity refresh
 
-The homepage reads GitHub's public profile contribution calendar through `getGitHubHomeData()`. Live client refreshes use the same coordinated result through `getGitHubHomeResult()` and `/api/github-activity`.
+The homepage reads GitHub's contribution calendar through `getGitHubHomeData()`. Live client refreshes use the same coordinated result through `getGitHubHomeResult()` and `/api/github-activity`.
 
 ## Counting contract
 
-- The scorecard and graph use only the public profile contribution calendar. Public events are not used as a fallback because event counts do not follow GitHub's contribution rules and can disagree with the profile.
-- Daily cells come directly from GitHub's contribution calendar markup.
+- The preferred source is GitHub's supported GraphQL `contributionsCollection.contributionCalendar` field.
+- Set the server-only `GITHUB_PROFILE_TOKEN` environment variable to use the authenticated calendar. The token must be able to call GitHub GraphQL and include the optional `read:user` scope when private and internal contribution counts should match the signed-in profile.
+- When the token is absent or the authenticated request fails, the homepage falls back to the anonymous public profile contribution calendar HTML.
+- The anonymous fallback can differ from the owner's signed-in graph when private or internal contribution counts are not public, when an organisation filter is active in the GitHub UI, or when SSO visibility changes the viewer's graph.
+- Public events are not used as a fallback because event counts do not follow GitHub's contribution rules and can disagree with the profile.
+- Daily cells use GitHub's own `date` and `contributionCount` values. No local time-zone conversion is applied to historical cells.
 - `Today` and `7D` are calculated from those daily profile counts in UTC, matching GitHub's contribution-date convention.
-- `1Y` uses the rolling-year total reported by the GitHub profile calendar. It is not a calendar-year-to-date sum.
+- `1Y` uses the rolling-year total reported by GitHub's contribution calendar. It is not a calendar-year-to-date sum.
 - The homepage and polling route both use the same stale-while-error coordinator, so a failed server render cannot replace a previously successful snapshot with zeroes.
 - The browser ignores an older generated snapshot if a different server instance returns one after a newer snapshot has already rendered.
+
+## Token setup
+
+For a personal deployment, a classic personal access token with only `read:user` is the least ambiguous way to include the account owner's private and internal contribution counts. Give it a short expiry, store it only as the Vercel server environment variable `GITHUB_PROFILE_TOKEN`, and never prefix it with `NEXT_PUBLIC_`.
+
+The public HTML fallback remains available so an expired or revoked token does not blank the homepage. The response header `X-Activity-Source` reports `github-graphql`, `public-profile`, or `unavailable`.
 
 ## Freshness and failure policy
 
@@ -32,11 +42,12 @@ Successful JSON responses include a `diagnostics` object. An unavailable `503` r
 Important fields:
 
 - `cacheStatus`: `miss`, `hit`, or `stale` for the current server-instance coordinator;
-- `upstreamSource`: `public-profile` or `unavailable`;
+- `upstreamSource`: `github-graphql`, `public-profile`, or `unavailable`;
 - `lastUpstreamAttempt` and `lastUpstreamFetch`;
-- `consecutiveFailures` and `nextRetryAt`.
+- `consecutiveFailures` and `nextRetryAt`;
+- `rateLimit`: populated by the authenticated GraphQL source.
 
-The route mirrors the most useful values in `X-Activity-*` headers, including cache status, source, failure count, last attempt, last successful fetch, next retry, and refresh durations. `X-Request-Id` ties a response to server logs.
+The route mirrors the most useful values in `X-Activity-*` headers, including cache status, source, failure count, last attempt, last successful fetch, next retry, rate limit, and refresh durations. `X-Request-Id` ties a response to server logs.
 
 ## Inspection
 

--- a/lib/github-activity-response.test.ts
+++ b/lib/github-activity-response.test.ts
@@ -9,7 +9,7 @@ function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResul
       source,
       generatedAt: '2026-07-27T01:00:00.000Z',
       total: 18,
-      periodLabel: source === 'public-profile' ? 'last year' : 'last 35 days',
+      periodLabel: source === 'unavailable' ? 'last 35 days' : 'last year',
       today: 3,
       weekTotal: 9,
       activeDays: 5,
@@ -48,6 +48,11 @@ describe('createGitHubActivityHeaders', () => {
     expect(headers.get('x-activity-failures')).toBe('2');
     expect(headers.has('x-activity-ratelimit-limit')).toBe(false);
     expect(headers.get('x-request-id')).toBe('request-123');
+  });
+
+  it('identifies the supported authenticated contribution source', () => {
+    const headers = createGitHubActivityHeaders(result('github-graphql'), 'request-graphql');
+    expect(headers.get('x-activity-source')).toBe('github-graphql');
   });
 
   it('does not label an unavailable placeholder as generated activity', () => {

--- a/lib/github-contribution-calendar.test.ts
+++ b/lib/github-contribution-calendar.test.ts
@@ -59,7 +59,7 @@ describe('parseGitHubContributionCalendar', () => {
 
 describe('fetchGitHubContributionCalendar', () => {
   it('uses GitHub GraphQL with bearer authentication and the requested login', async () => {
-    const fetchImpl = vi.fn(async () =>
+    const fetchImpl = vi.fn(async (..._args: Parameters<typeof fetch>) =>
       new Response(JSON.stringify(payload), {
         status: 200,
         headers: {
@@ -76,7 +76,7 @@ describe('fetchGitHubContributionCalendar', () => {
     const result = await fetchGitHubContributionCalendar(
       'teamleaderleo',
       'profile-token',
-      fetchImpl as typeof fetch,
+      fetchImpl,
     );
 
     expect(result.total).toBe(18);

--- a/lib/github-contribution-calendar.test.ts
+++ b/lib/github-contribution-calendar.test.ts
@@ -21,13 +21,6 @@ const payload = {
         },
       },
     },
-    rateLimit: {
-      limit: 5000,
-      remaining: 4998,
-      used: 2,
-      resetAt: '2026-07-28T17:00:00Z',
-      resource: 'graphql',
-    },
   },
 };
 
@@ -40,13 +33,7 @@ describe('parseGitHubContributionCalendar', () => {
       ['2026-07-28', 11],
     ]);
     expect(result.total).toBe(18);
-    expect(result.rateLimit).toEqual({
-      limit: 5000,
-      remaining: 4998,
-      used: 2,
-      resetAt: '2026-07-28T17:00:00Z',
-      resource: 'graphql',
-    });
+    expect(result.rateLimit).toBeNull();
   });
 
   it('rejects partial or malformed calendars instead of publishing zeroes', () => {
@@ -75,7 +62,14 @@ describe('fetchGitHubContributionCalendar', () => {
     const fetchImpl = vi.fn(async () =>
       new Response(JSON.stringify(payload), {
         status: 200,
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-RateLimit-Limit': '5000',
+          'X-RateLimit-Remaining': '4998',
+          'X-RateLimit-Used': '2',
+          'X-RateLimit-Reset': '1785258000',
+          'X-RateLimit-Resource': 'graphql',
+        },
       }),
     );
 
@@ -86,6 +80,13 @@ describe('fetchGitHubContributionCalendar', () => {
     );
 
     expect(result.total).toBe(18);
+    expect(result.rateLimit).toEqual({
+      limit: 5000,
+      remaining: 4998,
+      used: 2,
+      resetAt: '2026-07-28T17:00:00.000Z',
+      resource: 'graphql',
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     const [url, init] = fetchImpl.mock.calls[0];
     expect(url).toBe('https://api.github.com/graphql');

--- a/lib/github-contribution-calendar.test.ts
+++ b/lib/github-contribution-calendar.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchGitHubContributionCalendar,
+  parseGitHubContributionCalendar,
+} from './github-contribution-calendar';
+
+const payload = {
+  data: {
+    user: {
+      contributionsCollection: {
+        contributionCalendar: {
+          totalContributions: 18,
+          weeks: [
+            {
+              contributionDays: [
+                { date: '2026-07-27', contributionCount: 7 },
+                { date: '2026-07-28', contributionCount: 11 },
+              ],
+            },
+          ],
+        },
+      },
+    },
+    rateLimit: {
+      limit: 5000,
+      remaining: 4998,
+      used: 2,
+      resetAt: '2026-07-28T17:00:00Z',
+      resource: 'graphql',
+    },
+  },
+};
+
+describe('parseGitHubContributionCalendar', () => {
+  it('reads official per-day counts and the calendar total', () => {
+    const result = parseGitHubContributionCalendar(payload);
+
+    expect([...result.counts.entries()]).toEqual([
+      ['2026-07-27', 7],
+      ['2026-07-28', 11],
+    ]);
+    expect(result.total).toBe(18);
+    expect(result.rateLimit).toEqual({
+      limit: 5000,
+      remaining: 4998,
+      used: 2,
+      resetAt: '2026-07-28T17:00:00Z',
+      resource: 'graphql',
+    });
+  });
+
+  it('rejects partial or malformed calendars instead of publishing zeroes', () => {
+    expect(() => parseGitHubContributionCalendar({ data: { user: null } })).toThrow(
+      'contribution calendar was missing',
+    );
+    expect(() =>
+      parseGitHubContributionCalendar({
+        data: {
+          user: {
+            contributionsCollection: {
+              contributionCalendar: {
+                totalContributions: 1,
+                weeks: [{ contributionDays: [{ date: 'July 28', contributionCount: 1 }] }],
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow('contribution day was invalid');
+  });
+});
+
+describe('fetchGitHubContributionCalendar', () => {
+  it('uses GitHub GraphQL with bearer authentication and the requested login', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await fetchGitHubContributionCalendar(
+      'teamleaderleo',
+      'profile-token',
+      fetchImpl as typeof fetch,
+    );
+
+    expect(result.total).toBe(18);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://api.github.com/graphql');
+    expect(init?.method).toBe('POST');
+    expect(new Headers(init?.headers).get('authorization')).toBe('Bearer profile-token');
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      variables: { login: 'teamleaderleo' },
+    });
+  });
+});

--- a/lib/github-contribution-calendar.ts
+++ b/lib/github-contribution-calendar.ts
@@ -17,13 +17,6 @@ const CONTRIBUTION_CALENDAR_QUERY = `
         }
       }
     }
-    rateLimit {
-      limit
-      remaining
-      used
-      resetAt
-      resource
-    }
   }
 `;
 
@@ -53,7 +46,6 @@ type GraphqlPayload = {
         };
       };
     } | null;
-    rateLimit?: unknown;
   };
   errors?: Array<{ message?: unknown }>;
 };
@@ -62,22 +54,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function integerOrNull(value: unknown): number | null {
-  return Number.isInteger(value) ? (value as number) : null;
+function headerInteger(headers: Headers, name: string): number | null {
+  const value = headers.get(name);
+  if (value === null) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
-function stringOrNull(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
-}
+function parseRateLimitHeaders(headers: Headers): GitHubGraphqlRateLimit | null {
+  const limit = headerInteger(headers, 'x-ratelimit-limit');
+  const remaining = headerInteger(headers, 'x-ratelimit-remaining');
+  const used = headerInteger(headers, 'x-ratelimit-used');
+  const reset = headerInteger(headers, 'x-ratelimit-reset');
+  const resource = headers.get('x-ratelimit-resource');
 
-function parseRateLimit(value: unknown): GitHubGraphqlRateLimit | null {
-  if (!isRecord(value)) return null;
+  if (limit === null && remaining === null && used === null && reset === null && resource === null) {
+    return null;
+  }
+
   return {
-    limit: integerOrNull(value.limit),
-    remaining: integerOrNull(value.remaining),
-    used: integerOrNull(value.used),
-    resetAt: stringOrNull(value.resetAt),
-    resource: stringOrNull(value.resource),
+    limit,
+    remaining,
+    used,
+    resetAt: reset === null ? null : new Date(reset * 1_000).toISOString(),
+    resource,
   };
 }
 
@@ -123,7 +123,7 @@ export function parseGitHubContributionCalendar(
   return {
     counts,
     total: calendar.totalContributions as number,
-    rateLimit: parseRateLimit(typedPayload.data?.rateLimit),
+    rateLimit: null,
   };
 }
 
@@ -147,5 +147,6 @@ export async function fetchGitHubContributionCalendar(
   });
 
   if (!response.ok) throw new Error(`GitHub GraphQL returned ${response.status}`);
-  return parseGitHubContributionCalendar(await response.json());
+  const parsed = parseGitHubContributionCalendar(await response.json());
+  return { ...parsed, rateLimit: parseRateLimitHeaders(response.headers) };
 }

--- a/lib/github-contribution-calendar.ts
+++ b/lib/github-contribution-calendar.ts
@@ -1,0 +1,151 @@
+const GITHUB_GRAPHQL_ENDPOINT = 'https://api.github.com/graphql';
+const GITHUB_API_VERSION = '2022-11-28';
+const UPSTREAM_TIMEOUT_MS = 8_000;
+
+const CONTRIBUTION_CALENDAR_QUERY = `
+  query ContributionCalendar($login: String!) {
+    user(login: $login) {
+      contributionsCollection {
+        contributionCalendar {
+          totalContributions
+          weeks {
+            contributionDays {
+              date
+              contributionCount
+            }
+          }
+        }
+      }
+    }
+    rateLimit {
+      limit
+      remaining
+      used
+      resetAt
+      resource
+    }
+  }
+`;
+
+export type GitHubGraphqlRateLimit = {
+  limit: number | null;
+  remaining: number | null;
+  used: number | null;
+  resetAt: string | null;
+  resource: string | null;
+};
+
+export type GitHubContributionCalendarResult = {
+  counts: Map<string, number>;
+  total: number;
+  rateLimit: GitHubGraphqlRateLimit | null;
+};
+
+type FetchLike = typeof fetch;
+
+type GraphqlPayload = {
+  data?: {
+    user?: {
+      contributionsCollection?: {
+        contributionCalendar?: {
+          totalContributions?: unknown;
+          weeks?: unknown;
+        };
+      };
+    } | null;
+    rateLimit?: unknown;
+  };
+  errors?: Array<{ message?: unknown }>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function integerOrNull(value: unknown): number | null {
+  return Number.isInteger(value) ? (value as number) : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function parseRateLimit(value: unknown): GitHubGraphqlRateLimit | null {
+  if (!isRecord(value)) return null;
+  return {
+    limit: integerOrNull(value.limit),
+    remaining: integerOrNull(value.remaining),
+    used: integerOrNull(value.used),
+    resetAt: stringOrNull(value.resetAt),
+    resource: stringOrNull(value.resource),
+  };
+}
+
+export function parseGitHubContributionCalendar(
+  payload: unknown,
+): GitHubContributionCalendarResult {
+  if (!isRecord(payload)) throw new Error('GitHub GraphQL returned an invalid payload');
+
+  const typedPayload = payload as GraphqlPayload;
+  if (typedPayload.errors?.length) {
+    const message = typedPayload.errors
+      .map((error) => (typeof error.message === 'string' ? error.message : 'GraphQL error'))
+      .join('; ');
+    throw new Error(`GitHub GraphQL contribution query failed: ${message}`);
+  }
+
+  const calendar = typedPayload.data?.user?.contributionsCollection?.contributionCalendar;
+  if (!calendar || !Number.isInteger(calendar.totalContributions) || !Array.isArray(calendar.weeks)) {
+    throw new Error('GitHub GraphQL contribution calendar was missing');
+  }
+
+  const counts = new Map<string, number>();
+  for (const week of calendar.weeks) {
+    if (!isRecord(week) || !Array.isArray(week.contributionDays)) {
+      throw new Error('GitHub GraphQL contribution week was invalid');
+    }
+    for (const day of week.contributionDays) {
+      if (
+        !isRecord(day) ||
+        typeof day.date !== 'string' ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(day.date) ||
+        !Number.isInteger(day.contributionCount) ||
+        (day.contributionCount as number) < 0
+      ) {
+        throw new Error('GitHub GraphQL contribution day was invalid');
+      }
+      counts.set(day.date, day.contributionCount as number);
+    }
+  }
+
+  if (counts.size === 0) throw new Error('GitHub GraphQL contribution calendar was empty');
+
+  return {
+    counts,
+    total: calendar.totalContributions as number,
+    rateLimit: parseRateLimit(typedPayload.data?.rateLimit),
+  };
+}
+
+export async function fetchGitHubContributionCalendar(
+  username: string,
+  token: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<GitHubContributionCalendarResult> {
+  const response = await fetchImpl(GITHUB_GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    cache: 'no-store',
+    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'User-Agent': 'teamleaderleo-scrapbook',
+      'X-GitHub-Api-Version': GITHUB_API_VERSION,
+    },
+    body: JSON.stringify({ query: CONTRIBUTION_CALENDAR_QUERY, variables: { login: username } }),
+  });
+
+  if (!response.ok) throw new Error(`GitHub GraphQL returned ${response.status}`);
+  return parseGitHubContributionCalendar(await response.json());
+}

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { fetchGitHubContributionCalendar } from './github-contribution-calendar';
 import {
   dateKeyInTimeZone,
   getRecentDateKeys,
@@ -51,7 +52,7 @@ export type GitHubRateLimit = {
 
 export type GitHubHomeData = {
   username: string;
-  source: 'public-profile' | 'unavailable';
+  source: 'github-graphql' | 'public-profile' | 'unavailable';
   generatedAt: string;
   total: number | null;
   periodLabel: 'last year' | 'last 35 days';
@@ -119,17 +120,18 @@ function summarizeCounts(
 ): ActivitySummary {
   const days = daysFromCounts(counts, now);
   const today = dateKeyInTimeZone(now);
-  const periodLabel: GitHubHomeData['periodLabel'] =
-    source === 'public-profile' ? 'last year' : 'last 35 days';
-  const periodEntries =
-    source === 'public-profile'
-      ? [...counts.entries()].filter(([date]) => date <= today)
-      : days.map((day) => [day.date, day.count] as const);
-  const streakDays = source === 'public-profile' ? daysFromCounts(counts, now, 366) : days;
+  const hasRollingYearCalendar = source !== 'unavailable';
+  const periodLabel: GitHubHomeData['periodLabel'] = hasRollingYearCalendar
+    ? 'last year'
+    : 'last 35 days';
+  const periodEntries = hasRollingYearCalendar
+    ? [...counts.entries()].filter(([date]) => date <= today)
+    : days.map((day) => [day.date, day.count] as const);
+  const streakDays = hasRollingYearCalendar ? daysFromCounts(counts, now, 366) : days;
   const calculatedTotal = periodEntries.reduce((sum, [, count]) => sum + count, 0);
 
   return {
-    total: source === 'public-profile' && reportedTotal !== null ? reportedTotal : calculatedTotal,
+    total: hasRollingYearCalendar && reportedTotal !== null ? reportedTotal : calculatedTotal,
     periodLabel,
     today: days.at(-1)?.count ?? 0,
     weekTotal: days.slice(-7).reduce((sum, day) => sum + day.count, 0),
@@ -207,25 +209,49 @@ function unavailableHomeData(now = new Date()): GitHubHomeData {
   };
 }
 
-async function loadGitHubHomeData(): Promise<UpstreamActivity> {
-  const { counts, total } = await fetchPublicProfileCounts();
-  const summary = summarizeCounts(counts, 'public-profile', new Date(), total);
-
+function createUpstreamActivity(
+  counts: Map<string, number>,
+  total: number | null,
+  source: Exclude<ActivitySource, 'unavailable'>,
+  rateLimit: GitHubRateLimit | null,
+  now = new Date(),
+): UpstreamActivity {
+  const summary = summarizeCounts(counts, source, now, total);
   return {
     activity: {
       username: GITHUB_USERNAME,
-      source: 'public-profile',
-      generatedAt: new Date().toISOString(),
+      source,
+      generatedAt: now.toISOString(),
       ...summary,
       repositories: featuredRepositories(),
     },
-    rateLimit: null,
+    rateLimit,
   };
+}
+
+async function loadGitHubHomeData(): Promise<UpstreamActivity> {
+  const profileToken = process.env.GITHUB_PROFILE_TOKEN?.trim();
+  if (profileToken) {
+    try {
+      const result = await fetchGitHubContributionCalendar(GITHUB_USERNAME, profileToken);
+      return createUpstreamActivity(
+        result.counts,
+        result.total,
+        'github-graphql',
+        result.rateLimit,
+      );
+    } catch (error) {
+      console.warn('Authenticated GitHub contribution calendar failed; using public profile', error);
+    }
+  }
+
+  const { counts, total } = await fetchPublicProfileCounts();
+  return createUpstreamActivity(counts, total, 'public-profile', null);
 }
 
 const getCachedUpstreamActivity = unstable_cache(
   loadGitHubHomeData,
-  ['github-homepage-v8'],
+  ['github-homepage-v9'],
   { revalidate: GITHUB_ACTIVITY_UPSTREAM_FRESH_SECONDS },
 );
 


### PR DESCRIPTION
## Finding

The historical mismatch is not a UTC bucketing bug. A live production audit matched all 367 anonymous GitHub calendar cells one-for-one with the current parser, including the exact `data-date` and tooltip count for each day. The site currently displays the calendar GitHub serves to an anonymous viewer, while the signed-in owner profile may include private/internal contributions or a different organisation/SSO context.

## Change

- prefer GitHub GraphQL `contributionsCollection.contributionCalendar` when the server-only `GITHUB_PROFILE_TOKEN` is configured;
- use GitHub's official per-day `date` and `contributionCount` fields and official rolling-year total;
- strictly reject malformed or partial GraphQL calendars;
- expose GraphQL rate-limit diagnostics through the existing response headers;
- retain the anonymous public profile HTML as a fallback when the token is absent, expired, revoked, or temporarily fails;
- bump the data-cache key so a deployment with a newly configured token does not reuse an anonymous snapshot;
- document the required server-only token and `read:user` scope for private/internal contribution counts.

## Self-review corrections

- fixed the first test double after TypeScript correctly inferred it as a zero-argument function;
- read GraphQL rate limits from GitHub response headers rather than adding an unnecessary rate-limit field to the contribution query;
- widened the live client response type to accept the authenticated source without changing the browser payload;
- kept the token server-only and preserved stale-on-error behaviour.

## Behaviour fence

- no activity-grid layout, colour, animation, selection, tooltip, or refresh-cadence change;
- no arithmetic change to Today or 7D;
- no token reaches the client bundle or API response;
- no blank/zero replacement when the authenticated source fails.

## Runtime preview

The Vercel preview returned a fresh 200 response with `X-Activity-Source: public-profile`, no failures, and the existing no-store headers. This is the expected fallback while `GITHUB_PROFILE_TOKEN` is absent.

## Deployment requirement

After merge, add `GITHUB_PROFILE_TOKEN` to the Vercel production environment and redeploy. A short-lived classic personal access token with only `read:user` is the least ambiguous personal-account setup. Organisation SSO may also need authorisation. Until the variable exists, production intentionally continues to report `source: public-profile`.

## Validation

[CI run 591](https://github.com/teamleaderleo/scrapbook/actions/runs/30379316753) passed:

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit browser regressions;
- **171 passed, five intentional skips, zero retries**.

Playwright log: `sha256:0e00ba38698fb6924a170af2d1e8da8198b6567b020a9275d3bfa23d8dcae643`.

Ready to merge.