### PR TITLE
Use item IDs for duplicate-item drafts

### DIFF
--- a/components/space/review-gallery.tsx
+++ b/components/space/review-gallery.tsx
@@ -13,6 +13,7 @@ import { Rating } from 'ts-fsrs';
 import { reviewOnce } from '@/app/lib/fsrs-adapter';
 import { createClient } from '@/utils/supabase/client';
 import type { ReviewState } from '@/app/lib/review-types';
+import { duplicateItemHref } from '@/lib/space-routes';
 import { SpaceHeader } from './space-header';
 import { CodeDisplay } from './code-display';
 
@@ -178,7 +179,7 @@ export function ReviewGallery() {
                 <Link href={`/space/edit/${current.slug}`} prefetch>edit</Link>
               </Button>
               <Button asChild variant="outline" size="sm">
-                <Link href={`/space/add?duplicate=${current.slug}`} prefetch>duplicate</Link>
+                <Link href={duplicateItemHref(current.id)} prefetch>duplicate</Link>
               </Button>
             </>
           ) : undefined

--- a/lib/space-routes.test.ts
+++ b/lib/space-routes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { duplicateItemHref } from './space-routes';
+
+describe('duplicateItemHref', () => {
+  it('places the database item id in the duplicate query parameter', () => {
+    expect(duplicateItemHref('0f8fad5b-d9cb-469f-a165-70867728950e')).toBe(
+      '/space/add?duplicate=0f8fad5b-d9cb-469f-a165-70867728950e',
+    );
+  });
+
+  it('encodes the identifier and rejects an empty source', () => {
+    expect(duplicateItemHref(' item/id ')).toBe('/space/add?duplicate=item%2Fid');
+    expect(() => duplicateItemHref('   ')).toThrow('source item id is required');
+  });
+});

--- a/lib/space-routes.ts
+++ b/lib/space-routes.ts
@@ -1,0 +1,7 @@
+export function duplicateItemHref(itemId: string) {
+  const normalizedId = itemId.trim();
+  if (!normalizedId) throw new Error('Duplicate source item id is required');
+
+  const query = new URLSearchParams({ duplicate: normalizedId });
+  return `/space/add?${query.toString()}`;
+}


### PR DESCRIPTION
Advances #346.

## Defect

The review gallery sent an item slug in the `duplicate` query parameter, while the add form resolves that parameter against the database `id` column. Ordinary duplicate links therefore failed to load their source and silently showed the default add model.

## Fix

- define one tested duplicate-item route helper;
- pass `current.id` rather than `current.slug` from the review gallery;
- preserve the existing no-write-until-save duplicate form behavior.

## Boundary

This slice fixes source identity only. It does not yet choose repeated-copy slug naming or add visible missing-source error handling; those remain explicit acceptance items on #346.

No database, schema, review-history, authorization, or save-action changes.

## Validation requested

- lint, typecheck, and unit tests;
- production build;
- existing Chromium and WebKit regressions.

Recovery: revert the squash commit.