### PR TITLE
Stabilise the nav and Atlas shell geometry

### DIFF
--- a/app/dialog-scroll-lock.css
+++ b/app/dialog-scroll-lock.css
@@ -1,0 +1,16 @@
+@supports (scrollbar-gutter: stable) {
+  body[data-scroll-locked],
+  .with-scroll-bars-hidden {
+    --removed-body-scroll-bar-size: 0px !important;
+    margin-right: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .right-scroll-bar-position {
+    right: 0 !important;
+  }
+
+  .width-before-scroll-bar {
+    margin-right: 0 !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import '@/app/globals.css';
 import '@/app/materials.css';
 import '@/app/materials-accessibility.css';
 import '@/app/navigation-feedback.css';
+import '@/app/dialog-scroll-lock.css';
 import { inter } from '@/components/ui/assets/fonts';
 import type { Metadata, Viewport } from 'next';
 import { ThemeProvider } from '@/components/theme-provider';

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -63,12 +63,12 @@ export function SiteNavBar() {
   return (
     <nav
       aria-label="Site navigation"
-      className="sticky top-0 z-50 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
+      className="sticky top-0 z-50 h-12 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
       data-site-nav
       data-site-nav-ready={ready ? 'true' : undefined}
     >
-      <div className="mx-auto max-w-7xl px-2 sm:px-4 lg:px-6">
-        <div className="flex h-12 min-w-0 items-center gap-1 sm:gap-1.5">
+      <div className="mx-auto h-full max-w-7xl px-2 sm:px-4 lg:px-6">
+        <div className="flex h-full min-w-0 items-center gap-1 sm:gap-1.5">
           <Link
             href="/"
             prefetch

--- a/tests/e2e/site-shell-stability.spec.ts
+++ b/tests/e2e/site-shell-stability.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function waitForSiteNav(page: Page) {
+  const nav = page.locator('[data-site-nav]');
+  await expect(nav).toHaveAttribute('data-site-nav-ready', 'true');
+  return nav;
+}
+
+test('the bordered site nav is exactly 48px at desktop and phone widths', async ({ page }) => {
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/journal');
+    const nav = await waitForSiteNav(page);
+
+    const geometry = await nav.evaluate((element) => {
+      const firstWrapper = element.firstElementChild;
+      const row = firstWrapper?.firstElementChild;
+      return {
+        outer: element.getBoundingClientRect().height,
+        wrapper: firstWrapper?.getBoundingClientRect().height ?? 0,
+        row: row?.getBoundingClientRect().height ?? 0,
+      };
+    });
+
+    expect(geometry).toEqual({ outer: 48, wrapper: 48, row: 48 });
+  }
+});
+
+test('opening and closing the Atlas keeps shell geometry stable', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 760 });
+  await page.goto('/journal');
+  await waitForSiteNav(page);
+
+  const trigger = page.locator('[data-site-atlas-trigger]');
+  await expect(trigger).toBeVisible();
+
+  const shellGeometry = () =>
+    page.evaluate(() => {
+      const triggerElement = document.querySelector<HTMLElement>('[data-site-atlas-trigger]');
+      const nav = document.querySelector<HTMLElement>('[data-site-nav]');
+      if (!triggerElement || !nav) throw new Error('Missing Atlas shell geometry');
+      return {
+        triggerRight: triggerElement.getBoundingClientRect().right,
+        navLeft: nav.getBoundingClientRect().left,
+        navWidth: nav.getBoundingClientRect().width,
+      };
+    });
+
+  const before = await shellGeometry();
+  await trigger.click();
+  await expect(page.locator('[data-site-atlas]')).toBeVisible();
+
+  const open = await shellGeometry();
+  const compensation = await page.evaluate(() =>
+    getComputedStyle(document.body).getPropertyValue('--removed-body-scroll-bar-size').trim(),
+  );
+
+  expect(Math.abs(open.triggerRight - before.triggerRight)).toBeLessThan(1);
+  expect(Math.abs(open.navLeft - before.navLeft)).toBeLessThan(1);
+  expect(Math.abs(open.navWidth - before.navWidth)).toBeLessThan(1);
+  expect(compensation).toBe('0px');
+
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-site-atlas]')).toBeHidden();
+  const closed = await shellGeometry();
+  expect(Math.abs(closed.triggerRight - before.triggerRight)).toBeLessThan(1);
+  expect(Math.abs(closed.navLeft - before.navLeft)).toBeLessThan(1);
+  expect(Math.abs(closed.navWidth - before.navWidth)).toBeLessThan(1);
+});

--- a/tests/e2e/site-shell-stability.spec.ts
+++ b/tests/e2e/site-shell-stability.spec.ts
@@ -18,14 +18,19 @@ test('the bordered site nav is exactly 48px at desktop and phone widths', async 
     const geometry = await nav.evaluate((element) => {
       const firstWrapper = element.firstElementChild;
       const row = firstWrapper?.firstElementChild;
+      const style = getComputedStyle(element);
       return {
         outer: element.getBoundingClientRect().height,
+        borderBottom: Number.parseFloat(style.borderBottomWidth),
         wrapper: firstWrapper?.getBoundingClientRect().height ?? 0,
         row: row?.getBoundingClientRect().height ?? 0,
       };
     });
 
-    expect(geometry).toEqual({ outer: 48, wrapper: 48, row: 48 });
+    expect(geometry.outer).toBe(48);
+    expect(geometry.borderBottom).toBe(1);
+    expect(geometry.wrapper).toBe(geometry.outer - geometry.borderBottom);
+    expect(geometry.row).toBe(geometry.outer - geometry.borderBottom);
   }
 });
 


### PR DESCRIPTION
Closes #485

## What changed

- make the bordered global nav itself exactly 48px and size its inner wrappers with `h-full`;
- keep the existing 44px controls and Site Atlas hierarchy unchanged;
- when `scrollbar-gutter: stable` is supported, neutralise duplicate Radix/remove-scroll margin, padding, right-position and width compensation;
- add Chromium/WebKit coverage for desktop/phone nav height and Atlas open/close geometry.

## Scope

Four files only. This extracts the still-valid shell fixes identified in stale draft #477 without carrying forward its superseded homepage, activity, scorecard or Scraplet work.

## Verification

Initial CI pending on head `08a94590b232684544ef8543e27ac323cf46f9d4`. Keep draft until it is replayed after #465 and passes the final current-main gate.