### PR TITLE
Keep activity tooltip ownership scoped through handoffs

### DIFF
--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -226,6 +226,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
             transform:
               'translate3d(var(--activity-tooltip-x, 12px), var(--activity-tooltip-y, 12px), 0)',
           }}
+          data-activity-tooltip
         >
           {tooltipLabel}
         </div>

--- a/tests/e2e/activity-paper-marks.spec.ts
+++ b/tests/e2e/activity-paper-marks.spec.ts
@@ -70,6 +70,42 @@ for (const theme of ['light', 'dark'] as const) {
   });
 }
 
+test('the hydrated activity grid keeps one owned tooltip anchored through click', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.setViewportSize({ width: 1280, height: 760 });
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const section = hydratedActivitySection(page);
+  await expect(section).toBeVisible({ timeout: 15_000 });
+  await expect(section).toHaveAttribute('data-fine-pointer', 'true');
+
+  const mark = section.locator('[data-paper-activity-mark]').nth(8);
+  const label = await mark.getAttribute('aria-label');
+  expect(label).toBeTruthy();
+  await expect(mark).toHaveAttribute('aria-pressed', 'false');
+
+  await mark.hover();
+  const tooltip = section.locator('[data-activity-tooltip]');
+  await expect(tooltip).toHaveCount(1);
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toHaveText(label!);
+  const before = await tooltip.boundingBox();
+  expect(before).not.toBeNull();
+
+  await mark.click();
+  await expect(mark).toHaveAttribute('aria-pressed', 'true');
+  await expect(tooltip).toHaveCount(1);
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toHaveText(label!);
+  const after = await tooltip.boundingBox();
+  expect(after).not.toBeNull();
+
+  expect(Math.abs(after!.x - before!.x)).toBeLessThan(1);
+  expect(Math.abs(after!.y - before!.y)).toBeLessThan(1);
+  expect(page.locator('[data-activity-tooltip]')).toHaveCount(1);
+});
+
 test('activity marks stay planted with reduced motion', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'dark' });
   await page.setViewportSize({ width: 390, height: 844 });

--- a/tests/e2e/activity-paper-marks.spec.ts
+++ b/tests/e2e/activity-paper-marks.spec.ts
@@ -103,7 +103,7 @@ test('the hydrated activity grid keeps one owned tooltip anchored through click'
 
   expect(Math.abs(after!.x - before!.x)).toBeLessThan(1);
   expect(Math.abs(after!.y - before!.y)).toBeLessThan(1);
-  expect(page.locator('[data-activity-tooltip]')).toHaveCount(1);
+  await expect(page.locator('[data-activity-tooltip]')).toHaveCount(1);
 });
 
 test('activity marks stay planted with reduced motion', async ({ page }) => {


### PR DESCRIPTION
Closes #487.

## Fix

- add an explicit `data-activity-tooltip` hook to the tooltip rendered by each activity-grid section;
- keep the browser locator inside the already-selected hydrated dashboard/activity section;
- prove hover produces exactly one owned tooltip;
- prove clicking the same activity mark preserves the same text and anchored coordinates;
- prove the page does not expose a second matching tooltip during the handoff.

## Boundary

No activity data, layout, colour, motion, tooltip positioning, selection semantics, or mobile behavior changes. The production change is one inert data attribute; the rest is browser regression coverage.

## Scope

- `components/home/activity-grid.tsx`
- `tests/e2e/activity-paper-marks.spec.ts`

Recovery: revert the squash commit.