### PR TITLE
Keep GitHub cache refresh failures inside stale fallback

### DIFF
--- a/lib/cache-load-result.test.ts
+++ b/lib/cache-load-result.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { captureCacheLoad, unwrapCacheLoad } from './cache-load-result';
+
+describe('cache load results', () => {
+  it('returns successful values unchanged', async () => {
+    const captured = await captureCacheLoad(async () => ({ value: 7 }));
+
+    expect(captured).toEqual({ ok: true, value: { value: 7 } });
+    expect(unwrapCacheLoad(captured)).toEqual({ value: 7 });
+  });
+
+  it('serializes loader errors before they reach a persistent cache refresh', async () => {
+    const timeout = new Error('The operation was aborted due to timeout');
+    timeout.name = 'TimeoutError';
+
+    const captured = await captureCacheLoad(async () => {
+      throw timeout;
+    });
+
+    expect(captured).toEqual({
+      ok: false,
+      error: {
+        name: 'TimeoutError',
+        message: 'The operation was aborted due to timeout',
+      },
+    });
+
+    try {
+      unwrapCacheLoad(captured);
+      throw new Error('Expected unwrapCacheLoad to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).name).toBe('TimeoutError');
+      expect((error as Error).message).toBe('The operation was aborted due to timeout');
+    }
+  });
+
+  it('normalizes non-Error rejections', async () => {
+    const captured = await captureCacheLoad(async () => {
+      throw 'upstream unavailable';
+    });
+
+    expect(captured).toEqual({
+      ok: false,
+      error: { name: 'Error', message: 'upstream unavailable' },
+    });
+  });
+});

--- a/lib/cache-load-result.ts
+++ b/lib/cache-load-result.ts
@@ -1,0 +1,38 @@
+export type CacheLoadFailure = {
+  name: string;
+  message: string;
+};
+
+export type CacheLoadResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: CacheLoadFailure };
+
+function describeError(error: unknown): CacheLoadFailure {
+  if (error instanceof Error) {
+    return {
+      name: error.name || 'Error',
+      message: error.message || String(error),
+    };
+  }
+
+  return {
+    name: 'Error',
+    message: String(error),
+  };
+}
+
+export async function captureCacheLoad<T>(load: () => Promise<T>): Promise<CacheLoadResult<T>> {
+  try {
+    return { ok: true, value: await load() };
+  } catch (error) {
+    return { ok: false, error: describeError(error) };
+  }
+}
+
+export function unwrapCacheLoad<T>(result: CacheLoadResult<T>): T {
+  if (result.ok) return result.value;
+
+  const error = new Error(result.error.message);
+  error.name = result.error.name;
+  throw error;
+}

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -1,4 +1,5 @@
 import { unstable_cache } from 'next/cache';
+import { captureCacheLoad, unwrapCacheLoad } from './cache-load-result';
 import { fetchGitHubContributionCalendar } from './github-contribution-calendar';
 import {
   dateKeyInTimeZone,
@@ -250,13 +251,17 @@ async function loadGitHubHomeData(): Promise<UpstreamActivity> {
 }
 
 const getCachedUpstreamActivity = unstable_cache(
-  loadGitHubHomeData,
-  ['github-homepage-v9'],
+  () => captureCacheLoad(loadGitHubHomeData),
+  ['github-homepage-v10'],
   { revalidate: GITHUB_ACTIVITY_UPSTREAM_FRESH_SECONDS },
 );
 
+async function loadCachedUpstreamActivity(): Promise<UpstreamActivity> {
+  return unwrapCacheLoad(await getCachedUpstreamActivity());
+}
+
 const githubHomeCache = createStaleWhileErrorCache<UpstreamActivity>({
-  load: getCachedUpstreamActivity,
+  load: loadCachedUpstreamActivity,
   freshForMs: GITHUB_ACTIVITY_INSTANCE_FRESH_MS,
   staleForMs: GITHUB_ACTIVITY_STALE_SECONDS * 1_000,
   retryBaseMs: GITHUB_ACTIVITY_RETRY_BASE_MS,


### PR DESCRIPTION
## What changed

- wrap persistent GitHub activity cache loads in a serializable success/failure envelope
- unwrap failures inside the existing stale-while-error cache so retry backoff and stale data remain active
- bump the persistent cache key to avoid reusing the old callback result
- add focused tests for success, timeout serialization, and non-Error rejections

## Why

Vercel recorded `TimeoutError` runtime groups from background `unstable_cache` revalidation. The page continued serving cached data, but the callback rejection escaped the persistent cache refresh and was counted as a production runtime error.

This change makes the persistent callback resolve with failure data, then rethrows only inside the existing stale cache layer where failures are intentionally handled.