### PR TITLE
Keep authenticated GitHub profile diagnostics private

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -1,4 +1,7 @@
-import { createGitHubActivityHeaders } from '@/lib/github-activity-response';
+import {
+  createGitHubActivityHeaders,
+  publicGitHubActivityDiagnostics,
+} from '@/lib/github-activity-response';
 import { getGitHubHomeResult } from '@/lib/github-home';
 import { connection } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -9,7 +12,8 @@ export async function GET() {
 
   try {
     const result = await getGitHubHomeResult();
-    const { activity, diagnostics } = result;
+    const { activity } = result;
+    const diagnostics = publicGitHubActivityDiagnostics(result);
     const headers = createGitHubActivityHeaders(result, requestId);
 
     if (activity.source === 'unavailable') {

--- a/lib/github-activity-response.test.ts
+++ b/lib/github-activity-response.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { createGitHubActivityHeaders } from './github-activity-response';
+import {
+  createGitHubActivityHeaders,
+  publicGitHubActivityDiagnostics,
+} from './github-activity-response';
 import type { GitHubHomeResult } from './github-home';
 
 function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResult {
@@ -24,13 +27,19 @@ function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResul
       lastUpstreamFetch: '2026-07-27T01:00:00.000Z',
       consecutiveFailures: 2,
       nextRetryAt: '2026-07-27T01:07:00.000Z',
-      rateLimit: null,
+      rateLimit: {
+        limit: 5000,
+        remaining: 4998,
+        used: 2,
+        resetAt: '2026-07-27T02:00:00.000Z',
+        resource: 'graphql',
+      },
     },
   };
 }
 
 describe('createGitHubActivityHeaders', () => {
-  it('keeps live polling out of browser and CDN caches while exposing diagnostics', () => {
+  it('keeps live polling out of browser and CDN caches while exposing bounded diagnostics', () => {
     const headers = createGitHubActivityHeaders(result('public-profile'), 'request-123');
 
     expect(headers.get('cache-control')).toBe('private, no-store, max-age=0');
@@ -46,13 +55,33 @@ describe('createGitHubActivityHeaders', () => {
     expect(headers.get('x-activity-last-upstream-fetch')).toBe('2026-07-27T01:00:00.000Z');
     expect(headers.get('x-activity-next-retry-at')).toBe('2026-07-27T01:07:00.000Z');
     expect(headers.get('x-activity-failures')).toBe('2');
-    expect(headers.has('x-activity-ratelimit-limit')).toBe(false);
     expect(headers.get('x-request-id')).toBe('request-123');
   });
 
-  it('identifies the supported authenticated contribution source', () => {
-    const headers = createGitHubActivityHeaders(result('github-graphql'), 'request-graphql');
+  it('keeps authenticated GitHub rate-limit telemetry out of headers and JSON projections', () => {
+    const privateResult = result('github-graphql');
+    const headers = createGitHubActivityHeaders(privateResult, 'request-graphql');
+    const diagnostics = publicGitHubActivityDiagnostics(privateResult);
+
     expect(headers.get('x-activity-source')).toBe('github-graphql');
+    for (const name of [
+      'x-activity-ratelimit-limit',
+      'x-activity-ratelimit-remaining',
+      'x-activity-ratelimit-used',
+      'x-activity-ratelimit-reset',
+      'x-activity-ratelimit-resource',
+    ]) {
+      expect(headers.has(name)).toBe(false);
+    }
+    expect(diagnostics).toEqual({
+      cacheStatus: 'stale',
+      upstreamSource: 'github-graphql',
+      lastUpstreamAttempt: '2026-07-27T01:05:00.000Z',
+      lastUpstreamFetch: '2026-07-27T01:00:00.000Z',
+      consecutiveFailures: 2,
+      nextRetryAt: '2026-07-27T01:07:00.000Z',
+    });
+    expect('rateLimit' in diagnostics).toBe(false);
   });
 
   it('does not label an unavailable placeholder as generated activity', () => {

--- a/lib/github-activity-response.ts
+++ b/lib/github-activity-response.ts
@@ -7,6 +7,30 @@ import type { GitHubHomeResult } from './github-home';
 
 export { GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS } from './github-activity-policy';
 
+export type PublicGitHubActivityDiagnostics = Pick<
+  GitHubHomeResult['diagnostics'],
+  | 'cacheStatus'
+  | 'upstreamSource'
+  | 'lastUpstreamAttempt'
+  | 'lastUpstreamFetch'
+  | 'consecutiveFailures'
+  | 'nextRetryAt'
+>;
+
+export function publicGitHubActivityDiagnostics(
+  result: GitHubHomeResult,
+): PublicGitHubActivityDiagnostics {
+  const { diagnostics } = result;
+  return {
+    cacheStatus: diagnostics.cacheStatus,
+    upstreamSource: diagnostics.upstreamSource,
+    lastUpstreamAttempt: diagnostics.lastUpstreamAttempt,
+    lastUpstreamFetch: diagnostics.lastUpstreamFetch,
+    consecutiveFailures: diagnostics.consecutiveFailures,
+    nextRetryAt: diagnostics.nextRetryAt,
+  };
+}
+
 export function createGitHubActivityHeaders(result: GitHubHomeResult, requestId: string) {
   const { activity, diagnostics } = result;
   const headers = new Headers({
@@ -33,24 +57,6 @@ export function createGitHubActivityHeaders(result: GitHubHomeResult, requestId:
   }
   if (diagnostics.nextRetryAt) {
     headers.set('X-Activity-Next-Retry-At', diagnostics.nextRetryAt);
-  }
-  if (diagnostics.rateLimit?.limit !== null && diagnostics.rateLimit?.limit !== undefined) {
-    headers.set('X-Activity-RateLimit-Limit', String(diagnostics.rateLimit.limit));
-  }
-  if (
-    diagnostics.rateLimit?.remaining !== null &&
-    diagnostics.rateLimit?.remaining !== undefined
-  ) {
-    headers.set('X-Activity-RateLimit-Remaining', String(diagnostics.rateLimit.remaining));
-  }
-  if (diagnostics.rateLimit?.used !== null && diagnostics.rateLimit?.used !== undefined) {
-    headers.set('X-Activity-RateLimit-Used', String(diagnostics.rateLimit.used));
-  }
-  if (diagnostics.rateLimit?.resetAt) {
-    headers.set('X-Activity-RateLimit-Reset', diagnostics.rateLimit.resetAt);
-  }
-  if (diagnostics.rateLimit?.resource) {
-    headers.set('X-Activity-RateLimit-Resource', diagnostics.rateLimit.resource);
   }
 
   return headers;

--- a/lib/github-contribution-calendar.test.ts
+++ b/lib/github-contribution-calendar.test.ts
@@ -4,9 +4,11 @@ import {
   parseGitHubContributionCalendar,
 } from './github-contribution-calendar';
 
+const username = 'teamleaderleo';
 const payload = {
   data: {
     user: {
+      login: username,
       contributionsCollection: {
         contributionCalendar: {
           totalContributions: 18,
@@ -24,9 +26,30 @@ const payload = {
   },
 };
 
+function calendar(overrides: Record<string, unknown>, login = username) {
+  return {
+    data: {
+      user: {
+        login,
+        contributionsCollection: {
+          contributionCalendar: {
+            totalContributions: 1,
+            weeks: [
+              {
+                contributionDays: [{ date: '2026-07-28', contributionCount: 1 }],
+              },
+            ],
+            ...overrides,
+          },
+        },
+      },
+    },
+  };
+}
+
 describe('parseGitHubContributionCalendar', () => {
   it('reads official per-day counts and the calendar total', () => {
-    const result = parseGitHubContributionCalendar(payload);
+    const result = parseGitHubContributionCalendar(payload, username);
 
     expect([...result.counts.entries()]).toEqual([
       ['2026-07-27', 7],
@@ -36,24 +59,55 @@ describe('parseGitHubContributionCalendar', () => {
     expect(result.rateLimit).toBeNull();
   });
 
-  it('rejects partial or malformed calendars instead of publishing zeroes', () => {
-    expect(() => parseGitHubContributionCalendar({ data: { user: null } })).toThrow(
-      'contribution calendar was missing',
-    );
+  it('rejects missing, cross-user, and malformed calendars instead of publishing zeroes', () => {
     expect(() =>
-      parseGitHubContributionCalendar({
-        data: {
-          user: {
-            contributionsCollection: {
-              contributionCalendar: {
-                totalContributions: 1,
-                weeks: [{ contributionDays: [{ date: 'July 28', contributionCount: 1 }] }],
-              },
-            },
-          },
-        },
-      }),
+      parseGitHubContributionCalendar({ data: { user: null } }, username),
+    ).toThrow('user did not match the request');
+    expect(() =>
+      parseGitHubContributionCalendar(calendar({}, 'somebody-else'), username),
+    ).toThrow('user did not match the request');
+    expect(() =>
+      parseGitHubContributionCalendar(calendar({
+        weeks: [{ contributionDays: [{ date: 'July 28', contributionCount: 1 }] }],
+      }), username),
     ).toThrow('contribution day was invalid');
+  });
+
+  it('rejects impossible dates, duplicate dates, and contradictory totals', () => {
+    expect(() =>
+      parseGitHubContributionCalendar(calendar({
+        weeks: [{ contributionDays: [{ date: '2026-02-30', contributionCount: 1 }] }],
+      }), username),
+    ).toThrow('contribution day was invalid');
+
+    expect(() =>
+      parseGitHubContributionCalendar(calendar({
+        totalContributions: 2,
+        weeks: [
+          { contributionDays: [{ date: '2026-07-28', contributionCount: 1 }] },
+          { contributionDays: [{ date: '2026-07-28', contributionCount: 1 }] },
+        ],
+      }), username),
+    ).toThrow('duplicate dates');
+
+    expect(() =>
+      parseGitHubContributionCalendar(
+        calendar({ totalContributions: 2 }),
+        username,
+      ),
+    ).toThrow('total was inconsistent');
+  });
+
+  it('does not echo upstream GraphQL error text', () => {
+    const hostile = {
+      errors: [{ message: 'token ghp_should_never_reach_logs' }],
+    };
+    expect(() => parseGitHubContributionCalendar(hostile, username)).toThrow(
+      'contribution query returned errors',
+    );
+    expect(() => parseGitHubContributionCalendar(hostile, username)).not.toThrow(
+      'ghp_should_never_reach_logs',
+    );
   });
 });
 
@@ -74,7 +128,7 @@ describe('fetchGitHubContributionCalendar', () => {
     );
 
     const result = await fetchGitHubContributionCalendar(
-      'teamleaderleo',
+      'TeamLeaderLeo',
       'profile-token',
       fetchImpl,
     );
@@ -93,7 +147,35 @@ describe('fetchGitHubContributionCalendar', () => {
     expect(init?.method).toBe('POST');
     expect(new Headers(init?.headers).get('authorization')).toBe('Bearer profile-token');
     expect(JSON.parse(String(init?.body))).toMatchObject({
-      variables: { login: 'teamleaderleo' },
+      variables: { login: username },
     });
+  });
+
+  it('rejects oversized success responses before parsing', async () => {
+    const oversized = `{"padding":"${'x'.repeat(256 * 1024)}"}`;
+    await expect(fetchGitHubContributionCalendar(
+      username,
+      'profile-token',
+      vi.fn(async () => new Response(oversized, { status: 200 })),
+    )).rejects.toThrow('response was too large');
+  });
+
+  it('replaces network failures and provider bodies with stable local errors', async () => {
+    await expect(fetchGitHubContributionCalendar(
+      username,
+      'profile-token',
+      vi.fn(async () => {
+        throw new Error('request leaked profile-token');
+      }),
+    )).rejects.toThrow('contribution request failed');
+
+    await expect(fetchGitHubContributionCalendar(
+      username,
+      'profile-token',
+      vi.fn(async () => new Response(
+        JSON.stringify({ message: 'profile-token rejected' }),
+        { status: 401 },
+      )),
+    )).rejects.toThrow('contribution request returned 401');
   });
 });

--- a/lib/github-contribution-calendar.ts
+++ b/lib/github-contribution-calendar.ts
@@ -1,10 +1,17 @@
 const GITHUB_GRAPHQL_ENDPOINT = 'https://api.github.com/graphql';
 const GITHUB_API_VERSION = '2022-11-28';
 const UPSTREAM_TIMEOUT_MS = 8_000;
+const MAXIMUM_RESPONSE_BYTES = 256 * 1024;
+const MAXIMUM_CALENDAR_WEEKS = 54;
+const MAXIMUM_DAYS_PER_WEEK = 7;
+const MAXIMUM_CONTRIBUTION_COUNT = 1_000_000;
+const MAXIMUM_TOTAL_CONTRIBUTIONS = 10_000_000;
+const MAXIMUM_RATE_LIMIT_RESET_SECONDS = 8_640_000_000_000;
 
 const CONTRIBUTION_CALENDAR_QUERY = `
   query ContributionCalendar($login: String!) {
     user(login: $login) {
+      login
       contributionsCollection {
         contributionCalendar {
           totalContributions
@@ -39,6 +46,7 @@ type FetchLike = typeof fetch;
 type GraphqlPayload = {
   data?: {
     user?: {
+      login?: unknown;
       contributionsCollection?: {
         contributionCalendar?: {
           totalContributions?: unknown;
@@ -47,18 +55,38 @@ type GraphqlPayload = {
       };
     } | null;
   };
-  errors?: Array<{ message?: unknown }>;
+  errors?: unknown;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function githubLogin(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new Error('GitHub GraphQL contribution user was invalid');
+  }
+  const login = value.trim().toLowerCase();
+  if (
+    !/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(login)
+    || login.includes('--')
+  ) {
+    throw new Error('GitHub GraphQL contribution user was invalid');
+  }
+  return login;
 }
 
 function headerInteger(headers: Headers, name: string): number | null {
   const value = headers.get(name);
   if (value === null) return null;
   const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : null;
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function resetTimestamp(value: number | null): string | null {
+  if (value === null || value > MAXIMUM_RATE_LIMIT_RESET_SECONDS) return null;
+  const date = new Date(value * 1_000);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 function parseRateLimitHeaders(headers: Headers): GitHubGraphqlRateLimit | null {
@@ -67,8 +95,16 @@ function parseRateLimitHeaders(headers: Headers): GitHubGraphqlRateLimit | null 
   const used = headerInteger(headers, 'x-ratelimit-used');
   const reset = headerInteger(headers, 'x-ratelimit-reset');
   const resource = headers.get('x-ratelimit-resource');
+  const boundedResource = resource && /^[a-z0-9_-]{1,32}$/i.test(resource) ? resource : null;
+  const resetAt = resetTimestamp(reset);
 
-  if (limit === null && remaining === null && used === null && reset === null && resource === null) {
+  if (
+    limit === null
+    && remaining === null
+    && used === null
+    && resetAt === null
+    && boundedResource === null
+  ) {
     return null;
   }
 
@@ -76,49 +112,96 @@ function parseRateLimitHeaders(headers: Headers): GitHubGraphqlRateLimit | null 
     limit,
     remaining,
     used,
-    resetAt: reset === null ? null : new Date(reset * 1_000).toISOString(),
-    resource,
+    resetAt,
+    resource: boundedResource,
   };
+}
+
+function canonicalDate(value: unknown): string {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    throw new Error('GitHub GraphQL contribution day was invalid');
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error('GitHub GraphQL contribution day was invalid');
+  }
+  return value;
+}
+
+function boundedCount(value: unknown): number {
+  if (
+    !Number.isSafeInteger(value)
+    || (value as number) < 0
+    || (value as number) > MAXIMUM_CONTRIBUTION_COUNT
+  ) {
+    throw new Error('GitHub GraphQL contribution day was invalid');
+  }
+  return value as number;
 }
 
 export function parseGitHubContributionCalendar(
   payload: unknown,
+  expectedUsername: string,
 ): GitHubContributionCalendarResult {
   if (!isRecord(payload)) throw new Error('GitHub GraphQL returned an invalid payload');
 
   const typedPayload = payload as GraphqlPayload;
-  if (typedPayload.errors?.length) {
-    const message = typedPayload.errors
-      .map((error) => (typeof error.message === 'string' ? error.message : 'GraphQL error'))
-      .join('; ');
-    throw new Error(`GitHub GraphQL contribution query failed: ${message}`);
+  if (
+    typedPayload.errors !== undefined
+    && (!Array.isArray(typedPayload.errors) || typedPayload.errors.length > 0)
+  ) {
+    throw new Error('GitHub GraphQL contribution query returned errors');
   }
 
-  const calendar = typedPayload.data?.user?.contributionsCollection?.contributionCalendar;
-  if (!calendar || !Number.isInteger(calendar.totalContributions) || !Array.isArray(calendar.weeks)) {
+  const user = typedPayload.data?.user;
+  if (!user || githubLogin(user.login) !== githubLogin(expectedUsername)) {
+    throw new Error('GitHub GraphQL contribution user did not match the request');
+  }
+  const calendar = user.contributionsCollection?.contributionCalendar;
+  if (
+    !calendar
+    || !Number.isSafeInteger(calendar.totalContributions)
+    || (calendar.totalContributions as number) < 0
+    || (calendar.totalContributions as number) > MAXIMUM_TOTAL_CONTRIBUTIONS
+    || !Array.isArray(calendar.weeks)
+    || calendar.weeks.length < 1
+    || calendar.weeks.length > MAXIMUM_CALENDAR_WEEKS
+  ) {
     throw new Error('GitHub GraphQL contribution calendar was missing');
   }
 
   const counts = new Map<string, number>();
+  let calculatedTotal = 0;
   for (const week of calendar.weeks) {
-    if (!isRecord(week) || !Array.isArray(week.contributionDays)) {
+    if (
+      !isRecord(week)
+      || !Array.isArray(week.contributionDays)
+      || week.contributionDays.length < 1
+      || week.contributionDays.length > MAXIMUM_DAYS_PER_WEEK
+    ) {
       throw new Error('GitHub GraphQL contribution week was invalid');
     }
     for (const day of week.contributionDays) {
-      if (
-        !isRecord(day) ||
-        typeof day.date !== 'string' ||
-        !/^\d{4}-\d{2}-\d{2}$/.test(day.date) ||
-        !Number.isInteger(day.contributionCount) ||
-        (day.contributionCount as number) < 0
-      ) {
+      if (!isRecord(day)) {
         throw new Error('GitHub GraphQL contribution day was invalid');
       }
-      counts.set(day.date, day.contributionCount as number);
+      const date = canonicalDate(day.date);
+      const count = boundedCount(day.contributionCount);
+      if (counts.has(date)) {
+        throw new Error('GitHub GraphQL contribution calendar contained duplicate dates');
+      }
+      counts.set(date, count);
+      calculatedTotal += count;
+      if (calculatedTotal > MAXIMUM_TOTAL_CONTRIBUTIONS) {
+        throw new Error('GitHub GraphQL contribution calendar total was invalid');
+      }
     }
   }
 
   if (counts.size === 0) throw new Error('GitHub GraphQL contribution calendar was empty');
+  if (calculatedTotal !== calendar.totalContributions) {
+    throw new Error('GitHub GraphQL contribution calendar total was inconsistent');
+  }
 
   return {
     counts,
@@ -127,26 +210,52 @@ export function parseGitHubContributionCalendar(
   };
 }
 
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (Buffer.byteLength(text, 'utf8') > MAXIMUM_RESPONSE_BYTES) {
+    throw new Error('GitHub GraphQL contribution response was too large');
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error('GitHub GraphQL contribution response was not valid JSON');
+  }
+}
+
 export async function fetchGitHubContributionCalendar(
   username: string,
   token: string,
   fetchImpl: FetchLike = fetch,
 ): Promise<GitHubContributionCalendarResult> {
-  const response = await fetchImpl(GITHUB_GRAPHQL_ENDPOINT, {
-    method: 'POST',
-    cache: 'no-store',
-    signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-      'User-Agent': 'teamleaderleo-scrapbook',
-      'X-GitHub-Api-Version': GITHUB_API_VERSION,
-    },
-    body: JSON.stringify({ query: CONTRIBUTION_CALENDAR_QUERY, variables: { login: username } }),
-  });
+  const expectedUsername = githubLogin(username);
+  let response: Response;
+  try {
+    response = await fetchImpl(GITHUB_GRAPHQL_ENDPOINT, {
+      method: 'POST',
+      cache: 'no-store',
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'teamleaderleo-scrapbook',
+        'X-GitHub-Api-Version': GITHUB_API_VERSION,
+      },
+      body: JSON.stringify({
+        query: CONTRIBUTION_CALENDAR_QUERY,
+        variables: { login: expectedUsername },
+      }),
+    });
+  } catch {
+    throw new Error('GitHub GraphQL contribution request failed');
+  }
 
-  if (!response.ok) throw new Error(`GitHub GraphQL returned ${response.status}`);
-  const parsed = parseGitHubContributionCalendar(await response.json());
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL contribution request returned ${response.status}`);
+  }
+  const parsed = parseGitHubContributionCalendar(
+    await readBoundedJson(response),
+    expectedUsername,
+  );
   return { ...parsed, rateLimit: parseRateLimitHeaders(response.headers) };
 }


### PR DESCRIPTION
Advances #488.

## Objective

Keep Scrapbook's optional authenticated GitHub profile read narrow, bounded, and server-side without changing the public-profile fallback or page design.

## Changes

- bind every GraphQL contribution response to the exact requested GitHub login;
- bound successful GitHub GraphQL response bodies to 256 KiB before JSON parsing;
- reject arrays where object records are required;
- bound calendar weeks, days, per-day counts, and total contributions;
- reject impossible dates, duplicate dates, and totals inconsistent with the returned day set;
- replace upstream GraphQL and network error text with stable local errors before the existing fallback logger sees it;
- project a public diagnostics object that excludes authenticated rate-limit state;
- remove detailed GitHub rate-limit telemetry from public JSON bodies and response headers;
- add focused hostile-response, cross-user, and redaction coverage.

## Credential boundary

`GITHUB_PROFILE_TOKEN` remains read only from server environment state and is used only in the GitHub GraphQL Authorization header. This PR does not add a token, inspect its actual scopes, expose it to the browser, or introduce repository write authority. Anonymous public-profile fallback remains unchanged.

The deployed token's presence, age, rotation state, and minimum `read:user` scope cannot be proven from repository access because GitHub does not expose secret values or token scopes. Those remain an explicit deployment verification gate.

## Scope

- `app/api/github-activity/route.ts`
- `lib/github-contribution-calendar.ts`
- `lib/github-contribution-calendar.test.ts`
- `lib/github-activity-response.ts`
- `lib/github-activity-response.test.ts`

Recovery: revert the squash commit. No durable data migration or deployment configuration changes are involved.