### PR TITLE
Publish a small RSS feed for public writing

### DIFF
--- a/app/feed.xml/route.test.ts
+++ b/app/feed.xml/route.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getBlogPosts = vi.fn();
+
+vi.mock('@/app/lib/blog-utils', () => ({ getBlogPosts }));
+vi.mock('@/lib/agent-journal', () => ({
+  agentJournalEntries: [
+    {
+      id: 'journal-entry',
+      codename: 'Journal Agent',
+      occurredAt: '2026-07-29T11:00:00.000Z',
+      note: 'A public journal summary.',
+      model: 'GPT-5.6 Thinking',
+      artifact: {
+        kind: 'document',
+        path: '/journal/public-note.md',
+        label: 'Read the public journal note',
+      },
+    },
+    {
+      id: 'internal-record',
+      codename: 'Receipt Agent',
+      occurredAt: '2026-07-28T11:00:00.000Z',
+      note: 'This record has no public document.',
+    },
+  ],
+}));
+
+import { GET } from './route';
+
+describe('GET /feed.xml', () => {
+  beforeEach(() => {
+    getBlogPosts.mockResolvedValue([
+      {
+        slug: 'public-post',
+        title: 'Public post',
+        blurb: 'A public post summary.',
+        dateIso: '2026-07-30T12:00:00.000Z',
+        author: 'Leo Li',
+      },
+    ]);
+  });
+
+  it('returns public posts and document-backed journal entries as RSS', async () => {
+    const response = await GET();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/rss+xml; charset=utf-8');
+    expect(response.headers.get('x-content-type-options')).toBe('nosniff');
+    expect(xml).toContain('https://teamleaderleo.com/blog/public-post');
+    expect(xml).toContain('https://teamleaderleo.com/journal/public-note.md');
+    expect(xml).toContain('Journal Agent (GPT-5.6 Thinking)');
+    expect(xml).not.toContain('internal-record');
+    expect(xml.indexOf('Public post')).toBeLessThan(xml.indexOf('Read the public journal note'));
+  });
+});

