### PR TITLE
Keep unavailable GitHub activity separate from zero

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,21 +57,30 @@ function HomeActivityFallback() {
 async function HomeActivityContent() {
   await connection();
   const activity = await getGitHubHomeData();
-  const days = activity.days.slice(-21);
-  const yearTotal = activity.periodLabel === 'last year' ? activity.total : null;
+  const initialActivity =
+    activity.source === 'unavailable'
+      ? {
+          source: activity.source,
+          today: activity.today,
+          weekTotal: activity.weekTotal,
+          yearTotal: activity.total,
+          days: activity.days,
+          unit: 'contributions',
+          generatedAt: activity.generatedAt,
+        }
+      : {
+          source: activity.source,
+          today: activity.today,
+          weekTotal: activity.weekTotal,
+          yearTotal: activity.total,
+          days: activity.days.slice(-21),
+          unit: 'contributions',
+          generatedAt: activity.generatedAt,
+        };
 
   return (
     <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
-      <ActivityDashboard
-        initial={{
-          today: activity.today,
-          weekTotal: activity.weekTotal,
-          yearTotal,
-          days,
-          unit: 'contributions',
-          generatedAt: activity.generatedAt,
-        }}
-      />
+      <ActivityDashboard initial={initialActivity} />
 
       <section aria-label="Recent systems" className="min-w-0" data-recent-systems>
         <div className="flex items-center justify-between gap-4 px-0.5">
@@ -142,7 +151,10 @@ async function HomeActivityContent() {
                 </span>
                 <span className="flex items-center justify-between gap-2 font-semibold">
                   {destination.label}
-                  <ArrowRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+                  <ArrowRight
+                    className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                    aria-hidden="true"
+                  />
                 </span>
               </Link>
             );

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -9,7 +9,8 @@ const REFRESH_INTERVAL_MS = GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS * 1_000;
 const REQUEST_TIMEOUT_MS = 10_000;
 const MAX_FAILURE_BACKOFF_MS = 5 * 60_000;
 
-type ActivitySnapshot = {
+type SuccessfulActivitySnapshot = {
+  source: 'github-graphql' | 'public-profile';
   today: number;
   weekTotal: number;
   yearTotal: number | null;
@@ -18,27 +19,57 @@ type ActivitySnapshot = {
   generatedAt: string;
 };
 
-type LiveActivityResponse = {
-  source: 'github-graphql' | 'public-profile';
-  today: number;
-  weekTotal: number;
-  yearTotal: number | null;
-  days: ActivityGridDay[];
+type UnavailableActivitySnapshot = {
+  source: 'unavailable';
+  today: null;
+  weekTotal: null;
+  yearTotal: null;
+  days: [];
+  unit: string;
   generatedAt: string;
 };
+
+type ActivitySnapshot = SuccessfulActivitySnapshot | UnavailableActivitySnapshot;
+
+type LiveActivityResponse = Omit<SuccessfulActivitySnapshot, 'unit'>;
 
 function timestampOrNow(value: string) {
   const timestamp = Date.parse(value);
   return Number.isFinite(timestamp) ? timestamp : Date.now();
 }
 
+function UnavailableActivity() {
+  return (
+    <section
+      className="col-span-full flex min-h-[15.5rem] flex-col justify-center rounded-[1.25rem] border border-border/70 bg-card p-5 text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] sm:p-6 [@media(max-height:780px)]:min-h-[14.5rem]"
+      aria-labelledby="github-activity-unavailable-title"
+      data-home-activity-unavailable
+    >
+      <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        GitHub activity
+      </p>
+      <h2
+        id="github-activity-unavailable-title"
+        className="mt-2 text-xl font-semibold tracking-tight"
+      >
+        Activity is temporarily unavailable
+      </h2>
+      <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        The page will retry while it remains open. Contribution totals and calendar cells appear only after GitHub supplies a valid snapshot.
+      </p>
+    </section>
+  );
+}
+
 export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   const initialSnapshotAt = timestampOrNow(initial.generatedAt);
-  const [activity, setActivity] = useState(initial);
+  const [activity, setActivity] = useState<ActivitySnapshot>(initial);
   const [updating, setUpdating] = useState(false);
   const inFlight = useRef<AbortController | null>(null);
-  const newestSnapshotAt = useRef(initialSnapshotAt);
-  const nextAllowedAt = useRef(initialSnapshotAt + REFRESH_INTERVAL_MS);
+  const newestSnapshotAt = useRef(initial.source === 'unavailable' ? 0 : initialSnapshotAt);
+  const nextAllowedAt = useRef(
+    initial.source === 'unavailable' ? 0 : initialSnapshotAt + REFRESH_INTERVAL_MS,
+  );
   const consecutiveFailures = useRef(0);
 
   useEffect(() => {
@@ -134,6 +165,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
     <div
       className="relative grid min-w-0 items-stretch gap-3.5 sm:gap-4"
       data-home-activity-dashboard
+      data-home-activity-source={activity.source}
       style={{
         gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 24rem), 1fr))',
       }}
@@ -141,13 +173,20 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
       <span className="sr-only" aria-live="polite">
         {updating ? 'Updating GitHub activity' : ''}
       </span>
-      <ActivityScoreboard
-        today={activity.today}
-        weekTotal={activity.weekTotal}
-        yearTotal={activity.yearTotal}
-        updating={updating}
-      />
-      <ActivityGrid days={activity.days} unit={activity.unit} />
+
+      {activity.source === 'unavailable' ? (
+        <UnavailableActivity />
+      ) : (
+        <>
+          <ActivityScoreboard
+            today={activity.today}
+            weekTotal={activity.weekTotal}
+            yearTotal={activity.yearTotal}
+            updating={updating}
+          />
+          <ActivityGrid days={activity.days} unit={activity.unit} />
+        </>
+      )}
     </div>
   );
 }

--- a/lib/github-activity-response.test.ts
+++ b/lib/github-activity-response.test.ts
@@ -6,20 +6,37 @@ import {
 import type { GitHubHomeResult } from './github-home';
 
 function result(source: GitHubHomeResult['activity']['source']): GitHubHomeResult {
+  const activity: GitHubHomeResult['activity'] =
+    source === 'unavailable'
+      ? {
+          username: 'teamleaderleo',
+          source,
+          generatedAt: '2026-07-27T01:00:00.000Z',
+          total: null,
+          periodLabel: 'last 35 days',
+          today: null,
+          weekTotal: null,
+          activeDays: null,
+          currentStreak: null,
+          days: [],
+          repositories: [],
+        }
+      : {
+          username: 'teamleaderleo',
+          source,
+          generatedAt: '2026-07-27T01:00:00.000Z',
+          total: 18,
+          periodLabel: 'last year',
+          today: 3,
+          weekTotal: 9,
+          activeDays: 5,
+          currentStreak: 2,
+          days: [],
+          repositories: [],
+        };
+
   return {
-    activity: {
-      username: 'teamleaderleo',
-      source,
-      generatedAt: '2026-07-27T01:00:00.000Z',
-      total: 18,
-      periodLabel: source === 'unavailable' ? 'last 35 days' : 'last year',
-      today: 3,
-      weekTotal: 9,
-      activeDays: 5,
-      currentStreak: 2,
-      days: [],
-      repositories: [],
-    },
+    activity,
     diagnostics: {
       cacheStatus: 'stale',
       upstreamSource: source,

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -5,7 +5,7 @@ import {
   parsePublicContributionHtml,
   parsePublicContributionTotal,
 } from './github-activity-utils';
-import { parseGitHubRateLimit } from './github-home';
+import { createUnavailableGitHubHomeData, parseGitHubRateLimit } from './github-home';
 
 describe('parsePublicContributionHtml', () => {
   it('reads direct data-count attributes', () => {
@@ -85,6 +85,21 @@ describe('alignContributionDaysToWeekColumns', () => {
     expect(cells[6]).toEqual(days[3]);
     expect(cells[7]).toEqual(days[4]);
     expect(cells.slice(8)).toEqual([null, null, null, null, null, null]);
+  });
+});
+
+describe('unavailable GitHub activity', () => {
+  it('carries no numeric summaries or synthetic contribution days', () => {
+    expect(createUnavailableGitHubHomeData(new Date('2026-07-31T00:00:00Z'))).toMatchObject({
+      source: 'unavailable',
+      generatedAt: '2026-07-31T00:00:00.000Z',
+      total: null,
+      today: null,
+      weekTotal: null,
+      activeDays: null,
+      currentStreak: null,
+      days: [],
+    });
   });
 });
 

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -51,23 +51,39 @@ export type GitHubRateLimit = {
   resource: string | null;
 };
 
-export type GitHubHomeData = {
+type GitHubHomeCommon = {
   username: string;
-  source: 'github-graphql' | 'public-profile' | 'unavailable';
   generatedAt: string;
-  total: number | null;
-  periodLabel: 'last year' | 'last 35 days';
-  today: number;
-  weekTotal: number;
-  activeDays: number;
-  currentStreak: number;
-  days: ContributionDay[];
   repositories: Array<{
     name: string;
     url: string;
     note: string;
   }>;
 };
+
+type GitHubAvailableHomeData = GitHubHomeCommon & {
+  source: 'github-graphql' | 'public-profile';
+  total: number | null;
+  periodLabel: 'last year';
+  today: number;
+  weekTotal: number;
+  activeDays: number;
+  currentStreak: number;
+  days: ContributionDay[];
+};
+
+type GitHubUnavailableHomeData = GitHubHomeCommon & {
+  source: 'unavailable';
+  total: null;
+  periodLabel: 'last 35 days';
+  today: null;
+  weekTotal: null;
+  activeDays: null;
+  currentStreak: null;
+  days: [];
+};
+
+export type GitHubHomeData = GitHubAvailableHomeData | GitHubUnavailableHomeData;
 
 export type GitHubActivityDiagnostics = {
   cacheStatus: 'hit' | 'miss' | 'stale';
@@ -86,11 +102,11 @@ export type GitHubHomeResult = {
 
 type ActivitySource = GitHubHomeData['source'];
 type ActivitySummary = Pick<
-  GitHubHomeData,
+  GitHubAvailableHomeData,
   'total' | 'periodLabel' | 'today' | 'weekTotal' | 'activeDays' | 'currentStreak' | 'days'
 >;
 type UpstreamActivity = {
-  activity: GitHubHomeData;
+  activity: GitHubAvailableHomeData;
   rateLimit: GitHubRateLimit | null;
 };
 
@@ -115,25 +131,18 @@ function countCurrentStreak(days: ContributionDay[]): number {
 
 function summarizeCounts(
   counts: Map<string, number>,
-  source: ActivitySource,
   now = new Date(),
   reportedTotal: number | null = null,
 ): ActivitySummary {
   const days = daysFromCounts(counts, now);
   const today = dateKeyInTimeZone(now);
-  const hasRollingYearCalendar = source !== 'unavailable';
-  const periodLabel: GitHubHomeData['periodLabel'] = hasRollingYearCalendar
-    ? 'last year'
-    : 'last 35 days';
-  const periodEntries = hasRollingYearCalendar
-    ? [...counts.entries()].filter(([date]) => date <= today)
-    : days.map((day) => [day.date, day.count] as const);
-  const streakDays = hasRollingYearCalendar ? daysFromCounts(counts, now, 366) : days;
+  const periodEntries = [...counts.entries()].filter(([date]) => date <= today);
+  const streakDays = daysFromCounts(counts, now, 366);
   const calculatedTotal = periodEntries.reduce((sum, [, count]) => sum + count, 0);
 
   return {
-    total: hasRollingYearCalendar && reportedTotal !== null ? reportedTotal : calculatedTotal,
-    periodLabel,
+    total: reportedTotal ?? calculatedTotal,
+    periodLabel: 'last year',
     today: days.at(-1)?.count ?? 0,
     weekTotal: days.slice(-7).reduce((sum, day) => sum + day.count, 0),
     activeDays: periodEntries.filter(([, count]) => count > 0).length,
@@ -198,14 +207,18 @@ function featuredRepositories(): GitHubHomeData['repositories'] {
   return FEATURED_REPOSITORIES.map((repository) => ({ ...repository }));
 }
 
-function unavailableHomeData(now = new Date()): GitHubHomeData {
-  const summary = summarizeCounts(new Map(), 'unavailable', now);
+export function createUnavailableGitHubHomeData(now = new Date()): GitHubUnavailableHomeData {
   return {
     username: GITHUB_USERNAME,
     source: 'unavailable',
     generatedAt: now.toISOString(),
-    ...summary,
     total: null,
+    periodLabel: 'last 35 days',
+    today: null,
+    weekTotal: null,
+    activeDays: null,
+    currentStreak: null,
+    days: [],
     repositories: featuredRepositories(),
   };
 }
@@ -217,7 +230,7 @@ function createUpstreamActivity(
   rateLimit: GitHubRateLimit | null,
   now = new Date(),
 ): UpstreamActivity {
-  const summary = summarizeCounts(counts, source, now, total);
+  const summary = summarizeCounts(counts, now, total);
   return {
     activity: {
       username: GITHUB_USERNAME,
@@ -270,7 +283,7 @@ const githubHomeCache = createStaleWhileErrorCache<UpstreamActivity>({
 
 export async function getGitHubHomeResult(): Promise<GitHubHomeResult> {
   const cached = await githubHomeCache.get();
-  const activity = cached.value?.activity ?? unavailableHomeData();
+  const activity = cached.value?.activity ?? createUnavailableGitHubHomeData();
 
   return {
     activity,


### PR DESCRIPTION
## Result

Fix the homepage false-zero path without mixing in the activity-calendar redesign or a new persistence mechanism.

- model successful and unavailable GitHub activity as a discriminated union;
- carry null summaries and an empty day set when no successful upstream snapshot exists;
- render one restrained unavailable panel instead of the numeric scoreboard and calendar;
- retry immediately after hydration, then retain the existing backoff behavior;
- preserve the previous successful in-memory view during later refresh failures;
- keep the recently merged authenticated-diagnostics redaction intact.

This supersedes the correctness portion of draft #499. The four-week calendar and any durable shared snapshot should be reviewed separately.

## Exact candidate

- base branch: `main`
- base SHA: `bbeef643f3acabf472eee29bd4a864891ec3c602`
- head branch: `fix/github-activity-unavailable-state`
- head SHA: `08ba30d07d01ea85602bd36d4922eb616671ef2d`
- relation: 5 commits ahead, 0 behind

## Changed files

- `app/page.tsx`
- `components/home/activity-dashboard.tsx`
- `lib/github-activity-response.test.ts`
- `lib/github-home.test.ts`
- `lib/github-home.ts`

## Regression boundary

The cold unavailable state now contains:

- `source: unavailable`;
- null `total`, `today`, `weekTotal`, `activeDays`, and `currentStreak`;
- no contribution-day records.

The homepage branches on that source before rendering any numeric activity UI.

## Deliberately deferred

- exact four-week Monday–Sunday calendar;
- upcoming etched cells and month-transition labels;
- browser-local snapshots;
- shared persistence outside process memory.

The calendar belongs in a visual PR with screenshots. Shared persistence should solve cold-instance recovery for every visitor instead of only repeat visitors in one browser.

## Validation

Repository CI should run lint, typecheck, unit tests, build, and Chromium/WebKit regressions. The PR remains draft until those checks complete and the full diff is reviewed.

## Recovery

Revert the resulting merge commit. No migration, credential, API response, or deployment-control change is introduced.