### PR TITLE
Superseded: GitHub activity state and four-week prototype

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -32,7 +32,7 @@ export async function GET() {
         today: activity.today,
         weekTotal: activity.weekTotal,
         yearTotal: activity.periodLabel === 'last year' ? activity.total : null,
-        days: activity.days.slice(-21),
+        days: activity.days,
         diagnostics,
       },
       { headers },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,21 +57,31 @@ function HomeActivityFallback() {
 async function HomeActivityContent() {
   await connection();
   const { activity } = await getGitHubHomeResult();
-  const days = activity.source === 'unavailable' ? [] : activity.days;
-  const yearTotal = activity.periodLabel === 'last year' ? activity.total : null;
 
   return (
     <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
       <ActivityDashboard
-        initial={{
-          source: activity.source,
-          today: activity.today,
-          weekTotal: activity.weekTotal,
-          yearTotal,
-          days,
-          unit: 'contributions',
-          generatedAt: activity.generatedAt,
-        }}
+        initial={
+          activity.source === 'unavailable'
+            ? {
+                source: 'unavailable',
+                today: null,
+                weekTotal: null,
+                yearTotal: null,
+                days: [],
+                unit: 'contributions',
+                generatedAt: activity.generatedAt,
+              }
+            : {
+                source: activity.source,
+                today: activity.today,
+                weekTotal: activity.weekTotal,
+                yearTotal: activity.total,
+                days: activity.days,
+                unit: 'contributions',
+                generatedAt: activity.generatedAt,
+              }
+        }
       />
 
       <section aria-label="Recent systems" className="min-w-0" data-recent-systems>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import { ActivityDashboard } from '@/components/home/activity-dashboard';
 import { WindLiftCard } from '@/components/home/wind-lift-card';
 import ViewportPageShell from '@/components/viewport-page-shell';
-import { getGitHubHomeData } from '@/lib/github-home';
+import { getGitHubHomeResult } from '@/lib/github-home';
 import { ArrowRight, ArrowUpRight, Brain, Images, Palette, Snowflake } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -56,14 +56,15 @@ function HomeActivityFallback() {
 
 async function HomeActivityContent() {
   await connection();
-  const activity = await getGitHubHomeData();
-  const days = activity.days.slice(-21);
+  const { activity } = await getGitHubHomeResult();
+  const days = activity.source === 'unavailable' ? [] : activity.days;
   const yearTotal = activity.periodLabel === 'last year' ? activity.total : null;
 
   return (
     <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
       <ActivityDashboard
         initial={{
+          source: activity.source,
           today: activity.today,
           weekTotal: activity.weekTotal,
           yearTotal,
@@ -142,7 +143,10 @@ async function HomeActivityContent() {
                 </span>
                 <span className="flex items-center justify-between gap-2 font-semibold">
                   {destination.label}
-                  <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                  <ArrowRight
+                    className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                    aria-hidden="true"
+                  />
                 </span>
               </Link>
             );

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -82,7 +82,13 @@ function readStoredSnapshot(): StoredActivitySnapshot | null {
     if (parsed.yearTotal !== null && (!isFiniteNumber(parsed.yearTotal) || parsed.yearTotal < 0)) {
       return null;
     }
-    if (!Array.isArray(parsed.days) || !parsed.days.every(isActivityGridDay)) return null;
+    if (
+      !Array.isArray(parsed.days) ||
+      parsed.days.length === 0 ||
+      !parsed.days.every(isActivityGridDay)
+    ) {
+      return null;
+    }
     if (typeof parsed.generatedAt !== 'string') return null;
     const generatedAt = Date.parse(parsed.generatedAt);
     if (!Number.isFinite(generatedAt)) return null;
@@ -153,6 +159,8 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   const consecutiveFailures = useRef(0);
 
   useEffect(() => {
+    setCalendarGeneratedAt(new Date().toISOString());
+
     if (initial.source === 'unavailable') {
       const stored = readStoredSnapshot();
       if (!stored) return;
@@ -163,7 +171,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       return;
     }
 
-    writeStoredSnapshot(initial);
+    if (initial.days.length > 0) writeStoredSnapshot(initial);
   }, [initial]);
 
   useEffect(() => {

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -8,8 +8,13 @@ import { useEffect, useRef, useState } from 'react';
 const REFRESH_INTERVAL_MS = GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS * 1_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_FAILURE_BACKOFF_MS = 5 * 60_000;
+const STORED_SNAPSHOT_KEY = 'scrapbook:github-activity:last-success:v1';
+
+type ActivitySource = 'github-graphql' | 'public-profile' | 'unavailable';
+type SuccessfulActivitySource = Exclude<ActivitySource, 'unavailable'>;
 
 type ActivitySnapshot = {
+  source: ActivitySource;
   today: number;
   weekTotal: number;
   yearTotal: number | null;
@@ -18,8 +23,12 @@ type ActivitySnapshot = {
   generatedAt: string;
 };
 
+type StoredActivitySnapshot = ActivitySnapshot & {
+  source: SuccessfulActivitySource;
+};
+
 type LiveActivityResponse = {
-  source: 'github-graphql' | 'public-profile';
+  source: SuccessfulActivitySource;
   today: number;
   weekTotal: number;
   yearTotal: number | null;
@@ -32,14 +41,118 @@ function timestampOrNow(value: string) {
   return Number.isFinite(timestamp) ? timestamp : Date.now();
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isActivityGridDay(value: unknown): value is ActivityGridDay {
+  return (
+    isRecord(value) &&
+    typeof value.date === 'string' &&
+    /^\d{4}-\d{2}-\d{2}$/.test(value.date) &&
+    isFiniteNumber(value.count) &&
+    value.count >= 0
+  );
+}
+
+function readStoredSnapshot(): StoredActivitySnapshot | null {
+  try {
+    const value = window.localStorage.getItem(STORED_SNAPSHOT_KEY);
+    if (!value) return null;
+
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed)) return null;
+    if (parsed.source !== 'github-graphql' && parsed.source !== 'public-profile') return null;
+    if (!isFiniteNumber(parsed.today) || parsed.today < 0) return null;
+    if (!isFiniteNumber(parsed.weekTotal) || parsed.weekTotal < 0) return null;
+    if (parsed.yearTotal !== null && (!isFiniteNumber(parsed.yearTotal) || parsed.yearTotal < 0)) {
+      return null;
+    }
+    if (!Array.isArray(parsed.days) || !parsed.days.every(isActivityGridDay)) return null;
+    if (typeof parsed.generatedAt !== 'string' || !Number.isFinite(Date.parse(parsed.generatedAt))) {
+      return null;
+    }
+
+    return {
+      source: parsed.source,
+      today: parsed.today,
+      weekTotal: parsed.weekTotal,
+      yearTotal: parsed.yearTotal,
+      days: parsed.days,
+      unit: 'contributions',
+      generatedAt: parsed.generatedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSnapshot(snapshot: StoredActivitySnapshot) {
+  try {
+    window.localStorage.setItem(STORED_SNAPSHOT_KEY, JSON.stringify(snapshot));
+  } catch {
+    // Storage can be disabled or full. The live snapshot remains usable in memory.
+  }
+}
+
+function ActivityUnavailableScoreboard({ updating }: { updating: boolean }) {
+  return (
+    <section
+      className="flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] [@media(max-height:780px)]:min-h-[14.5rem]"
+      data-activity-scoreboard
+      data-activity-unavailable
+    >
+      <div className="border-b border-border/70 bg-muted/70 px-4 py-2.5 [@media(max-height:780px)]:py-2">
+        <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+          <span>Today</span>
+          <span>{updating ? 'retrying' : 'GitHub'}</span>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col justify-center gap-3 p-5 sm:p-6">
+        <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Activity unavailable
+        </p>
+        <p className="max-w-md text-lg font-semibold tracking-tight sm:text-xl">
+          GitHub could not supply a contribution snapshot.
+        </p>
+        <p className="max-w-md text-sm leading-relaxed text-muted-foreground">
+          This page will retry while it remains open. A previous successful browser snapshot appears automatically when one exists.
+        </p>
+      </div>
+    </section>
+  );
+}
+
 export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   const initialSnapshotAt = timestampOrNow(initial.generatedAt);
   const [activity, setActivity] = useState(initial);
+  const [calendarGeneratedAt, setCalendarGeneratedAt] = useState(initial.generatedAt);
+  const [restoredFromBrowser, setRestoredFromBrowser] = useState(false);
   const [updating, setUpdating] = useState(false);
   const inFlight = useRef<AbortController | null>(null);
-  const newestSnapshotAt = useRef(initialSnapshotAt);
-  const nextAllowedAt = useRef(initialSnapshotAt + REFRESH_INTERVAL_MS);
+  const newestSnapshotAt = useRef(initial.source === 'unavailable' ? 0 : initialSnapshotAt);
+  const nextAllowedAt = useRef(
+    initial.source === 'unavailable' ? Date.now() : initialSnapshotAt + REFRESH_INTERVAL_MS,
+  );
   const consecutiveFailures = useRef(0);
+
+  useEffect(() => {
+    if (initial.source === 'unavailable') {
+      const stored = readStoredSnapshot();
+      if (!stored) return;
+
+      newestSnapshotAt.current = timestampOrNow(stored.generatedAt);
+      setActivity(stored);
+      setRestoredFromBrowser(true);
+      return;
+    }
+
+    writeStoredSnapshot(initial as StoredActivitySnapshot);
+  }, [initial]);
 
   useEffect(() => {
     let mounted = true;
@@ -74,11 +187,15 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
         const nextGeneratedAt = timestampOrNow(next.generatedAt);
         if (nextGeneratedAt < newestSnapshotAt.current) return;
 
-        newestSnapshotAt.current = nextGeneratedAt;
-        setActivity({
+        const nextSnapshot: StoredActivitySnapshot = {
           ...next,
           unit: 'contributions',
-        });
+        };
+        newestSnapshotAt.current = nextGeneratedAt;
+        setActivity(nextSnapshot);
+        setCalendarGeneratedAt(new Date().toISOString());
+        setRestoredFromBrowser(false);
+        writeStoredSnapshot(nextSnapshot);
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError' && !timeoutExpired) return;
         consecutiveFailures.current += 1;
@@ -130,10 +247,14 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
     };
   }, []);
 
+  const hasSuccessfulSnapshot = activity.source !== 'unavailable' && activity.days.length > 0;
+
   return (
     <div
       className="relative grid min-w-0 items-stretch gap-3.5 sm:gap-4"
       data-home-activity-dashboard
+      data-home-activity-source={activity.source}
+      data-home-activity-restored={restoredFromBrowser ? 'true' : 'false'}
       style={{
         gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 24rem), 1fr))',
       }}
@@ -141,13 +262,33 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       <span className="sr-only" aria-live="polite">
         {updating ? 'Updating GitHub activity' : ''}
       </span>
-      <ActivityScoreboard
-        today={activity.today}
-        weekTotal={activity.weekTotal}
-        yearTotal={activity.yearTotal}
-        updating={updating}
+
+      {restoredFromBrowser ? (
+        <p
+          className="col-span-full rounded-xl border border-border/65 bg-muted/45 px-3 py-2 font-mono text-[9px] uppercase tracking-[0.13em] text-muted-foreground"
+          data-home-activity-saved-snapshot
+        >
+          Showing the last successful browser snapshot while GitHub activity refreshes.
+        </p>
+      ) : null}
+
+      {hasSuccessfulSnapshot ? (
+        <ActivityScoreboard
+          today={activity.today}
+          weekTotal={activity.weekTotal}
+          yearTotal={activity.yearTotal}
+          updating={updating}
+        />
+      ) : (
+        <ActivityUnavailableScoreboard updating={updating} />
+      )}
+
+      <ActivityGrid
+        days={hasSuccessfulSnapshot ? activity.days : []}
+        unit={activity.unit}
+        generatedAt={calendarGeneratedAt}
+        unavailableMessage="GitHub activity is temporarily unavailable."
       />
-      <ActivityGrid days={activity.days} unit={activity.unit} />
     </div>
   );
 }

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -9,12 +9,13 @@ const REFRESH_INTERVAL_MS = GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS * 1_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_FAILURE_BACKOFF_MS = 5 * 60_000;
 const STORED_SNAPSHOT_KEY = 'scrapbook:github-activity:last-success:v1';
+const MAX_STORED_SNAPSHOT_AGE_MS = 24 * 60 * 60_000;
 
 type ActivitySource = 'github-graphql' | 'public-profile' | 'unavailable';
 type SuccessfulActivitySource = Exclude<ActivitySource, 'unavailable'>;
 
-type ActivitySnapshot = {
-  source: ActivitySource;
+type SuccessfulActivitySnapshot = {
+  source: SuccessfulActivitySource;
   today: number;
   weekTotal: number;
   yearTotal: number | null;
@@ -23,9 +24,18 @@ type ActivitySnapshot = {
   generatedAt: string;
 };
 
-type StoredActivitySnapshot = ActivitySnapshot & {
-  source: SuccessfulActivitySource;
+type UnavailableActivitySnapshot = {
+  source: 'unavailable';
+  today: null;
+  weekTotal: null;
+  yearTotal: null;
+  days: [];
+  unit: string;
+  generatedAt: string;
 };
+
+type ActivitySnapshot = SuccessfulActivitySnapshot | UnavailableActivitySnapshot;
+type StoredActivitySnapshot = SuccessfulActivitySnapshot;
 
 type LiveActivityResponse = {
   source: SuccessfulActivitySource;
@@ -73,9 +83,11 @@ function readStoredSnapshot(): StoredActivitySnapshot | null {
       return null;
     }
     if (!Array.isArray(parsed.days) || !parsed.days.every(isActivityGridDay)) return null;
-    if (typeof parsed.generatedAt !== 'string' || !Number.isFinite(Date.parse(parsed.generatedAt))) {
-      return null;
-    }
+    if (typeof parsed.generatedAt !== 'string') return null;
+    const generatedAt = Date.parse(parsed.generatedAt);
+    if (!Number.isFinite(generatedAt)) return null;
+    if (generatedAt > Date.now() + 5 * 60_000) return null;
+    if (Date.now() - generatedAt > MAX_STORED_SNAPSHOT_AGE_MS) return null;
 
     return {
       source: parsed.source,
@@ -151,7 +163,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       return;
     }
 
-    writeStoredSnapshot(initial as StoredActivitySnapshot);
+    writeStoredSnapshot(initial);
   }, [initial]);
 
   useEffect(() => {
@@ -247,7 +259,8 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
     };
   }, []);
 
-  const hasSuccessfulSnapshot = activity.source !== 'unavailable' && activity.days.length > 0;
+  const successfulActivity =
+    activity.source === 'unavailable' || activity.days.length === 0 ? null : activity;
 
   return (
     <div
@@ -272,11 +285,11 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
         </p>
       ) : null}
 
-      {hasSuccessfulSnapshot ? (
+      {successfulActivity ? (
         <ActivityScoreboard
-          today={activity.today}
-          weekTotal={activity.weekTotal}
-          yearTotal={activity.yearTotal}
+          today={successfulActivity.today}
+          weekTotal={successfulActivity.weekTotal}
+          yearTotal={successfulActivity.yearTotal}
           updating={updating}
         />
       ) : (
@@ -284,7 +297,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       )}
 
       <ActivityGrid
-        days={hasSuccessfulSnapshot ? activity.days : []}
+        days={successfulActivity?.days ?? []}
         unit={activity.unit}
         generatedAt={calendarGeneratedAt}
         unavailableMessage="GitHub activity is temporarily unavailable."

--- a/components/home/activity-grid.module.css
+++ b/components/home/activity-grid.module.css
@@ -26,6 +26,40 @@
     0 2px 5px rgb(58 45 31 / 0.08);
 }
 
+.etchedMark {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid hsl(var(--foreground) / 0.14);
+  background-color: hsl(var(--muted) / 0.22);
+  box-shadow: inset 0 0 0 1px hsl(var(--background) / 0.35);
+}
+
+.upcomingMark {
+  opacity: 0.48;
+  background-image:
+    linear-gradient(112deg, transparent 18%, hsl(var(--foreground) / 0.08) 19%, transparent 21%),
+    linear-gradient(24deg, transparent 52%, hsl(var(--foreground) / 0.055) 53%, transparent 55%);
+}
+
+.upcomingMark::after {
+  position: absolute;
+  inset: 22%;
+  border: 1px dashed hsl(var(--foreground) / 0.16);
+  border-radius: 0.18rem;
+  content: '';
+}
+
+.unavailableMark {
+  opacity: 0.62;
+  background-image: repeating-linear-gradient(
+    -36deg,
+    transparent 0,
+    transparent 4px,
+    hsl(var(--foreground) / 0.055) 4px,
+    hsl(var(--foreground) / 0.055) 5px
+  );
+}
+
 :global(.dark) .paperMark {
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.07),
@@ -41,6 +75,12 @@
     0 4px 9px rgb(0 0 0 / 0.28);
 }
 
+:global(.dark) .etchedMark {
+  border-color: hsl(var(--foreground) / 0.18);
+  background-color: hsl(var(--muted) / 0.15);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.025);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .paperMark {
     transition: none;
@@ -51,10 +91,15 @@
   .paperMark,
   .paperMark:hover,
   .paperMark:focus-visible,
-  .paperMark[aria-pressed='true'] {
+  .paperMark[aria-pressed='true'],
+  .etchedMark {
     border: 1px solid CanvasText;
     background: Canvas;
     color: CanvasText;
     box-shadow: none;
+  }
+
+  .upcomingMark::after {
+    border-color: CanvasText;
   }
 }

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { alignContributionDaysToWeekColumns } from '@/lib/github-activity-utils';
+import {
+  buildFourWeekContributionCells,
+  dateKeyInTimeZone,
+  type FourWeekContributionCell,
+} from '@/lib/github-activity-utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './activity-grid.module.css';
 
@@ -9,15 +13,37 @@ export type ActivityGridDay = {
   count: number;
 };
 
-const WEEKDAY_LABELS = ['Sun', '', 'Tue', '', 'Thu', '', 'Sat'] as const;
+const WEEKDAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', 'Sun'] as const;
+const WEEK_COUNT = 4;
+
+function dateFromKey(date: string): Date {
+  return new Date(`${date}T00:00:00Z`);
+}
 
 function formatDay(date: string): string {
-  return new Intl.DateTimeFormat('en-GB', {
-    weekday: 'short',
-    month: 'short',
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'long',
     day: 'numeric',
     timeZone: 'UTC',
-  }).format(new Date(`${date}T00:00:00Z`));
+  }).format(dateFromKey(date));
+}
+
+function formatMonth(date: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    month: 'short',
+    timeZone: 'UTC',
+  }).format(dateFromKey(date));
+}
+
+function weekMonthLabel(cells: FourWeekContributionCell<ActivityGridDay>[]): string {
+  const first = cells[0]?.date;
+  const last = cells.at(-1)?.date;
+  if (!first || !last) return '';
+
+  const firstMonth = formatMonth(first);
+  const lastMonth = formatMonth(last);
+  return firstMonth === lastMonth ? firstMonth : `${firstMonth} / ${lastMonth}`;
 }
 
 function activityClass(count: number, maximum: number): string {
@@ -36,16 +62,46 @@ function labelForDay(day: ActivityGridDay, unit: string) {
   return `${formatDay(day.date)} · ${day.count.toLocaleString('en-GB')} ${unit}`;
 }
 
-export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: string }) {
-  const maximum = Math.max(...days.map((day) => day.count), 0);
-  const gridDays = useMemo(() => alignContributionDaysToWeekColumns(days), [days]);
-  const weekCount = Math.max(1, gridDays.length / 7);
-  const calendarMaxWidthRem = 2.3 + weekCount * 3.15;
-  const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
+function referenceDate(value: string): Date {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+export function ActivityGrid({
+  days,
+  unit,
+  generatedAt,
+  unavailableMessage = 'GitHub activity is temporarily unavailable.',
+}: {
+  days: ActivityGridDay[];
+  unit: string;
+  generatedAt: string;
+  unavailableMessage?: string;
+}) {
+  const calendarDate = useMemo(() => referenceDate(generatedAt), [generatedAt]);
+  const today = dateKeyInTimeZone(calendarDate);
+  const cells = useMemo(
+    () => buildFourWeekContributionCells(days, calendarDate),
+    [calendarDate, days],
+  );
+  const recordedDays = useMemo(
+    () => cells.flatMap((cell) => (cell.state === 'recorded' ? [cell.day] : [])),
+    [cells],
+  );
+  const maximum = Math.max(...recordedDays.map((day) => day.count), 0);
+  const weekLabels = useMemo(
+    () =>
+      Array.from({ length: WEEK_COUNT }, (_, index) =>
+        weekMonthLabel(cells.slice(index * 7, index * 7 + 7)),
+      ),
+    [cells],
+  );
+  const latestRecordedDate = recordedDays.at(-1)?.date ?? '';
+  const [selectedDate, setSelectedDate] = useState(latestRecordedDate);
   const [tooltipDate, setTooltipDate] = useState<string | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [finePointer, setFinePointer] = useState(false);
-  const previousLatest = useRef(days.at(-1)?.date ?? '');
+  const previousLatest = useRef(latestRecordedDate);
   const sectionRef = useRef<HTMLElement | null>(null);
   const hideTimer = useRef<number | null>(null);
   const positionFrame = useRef<number | null>(null);
@@ -67,21 +123,24 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   }, []);
 
   useEffect(() => {
-    const latest = days.at(-1)?.date ?? '';
     setSelectedDate((current) => {
-      if (!current || current === previousLatest.current || !days.some((day) => day.date === current)) {
-        return latest;
+      if (
+        !current ||
+        current === previousLatest.current ||
+        !recordedDays.some((day) => day.date === current)
+      ) {
+        return latestRecordedDate;
       }
       return current;
     });
-    previousLatest.current = latest;
-  }, [days]);
+    previousLatest.current = latestRecordedDate;
+  }, [latestRecordedDate, recordedDays]);
 
-  const selected = days.find((day) => day.date === selectedDate);
-  const tooltipDay = days.find((day) => day.date === tooltipDate);
+  const selected = recordedDays.find((day) => day.date === selectedDate);
+  const tooltipDay = recordedDays.find((day) => day.date === tooltipDate);
   const selectedLabel = useMemo(
-    () => (selected ? labelForDay(selected, unit) : ''),
-    [selected, unit],
+    () => (selected ? labelForDay(selected, unit) : unavailableMessage),
+    [selected, unit, unavailableMessage],
   );
   const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
 
@@ -126,7 +185,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     >
       <div className="flex items-center justify-between gap-4">
         <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          21 days · UTC
+          4 weeks · UTC
         </span>
         <div
           className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
@@ -142,10 +201,20 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div
-        className="mx-auto mt-3 grid w-full grid-cols-[1.65rem_minmax(0,1fr)] gap-2 sm:gap-2.5 [@media(max-height:780px)]:mt-2"
-        style={{ maxWidth: `min(100%, ${calendarMaxWidthRem}rem)` }}
-      >
+      <div className="mx-auto mt-3 grid w-full max-w-[15rem] grid-cols-[1.65rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 sm:max-w-[17rem] sm:gap-x-2.5 [@media(max-height:780px)]:mt-2">
+        <span aria-hidden="true" />
+        <div
+          className="grid grid-cols-4 gap-1.5 px-px font-mono text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground sm:gap-2"
+          aria-hidden="true"
+          data-contribution-month-labels
+        >
+          {weekLabels.map((label, index) => (
+            <span key={`${label}-${index}`} className="truncate text-center">
+              {label}
+            </span>
+          ))}
+        </div>
+
         <div
           className="grid grid-rows-7 gap-1.5 py-px font-mono text-[8px] font-medium text-muted-foreground sm:gap-2"
           aria-hidden="true"
@@ -160,41 +229,67 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         <div
           className="grid min-w-0 gap-1.5 sm:gap-2"
           style={{
-            gridTemplateColumns: `repeat(${weekCount}, minmax(0, 1fr))`,
+            gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
             gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
           }}
-          aria-label="GitHub contribution calendar for the last 21 days"
+          aria-label="GitHub contribution calendar for three completed weeks and the current week"
+          data-calendar-weeks="4"
           data-contribution-week-grid
           data-paper-activity-grid
         >
-          {gridDays.map((day, index) => {
+          {cells.map((cell, index) => {
             const gridColumn = Math.floor(index / 7) + 1;
             const gridRow = (index % 7) + 1;
+            const sharedStyle = { gridColumn, gridRow };
 
-            if (!day) {
+            if (cell.state === 'upcoming') {
               return (
                 <span
-                  key={`empty-${index}`}
-                  aria-hidden="true"
-                  className="aspect-square min-w-0 rounded-[0.38rem]"
-                  style={{ gridColumn, gridRow }}
+                  key={cell.date}
+                  role="img"
+                  aria-label={`${formatDay(cell.date)} — upcoming.`}
+                  className={`${styles.etchedMark} ${styles.upcomingMark} aspect-square min-w-0 rounded-[0.38rem]`}
+                  style={sharedStyle}
+                  data-contribution-cell
+                  data-contribution-date={cell.date}
+                  data-contribution-state="upcoming"
+                  data-contribution-upcoming
                 />
               );
             }
 
+            if (cell.state === 'unavailable') {
+              return (
+                <span
+                  key={cell.date}
+                  role="img"
+                  aria-label={`${formatDay(cell.date)} — activity unavailable.`}
+                  className={`${styles.etchedMark} ${styles.unavailableMark} aspect-square min-w-0 rounded-[0.38rem]`}
+                  style={sharedStyle}
+                  data-contribution-cell
+                  data-contribution-date={cell.date}
+                  data-contribution-state="unavailable"
+                  data-contribution-unavailable
+                />
+              );
+            }
+
+            const day = cell.day;
             const label = labelForDay(day, unit);
             const isSelected = day.date === selected?.date;
-            const isLatest = day.date === days.at(-1)?.date;
+            const isToday = day.date === today;
 
             return (
               <button
                 key={day.date}
                 type="button"
-                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
-                style={{ gridColumn, gridRow }}
+                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isToday ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
+                style={sharedStyle}
                 aria-label={label}
                 aria-pressed={isSelected}
+                data-contribution-cell
                 data-contribution-date={day.date}
+                data-contribution-state="recorded"
                 data-paper-activity-mark
                 onPointerEnter={(event) => showTooltip(day.date, event.clientX, event.clientY)}
                 onPointerMove={(event) => {
@@ -215,7 +310,10 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden" aria-live="polite">
+      <div
+        className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden"
+        aria-live="polite"
+      >
         {selectedLabel}
       </div>
 

--- a/lib/github-activity-response.test.ts
+++ b/lib/github-activity-response.test.ts
@@ -3,20 +3,37 @@ import { createGitHubActivityHeaders } from './github-activity-response';
 import type { GitHubHomeResult } from './github-home';
 
 function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResult {
+  const common = {
+    username: 'teamleaderleo',
+    generatedAt: '2026-07-27T01:00:00.000Z',
+    repositories: [],
+  };
+
   return {
-    activity: {
-      username: 'teamleaderleo',
-      source,
-      generatedAt: '2026-07-27T01:00:00.000Z',
-      total: 18,
-      periodLabel: source === 'unavailable' ? 'last 35 days' : 'last year',
-      today: 3,
-      weekTotal: 9,
-      activeDays: 5,
-      currentStreak: 2,
-      days: [],
-      repositories: [],
-    },
+    activity:
+      source === 'unavailable'
+        ? {
+            ...common,
+            source,
+            total: null,
+            periodLabel: 'last 35 days',
+            today: null,
+            weekTotal: null,
+            activeDays: null,
+            currentStreak: null,
+            days: [],
+          }
+        : {
+            ...common,
+            source,
+            total: 18,
+            periodLabel: 'last year',
+            today: 3,
+            weekTotal: 9,
+            activeDays: 5,
+            currentStreak: 2,
+            days: [],
+          },
     diagnostics: {
       cacheStatus: 'stale',
       upstreamSource: source,

--- a/lib/github-activity-utils.ts
+++ b/lib/github-activity-utils.ts
@@ -5,6 +5,21 @@ export type ContributionGridDay = {
   count: number;
 };
 
+export type FourWeekContributionCell<T extends ContributionGridDay> =
+  | {
+      date: string;
+      state: 'recorded';
+      day: T;
+    }
+  | {
+      date: string;
+      state: 'upcoming';
+    }
+  | {
+      date: string;
+      state: 'unavailable';
+    };
+
 export function dateKeyInTimeZone(date: Date, timeZone = DISPLAY_TIME_ZONE): string {
   const parts = new Intl.DateTimeFormat('en-CA', {
     timeZone,
@@ -25,6 +40,40 @@ export function getRecentDateKeys(now = new Date(), length = 7): string[] {
   return Array.from({ length: safeLength }, (_, index) => {
     const date = new Date(Date.UTC(year, month - 1, day - (safeLength - 1 - index)));
     return date.toISOString().slice(0, 10);
+  });
+}
+
+export function getFourWeekDateKeys(now = new Date()): string[] {
+  const [year, month, day] = dateKeyInTimeZone(now)
+    .split('-')
+    .map(Number);
+  const today = new Date(Date.UTC(year, month - 1, day));
+  const daysSinceMonday = (today.getUTCDay() + 6) % 7;
+  const currentMonday = new Date(Date.UTC(year, month - 1, day - daysSinceMonday));
+  const firstMonday = new Date(currentMonday);
+  firstMonday.setUTCDate(firstMonday.getUTCDate() - 21);
+
+  return Array.from({ length: 28 }, (_, index) => {
+    const date = new Date(firstMonday);
+    date.setUTCDate(firstMonday.getUTCDate() + index);
+    return date.toISOString().slice(0, 10);
+  });
+}
+
+export function buildFourWeekContributionCells<T extends ContributionGridDay>(
+  days: T[],
+  now = new Date(),
+): FourWeekContributionCell<T>[] {
+  const today = dateKeyInTimeZone(now);
+  const byDate = new Map(days.map((day) => [day.date, day]));
+
+  return getFourWeekDateKeys(now).map((date) => {
+    if (date > today) return { date, state: 'upcoming' };
+
+    const day = byDate.get(date);
+    if (!day) return { date, state: 'unavailable' };
+
+    return { date, state: 'recorded', day };
   });
 }
 

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   alignContributionDaysToWeekColumns,
+  buildFourWeekContributionCells,
+  getFourWeekDateKeys,
   getRecentDateKeys,
   parsePublicContributionHtml,
   parsePublicContributionTotal,
@@ -65,6 +67,40 @@ describe('getRecentDateKeys', () => {
     expect(days).toHaveLength(35);
     expect(days[0]).toBe('2026-06-21');
     expect(days.at(-1)).toBe('2026-07-25');
+  });
+});
+
+describe('four-week contribution field', () => {
+  const now = new Date('2026-07-31T08:00:00Z');
+
+  it('renders three completed Monday-Sunday weeks plus the current week', () => {
+    const dates = getFourWeekDateKeys(now);
+
+    expect(dates).toHaveLength(28);
+    expect(dates[0]).toBe('2026-07-06');
+    expect(dates[20]).toBe('2026-07-26');
+    expect(dates[21]).toBe('2026-07-27');
+    expect(dates.at(-1)).toBe('2026-08-02');
+  });
+
+  it('keeps future dates upcoming and missing past data unavailable', () => {
+    const cells = buildFourWeekContributionCells([], now);
+
+    expect(cells.slice(0, 26).every((cell) => cell.state === 'unavailable')).toBe(true);
+    expect(cells.slice(26).map((cell) => cell.state)).toEqual(['upcoming', 'upcoming']);
+  });
+
+  it('preserves a recorded zero without using zero for missing data', () => {
+    const cells = buildFourWeekContributionCells([{ date: '2026-07-31', count: 0 }], now);
+    const today = cells.find((cell) => cell.date === '2026-07-31');
+    const yesterday = cells.find((cell) => cell.date === '2026-07-30');
+
+    expect(today).toEqual({
+      date: '2026-07-31',
+      state: 'recorded',
+      day: { date: '2026-07-31', count: 0 },
+    });
+    expect(yesterday).toEqual({ date: '2026-07-30', state: 'unavailable' });
   });
 });
 

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -7,7 +7,7 @@ import {
   parsePublicContributionHtml,
   parsePublicContributionTotal,
 } from './github-activity-utils';
-import { parseGitHubRateLimit } from './github-home';
+import { createUnavailableGitHubHomeData, parseGitHubRateLimit } from './github-home';
 
 describe('parsePublicContributionHtml', () => {
   it('reads direct data-count attributes', () => {
@@ -121,6 +121,22 @@ describe('alignContributionDaysToWeekColumns', () => {
     expect(cells[6]).toEqual(days[3]);
     expect(cells[7]).toEqual(days[4]);
     expect(cells.slice(8)).toEqual([null, null, null, null, null, null]);
+  });
+});
+
+describe('createUnavailableGitHubHomeData', () => {
+  it('keeps a cold-cache upstream failure free of manufactured zero activity', () => {
+    const activity = createUnavailableGitHubHomeData(new Date('2026-07-31T08:00:00Z'));
+
+    expect(activity).toMatchObject({
+      source: 'unavailable',
+      total: null,
+      today: null,
+      weekTotal: null,
+      activeDays: null,
+      currentStreak: null,
+      days: [],
+    });
   });
 });
 

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -51,23 +51,39 @@ export type GitHubRateLimit = {
   resource: string | null;
 };
 
-export type GitHubHomeData = {
+type GitHubHomeCommon = {
   username: string;
-  source: 'github-graphql' | 'public-profile' | 'unavailable';
   generatedAt: string;
-  total: number | null;
-  periodLabel: 'last year' | 'last 35 days';
-  today: number;
-  weekTotal: number;
-  activeDays: number;
-  currentStreak: number;
-  days: ContributionDay[];
   repositories: Array<{
     name: string;
     url: string;
     note: string;
   }>;
 };
+
+type GitHubAvailableHomeData = GitHubHomeCommon & {
+  source: 'github-graphql' | 'public-profile';
+  total: number | null;
+  periodLabel: 'last year';
+  today: number;
+  weekTotal: number;
+  activeDays: number;
+  currentStreak: number;
+  days: ContributionDay[];
+};
+
+type GitHubUnavailableHomeData = GitHubHomeCommon & {
+  source: 'unavailable';
+  total: null;
+  periodLabel: 'last 35 days';
+  today: null;
+  weekTotal: null;
+  activeDays: null;
+  currentStreak: null;
+  days: [];
+};
+
+export type GitHubHomeData = GitHubAvailableHomeData | GitHubUnavailableHomeData;
 
 export type GitHubActivityDiagnostics = {
   cacheStatus: 'hit' | 'miss' | 'stale';
@@ -86,11 +102,11 @@ export type GitHubHomeResult = {
 
 type ActivitySource = GitHubHomeData['source'];
 type ActivitySummary = Pick<
-  GitHubHomeData,
+  GitHubAvailableHomeData,
   'total' | 'periodLabel' | 'today' | 'weekTotal' | 'activeDays' | 'currentStreak' | 'days'
 >;
 type UpstreamActivity = {
-  activity: GitHubHomeData;
+  activity: GitHubAvailableHomeData;
   rateLimit: GitHubRateLimit | null;
 };
 
@@ -115,25 +131,18 @@ function countCurrentStreak(days: ContributionDay[]): number {
 
 function summarizeCounts(
   counts: Map<string, number>,
-  source: ActivitySource,
   now = new Date(),
   reportedTotal: number | null = null,
 ): ActivitySummary {
   const days = daysFromCounts(counts, now);
   const today = dateKeyInTimeZone(now);
-  const hasRollingYearCalendar = source !== 'unavailable';
-  const periodLabel: GitHubHomeData['periodLabel'] = hasRollingYearCalendar
-    ? 'last year'
-    : 'last 35 days';
-  const periodEntries = hasRollingYearCalendar
-    ? [...counts.entries()].filter(([date]) => date <= today)
-    : days.map((day) => [day.date, day.count] as const);
-  const streakDays = hasRollingYearCalendar ? daysFromCounts(counts, now, 366) : days;
+  const periodEntries = [...counts.entries()].filter(([date]) => date <= today);
+  const streakDays = daysFromCounts(counts, now, 366);
   const calculatedTotal = periodEntries.reduce((sum, [, count]) => sum + count, 0);
 
   return {
-    total: hasRollingYearCalendar && reportedTotal !== null ? reportedTotal : calculatedTotal,
-    periodLabel,
+    total: reportedTotal ?? calculatedTotal,
+    periodLabel: 'last year',
     today: days.at(-1)?.count ?? 0,
     weekTotal: days.slice(-7).reduce((sum, day) => sum + day.count, 0),
     activeDays: periodEntries.filter(([, count]) => count > 0).length,
@@ -198,14 +207,18 @@ function featuredRepositories(): GitHubHomeData['repositories'] {
   return FEATURED_REPOSITORIES.map((repository) => ({ ...repository }));
 }
 
-function unavailableHomeData(now = new Date()): GitHubHomeData {
-  const summary = summarizeCounts(new Map(), 'unavailable', now);
+export function createUnavailableGitHubHomeData(now = new Date()): GitHubUnavailableHomeData {
   return {
     username: GITHUB_USERNAME,
     source: 'unavailable',
     generatedAt: now.toISOString(),
-    ...summary,
     total: null,
+    periodLabel: 'last 35 days',
+    today: null,
+    weekTotal: null,
+    activeDays: null,
+    currentStreak: null,
+    days: [],
     repositories: featuredRepositories(),
   };
 }
@@ -217,7 +230,7 @@ function createUpstreamActivity(
   rateLimit: GitHubRateLimit | null,
   now = new Date(),
 ): UpstreamActivity {
-  const summary = summarizeCounts(counts, source, now, total);
+  const summary = summarizeCounts(counts, now, total);
   return {
     activity: {
       username: GITHUB_USERNAME,
@@ -270,7 +283,7 @@ const githubHomeCache = createStaleWhileErrorCache<UpstreamActivity>({
 
 export async function getGitHubHomeResult(): Promise<GitHubHomeResult> {
   const cached = await githubHomeCache.get();
-  const activity = cached.value?.activity ?? unavailableHomeData();
+  const activity = cached.value?.activity ?? createUnavailableGitHubHomeData();
 
   return {
     activity,

--- a/tests/e2e/activity-paper-marks.spec.ts
+++ b/tests/e2e/activity-paper-marks.spec.ts
@@ -26,7 +26,10 @@ for (const theme of ['light', 'dark'] as const) {
     const marks = grid.locator('[data-paper-activity-mark]');
     await expect(section).toBeVisible({ timeout: 15_000 });
     await expect(grid).toBeVisible();
-    await expect(marks).toHaveCount(21);
+    await expect(grid.locator('[data-contribution-cell]')).toHaveCount(28);
+    const recordedCount = await marks.count();
+    expect(recordedCount).toBeGreaterThanOrEqual(22);
+    expect(recordedCount).toBeLessThanOrEqual(28);
 
     const mark = marks.nth(8);
     const resting = await mark.evaluate((element) => {

--- a/tests/e2e/restored-home-time-contracts.spec.ts
+++ b/tests/e2e/restored-home-time-contracts.spec.ts
@@ -8,16 +8,26 @@ async function waitForHydratedHomepage(page: Page) {
   return dashboard;
 }
 
-test('homepage keeps the requested 21-day activity window', async ({ page }) => {
+test('homepage keeps the exact four-week Monday-Sunday activity field', async ({ page }) => {
   await page.goto('/');
   const dashboard = await waitForHydratedHomepage(page);
+  const grid = dashboard.locator('[data-contribution-week-grid]');
 
-  await expect(dashboard.getByText('21 days · UTC', { exact: true })).toBeVisible();
-  await expect(dashboard.locator('[data-contribution-date]')).toHaveCount(21);
-  await expect(dashboard.locator('[data-contribution-week-grid]')).toHaveAttribute(
+  await expect(dashboard.getByText('4 weeks · UTC', { exact: true })).toBeVisible();
+  await expect(grid.locator('[data-contribution-cell]')).toHaveCount(28);
+  await expect(grid).toHaveAttribute('data-calendar-weeks', '4');
+  await expect(grid).toHaveAttribute(
     'aria-label',
-    'GitHub contribution calendar for the last 21 days',
+    'GitHub contribution calendar for three completed weeks and the current week',
   );
+
+  const upcoming = grid.locator('[data-contribution-upcoming]');
+  const upcomingCount = await upcoming.count();
+  expect(upcomingCount).toBeGreaterThanOrEqual(0);
+  expect(upcomingCount).toBeLessThanOrEqual(6);
+  if (upcomingCount > 0) {
+    await expect(upcoming.first()).toHaveAttribute('aria-label', /— upcoming\.$/);
+  }
 });
 
 test('Time Machine uses the intended monospaced controls', async ({ page }) => {


### PR DESCRIPTION
## Superseded

This draft combined three decisions that deserve separate review:

1. the correctness fix for unavailable activity being represented as zero;
2. the exact four-week calendar redesign;
3. browser-local retention of a successful snapshot.

After re-review against current `main`, the combined approach is too broad and now overlaps the merged authenticated-diagnostics hardening in #495.

The correctness fix continues in #502 as a five-file draft from current `main`. It uses a discriminated unavailable state, null summaries, an empty day set, and one restrained retrying panel.

The four-week calendar should follow as a visual PR with screenshots. Browser-local storage is dropped from the preferred plan; shared persistence outside process memory would provide a more consistent cold-instance fallback for every visitor.

This branch remains available as a prototype reference. Do not merge it.