--- a/app/feed.xml/route.test.ts
+++ b/app/feed.xml/route.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const getBlogPosts = vi.fn();
+const { getBlogPosts } = vi.hoisted(() => ({ getBlogPosts: vi.fn() }));
 
 vi.mock('@/app/lib/blog-utils', () => ({ getBlogPosts }));
 vi.mock('@/lib/agent-journal', () => ({

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,0 +1,60 @@
+import { getBlogPosts } from '@/app/lib/blog-utils';
+import { agentJournalEntries } from '@/lib/agent-journal';
+import { createRssFeed, type RssFeedItem } from '@/lib/rss-feed';
+
+const SITE_URL = 'https://teamleaderleo.com/';
+const FEED_URL = new URL('/feed.xml', SITE_URL).toString();
+
+function siteUrl(pathname: string): string {
+  const url = new URL(pathname, SITE_URL);
+  if (url.origin !== new URL(SITE_URL).origin) {
+    throw new Error(`Public feed path escaped the Scrapbook origin: ${pathname}`);
+  }
+  return url.toString();
+}
+
+export async function GET() {
+  const posts = await getBlogPosts();
+  const blogItems: RssFeedItem[] = posts.map((post) => {
+    const link = siteUrl(`/blog/${encodeURIComponent(post.slug)}`);
+    return {
+      id: link,
+      title: post.title,
+      summary: post.blurb,
+      publishedAt: post.dateIso,
+      link,
+      author: post.author,
+    };
+  });
+
+  const journalItems: RssFeedItem[] = agentJournalEntries.flatMap((entry) => {
+    if (entry.artifact?.kind !== 'document') return [];
+    const link = siteUrl(entry.artifact.path);
+    return [
+      {
+        id: link,
+        title: entry.artifact.label,
+        summary: entry.note,
+        publishedAt: entry.occurredAt,
+        link,
+        author: entry.model ? `${entry.codename} (${entry.model})` : entry.codename,
+      },
+    ];
+  });
+
+  const body = createRssFeed({
+    title: 'teamleaderleo — posts and journal',
+    description: 'Public writing, engineering notes, and selected journal entries from Leo Li.',
+    siteUrl: SITE_URL,
+    feedUrl: FEED_URL,
+    items: [...blogItems, ...journalItems],
+  });
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400',
+      'X-Content-Type-Options': 'nosniff',
+    },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,6 +49,7 @@ export default function RootLayout({
             color-scheme: dark;
           }
         `}</style>
+        <link rel="alternate" type="application/rss+xml" title="teamleaderleo RSS feed" href="/feed.xml" />
         <link rel="preconnect" href="https://vitals.vercel-insights.com" />
         <link rel="dns-prefetch" href="https://vitals.vercel-insights.com" />
       </head>

--- a/lib/rss-feed.test.ts
+++ b/lib/rss-feed.test.ts
@@ -36,7 +36,7 @@ describe('createRssFeed', () => {
       }),
     ]);
 
-    expect(xml).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
     expect(xml).toContain('<title>teamleaderleo &amp; notes</title>');
     expect(xml).toContain('<description>Posts &lt; journal entries</description>');
     expect(xml).toContain('Newer &lt;post&gt; &amp; &quot;notes&quot;');

--- a/lib/rss-feed.test.ts
+++ b/lib/rss-feed.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { createRssFeed, type RssFeedItem } from './rss-feed';
+
+const item = (overrides: Partial<RssFeedItem> = {}): RssFeedItem => ({
+  id: 'https://teamleaderleo.com/blog/older',
+  title: 'Older post',
+  summary: 'A useful summary.',
+  publishedAt: '2026-07-20T10:00:00.000Z',
+  link: 'https://teamleaderleo.com/blog/older',
+  author: 'Leo Li',
+  ...overrides,
+});
+
+function feed(items: RssFeedItem[], maximumItems?: number) {
+  return createRssFeed({
+    title: 'teamleaderleo & notes',
+    description: 'Posts < journal entries',
+    siteUrl: 'https://teamleaderleo.com/',
+    feedUrl: 'https://teamleaderleo.com/feed.xml',
+    items,
+    maximumItems,
+  });
+}
+
+describe('createRssFeed', () => {
+  it('sorts newest first and escapes XML-sensitive text', () => {
+    const xml = feed([
+      item(),
+      item({
+        id: 'https://teamleaderleo.com/blog/newer',
+        link: 'https://teamleaderleo.com/blog/newer',
+        title: 'Newer <post> & "notes"',
+        summary: "One 'careful' summary\u0001",
+        publishedAt: '2026-07-30T12:00:00.000Z',
+        author: 'Agent & editor',
+      }),
+    ]);
+
+    expect(xml).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<title>teamleaderleo &amp; notes</title>');
+    expect(xml).toContain('<description>Posts &lt; journal entries</description>');
+    expect(xml).toContain('Newer &lt;post&gt; &amp; &quot;notes&quot;');
+    expect(xml).toContain('One &apos;careful&apos; summary�');
+    expect(xml).toContain('<dc:creator>Agent &amp; editor</dc:creator>');
+    expect(xml.indexOf('/blog/newer')).toBeLessThan(xml.indexOf('/blog/older'));
+    expect(xml).toContain('<lastBuildDate>Thu, 30 Jul 2026 12:00:00 GMT</lastBuildDate>');
+  });
+
+  it('keeps item identities on the canonical site origin', () => {
+    expect(() =>
+      feed([
+        item({
+          id: 'https://example.com/copied',
+          link: 'https://example.com/copied',
+        }),
+      ]),
+    ).toThrow('must stay on the site origin');
+  });
+
+  it('rejects duplicate identities and bounds the item count', () => {
+    expect(() => feed([item(), item()])).toThrow('item id is duplicated');
+
+    const xml = feed(
+      [
+        item(),
+        item({
+          id: 'https://teamleaderleo.com/blog/newer',
+          link: 'https://teamleaderleo.com/blog/newer',
+          publishedAt: '2026-07-30T12:00:00.000Z',
+        }),
+      ],
+      1,
+    );
+    expect(xml).toContain('/blog/newer');
+    expect(xml).not.toContain('/blog/older');
+  });
+});

--- a/lib/rss-feed.ts
+++ b/lib/rss-feed.ts
@@ -1,0 +1,116 @@
+export type RssFeedItem = {
+  id: string;
+  title: string;
+  summary: string;
+  publishedAt: string;
+  link: string;
+  author: string;
+};
+
+export type RssFeedOptions = {
+  title: string;
+  description: string;
+  siteUrl: string;
+  feedUrl: string;
+  items: RssFeedItem[];
+  maximumItems?: number;
+};
+
+const DEFAULT_MAXIMUM_ITEMS = 50;
+
+function xmlText(value: string): string {
+  return value
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '\uFFFD')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function canonicalHttpsUrl(value: string, expectedOrigin?: string): string {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' || url.username || url.password) {
+    throw new Error(`RSS feed URL must use credential-free HTTPS: ${value}`);
+  }
+  if (expectedOrigin && url.origin !== expectedOrigin) {
+    throw new Error(`RSS feed item must stay on the site origin: ${value}`);
+  }
+  url.hash = '';
+  return url.toString();
+}
+
+function publishedTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) throw new Error(`RSS feed date is invalid: ${value}`);
+  return timestamp;
+}
+
+function boundedText(value: string, label: string, maximum: number): string {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maximum) {
+    throw new Error(`RSS feed ${label} must contain 1–${maximum} characters`);
+  }
+  return trimmed;
+}
+
+export function createRssFeed(options: RssFeedOptions): string {
+  const title = boundedText(options.title, 'title', 160);
+  const description = boundedText(options.description, 'description', 500);
+  const siteUrl = canonicalHttpsUrl(options.siteUrl);
+  const siteOrigin = new URL(siteUrl).origin;
+  const feedUrl = canonicalHttpsUrl(options.feedUrl, siteOrigin);
+  const maximumItems = options.maximumItems ?? DEFAULT_MAXIMUM_ITEMS;
+
+  if (!Number.isSafeInteger(maximumItems) || maximumItems < 1 || maximumItems > 200) {
+    throw new Error('RSS feed maximumItems must be an integer between 1 and 200');
+  }
+
+  const seenIds = new Set<string>();
+  const items = options.items
+    .map((item) => {
+      const id = canonicalHttpsUrl(item.id, siteOrigin);
+      if (seenIds.has(id)) throw new Error(`RSS feed item id is duplicated: ${id}`);
+      seenIds.add(id);
+
+      return {
+        id,
+        title: boundedText(item.title, 'item title', 240),
+        summary: boundedText(item.summary, 'item summary', 2_000),
+        publishedAt: publishedTimestamp(item.publishedAt),
+        link: canonicalHttpsUrl(item.link, siteOrigin),
+        author: boundedText(item.author, 'item author', 160),
+      };
+    })
+    .sort((left, right) => right.publishedAt - left.publishedAt)
+    .slice(0, maximumItems);
+
+  if (items.length === 0) throw new Error('RSS feed requires at least one public item');
+
+  const itemXml = items
+    .map(
+      (item) => `    <item>
+      <title>${xmlText(item.title)}</title>
+      <link>${xmlText(item.link)}</link>
+      <guid isPermaLink="true">${xmlText(item.id)}</guid>
+      <pubDate>${new Date(item.publishedAt).toUTCString()}</pubDate>
+      <dc:creator>${xmlText(item.author)}</dc:creator>
+      <description>${xmlText(item.summary)}</description>
+    </item>`,
+    )
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>${xmlText(title)}</title>
+    <link>${xmlText(siteUrl)}</link>
+    <description>${xmlText(description)}</description>
+    <language>en</language>
+    <lastBuildDate>${new Date(items[0].publishedAt).toUTCString()}</lastBuildDate>
+    <atom:link href="${xmlText(feedUrl)}" rel="self" type="application/rss+xml" />
+${itemXml}
+  </channel>
+</rss>
+`;
+}


### PR DESCRIPTION
Advances #312.

## Result

Publish one summary-only RSS 2.0 feed at `/feed.xml` containing:

- public blog posts with their existing canonical metadata;
- journal entries only when they point to an intentional public document artifact.

Internal journal receipts without a public document are excluded.

## Feed contract

- canonical origin: `https://teamleaderleo.com`;
- newest-first, bounded to 50 entries by default;
- stable permalink GUIDs;
- title, summary, publication date, creator, and canonical link;
- summary text only—no MDX rendering or private payloads;
- credential-free HTTPS and same-origin item validation;
- XML control-character replacement and entity escaping;
- duplicate identity rejection;
- RSS discovery through a global `<link rel="alternate">`.

## HTTP boundary

- `application/rss+xml; charset=utf-8`;
- `nosniff`;
- one-hour shared-cache freshness with stale revalidation;
- feed generation failure does not affect ordinary page routes.

## Scope

- `app/feed.xml/route.ts`
- `app/feed.xml/route.test.ts`
- `lib/rss-feed.ts`
- `lib/rss-feed.test.ts`
- one discovery link in `app/layout.tsx`

No dependencies, database changes, private routes, content rewrites, or site-navigation changes.

## Validation requested

- lint and typecheck;
- serializer and route tests;
- production build;
- existing Chromium and WebKit regressions.

After merge and deployment, #312 still needs one real feed-reader or validator smoke test before closure.

Recovery: revert the squash commit.