### PR TITLE
Render an exact four-week GitHub activity calendar

### DIFF
--- a/app/api/github-activity/route.ts
+++ b/app/api/github-activity/route.ts
@@ -36,7 +36,7 @@ export async function GET() {
         today: activity.today,
         weekTotal: activity.weekTotal,
         yearTotal: activity.periodLabel === 'last year' ? activity.total : null,
-        days: activity.days.slice(-21),
+        days: activity.days,
         diagnostics,
       },
       { headers },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,7 @@ async function HomeActivityContent() {
           today: activity.today,
           weekTotal: activity.weekTotal,
           yearTotal: activity.total,
-          days: activity.days.slice(-21),
+          days: activity.days,
           unit: 'contributions',
           generatedAt: activity.generatedAt,
         };

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -184,7 +184,11 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
             yearTotal={activity.yearTotal}
             updating={updating}
           />
-          <ActivityGrid days={activity.days} unit={activity.unit} />
+          <ActivityGrid
+            days={activity.days}
+            unit={activity.unit}
+            generatedAt={activity.generatedAt}
+          />
         </>
       )}
     </div>

--- a/components/home/activity-grid.module.css
+++ b/components/home/activity-grid.module.css
@@ -26,6 +26,40 @@
     0 2px 5px rgb(58 45 31 / 0.08);
 }
 
+.etchedMark {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid hsl(var(--foreground) / 0.14);
+  background-color: hsl(var(--muted) / 0.22);
+  box-shadow: inset 0 0 0 1px hsl(var(--background) / 0.35);
+}
+
+.upcomingMark {
+  opacity: 0.48;
+  background-image:
+    linear-gradient(112deg, transparent 18%, hsl(var(--foreground) / 0.08) 19%, transparent 21%),
+    linear-gradient(24deg, transparent 52%, hsl(var(--foreground) / 0.055) 53%, transparent 55%);
+}
+
+.upcomingMark::after {
+  position: absolute;
+  inset: 22%;
+  border: 1px dashed hsl(var(--foreground) / 0.16);
+  border-radius: 0.18rem;
+  content: '';
+}
+
+.unavailableMark {
+  opacity: 0.62;
+  background-image: repeating-linear-gradient(
+    -36deg,
+    transparent 0,
+    transparent 4px,
+    hsl(var(--foreground) / 0.055) 4px,
+    hsl(var(--foreground) / 0.055) 5px
+  );
+}
+
 :global(.dark) .paperMark {
   box-shadow:
     inset 0 1px 0 rgb(255 255 255 / 0.07),
@@ -41,6 +75,20 @@
     0 4px 9px rgb(0 0 0 / 0.28);
 }
 
+:global(.dark) .etchedMark {
+  border-color: hsl(var(--foreground) / 0.18);
+  background-color: hsl(var(--muted) / 0.15);
+  box-shadow: inset 0 0 0 1px rgb(255 255 255 / 0.025);
+}
+
+@media (max-height: 780px) and (min-width: 768px) {
+  .paperMark,
+  .etchedMark {
+    width: min(100%, 3rem);
+    justify-self: center;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .paperMark {
     transition: none;
@@ -51,10 +99,15 @@
   .paperMark,
   .paperMark:hover,
   .paperMark:focus-visible,
-  .paperMark[aria-pressed='true'] {
+  .paperMark[aria-pressed='true'],
+  .etchedMark {
     border: 1px solid CanvasText;
     background: Canvas;
     color: CanvasText;
     box-shadow: none;
+  }
+
+  .upcomingMark::after {
+    border-color: CanvasText;
   }
 }

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { alignContributionDaysToWeekColumns } from '@/lib/github-activity-utils';
+import {
+  buildFourWeekContributionCells,
+  dateKeyInTimeZone,
+  type FourWeekContributionCell,
+} from '@/lib/github-activity-utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './activity-grid.module.css';
 
@@ -9,15 +13,37 @@ export type ActivityGridDay = {
   count: number;
 };
 
-const WEEKDAY_LABELS = ['Sun', '', 'Tue', '', 'Thu', '', 'Sat'] as const;
+const WEEKDAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', 'Sun'] as const;
+const WEEK_COUNT = 4;
+
+function dateFromKey(date: string): Date {
+  return new Date(`${date}T00:00:00Z`);
+}
 
 function formatDay(date: string): string {
-  return new Intl.DateTimeFormat('en-GB', {
-    weekday: 'short',
-    month: 'short',
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    month: 'long',
     day: 'numeric',
     timeZone: 'UTC',
-  }).format(new Date(`${date}T00:00:00Z`));
+  }).format(dateFromKey(date));
+}
+
+function formatMonth(date: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    month: 'short',
+    timeZone: 'UTC',
+  }).format(dateFromKey(date));
+}
+
+function weekMonthLabel(cells: FourWeekContributionCell<ActivityGridDay>[]): string {
+  const first = cells[0]?.date;
+  const last = cells.at(-1)?.date;
+  if (!first || !last) return '';
+
+  const firstMonth = formatMonth(first);
+  const lastMonth = formatMonth(last);
+  return firstMonth === lastMonth ? firstMonth : `${firstMonth} / ${lastMonth}`;
 }
 
 function activityClass(count: number, maximum: number): string {
@@ -36,16 +62,46 @@ function labelForDay(day: ActivityGridDay, unit: string) {
   return `${formatDay(day.date)} · ${day.count.toLocaleString('en-GB')} ${unit}`;
 }
 
-export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: string }) {
-  const maximum = Math.max(...days.map((day) => day.count), 0);
-  const gridDays = useMemo(() => alignContributionDaysToWeekColumns(days), [days]);
-  const weekCount = Math.max(1, gridDays.length / 7);
-  const calendarMaxWidthRem = 2.3 + weekCount * 3.15;
-  const [selectedDate, setSelectedDate] = useState(days.at(-1)?.date ?? '');
+function referenceDate(value: string): Date {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+export function ActivityGrid({
+  days,
+  unit,
+  generatedAt,
+  unavailableMessage = 'GitHub activity is temporarily unavailable.',
+}: {
+  days: ActivityGridDay[];
+  unit: string;
+  generatedAt: string;
+  unavailableMessage?: string;
+}) {
+  const calendarDate = useMemo(() => referenceDate(generatedAt), [generatedAt]);
+  const today = dateKeyInTimeZone(calendarDate);
+  const cells = useMemo(
+    () => buildFourWeekContributionCells(days, calendarDate),
+    [calendarDate, days],
+  );
+  const recordedDays = useMemo(
+    () => cells.flatMap((cell) => (cell.state === 'recorded' ? [cell.day] : [])),
+    [cells],
+  );
+  const maximum = Math.max(...recordedDays.map((day) => day.count), 0);
+  const weekLabels = useMemo(
+    () =>
+      Array.from({ length: WEEK_COUNT }, (_, index) =>
+        weekMonthLabel(cells.slice(index * 7, index * 7 + 7)),
+      ),
+    [cells],
+  );
+  const latestRecordedDate = recordedDays.at(-1)?.date ?? '';
+  const [selectedDate, setSelectedDate] = useState(latestRecordedDate);
   const [tooltipDate, setTooltipDate] = useState<string | null>(null);
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const [finePointer, setFinePointer] = useState(false);
-  const previousLatest = useRef(days.at(-1)?.date ?? '');
+  const previousLatest = useRef(latestRecordedDate);
   const sectionRef = useRef<HTMLElement | null>(null);
   const hideTimer = useRef<number | null>(null);
   const positionFrame = useRef<number | null>(null);
@@ -67,21 +123,24 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
   }, []);
 
   useEffect(() => {
-    const latest = days.at(-1)?.date ?? '';
     setSelectedDate((current) => {
-      if (!current || current === previousLatest.current || !days.some((day) => day.date === current)) {
-        return latest;
+      if (
+        !current ||
+        current === previousLatest.current ||
+        !recordedDays.some((day) => day.date === current)
+      ) {
+        return latestRecordedDate;
       }
       return current;
     });
-    previousLatest.current = latest;
-  }, [days]);
+    previousLatest.current = latestRecordedDate;
+  }, [latestRecordedDate, recordedDays]);
 
-  const selected = days.find((day) => day.date === selectedDate);
-  const tooltipDay = days.find((day) => day.date === tooltipDate);
+  const selected = recordedDays.find((day) => day.date === selectedDate);
+  const tooltipDay = recordedDays.find((day) => day.date === tooltipDate);
   const selectedLabel = useMemo(
-    () => (selected ? labelForDay(selected, unit) : ''),
-    [selected, unit],
+    () => (selected ? labelForDay(selected, unit) : unavailableMessage),
+    [selected, unit, unavailableMessage],
   );
   const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
 
@@ -126,7 +185,7 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
     >
       <div className="flex items-center justify-between gap-4">
         <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          21 days · UTC
+          4 weeks · UTC
         </span>
         <div
           className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
@@ -142,10 +201,20 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div
-        className="mx-auto mt-3 grid w-full grid-cols-[1.65rem_minmax(0,1fr)] gap-2 sm:gap-2.5 [@media(max-height:780px)]:mt-2"
-        style={{ maxWidth: `min(100%, ${calendarMaxWidthRem}rem)` }}
-      >
+      <div className="mx-auto mt-3 grid w-full max-w-[15rem] grid-cols-[1.65rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 sm:max-w-[17rem] sm:gap-x-2.5 [@media(max-height:780px)]:mt-2">
+        <span aria-hidden="true" />
+        <div
+          className="grid grid-cols-4 gap-1.5 px-px font-mono text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground sm:gap-2"
+          aria-hidden="true"
+          data-contribution-month-labels
+        >
+          {weekLabels.map((label, index) => (
+            <span key={`${label}-${index}`} className="truncate text-center">
+              {label}
+            </span>
+          ))}
+        </div>
+
         <div
           className="grid grid-rows-7 gap-1.5 py-px font-mono text-[8px] font-medium text-muted-foreground sm:gap-2"
           aria-hidden="true"
@@ -160,41 +229,67 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         <div
           className="grid min-w-0 gap-1.5 sm:gap-2"
           style={{
-            gridTemplateColumns: `repeat(${weekCount}, minmax(0, 1fr))`,
+            gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
             gridTemplateRows: 'repeat(7, minmax(0, 1fr))',
           }}
-          aria-label="GitHub contribution calendar for the last 21 days"
+          aria-label="GitHub contribution calendar for three completed weeks and the current week"
+          data-calendar-weeks="4"
           data-contribution-week-grid
           data-paper-activity-grid
         >
-          {gridDays.map((day, index) => {
+          {cells.map((cell, index) => {
             const gridColumn = Math.floor(index / 7) + 1;
             const gridRow = (index % 7) + 1;
+            const sharedStyle = { gridColumn, gridRow };
 
-            if (!day) {
+            if (cell.state === 'upcoming') {
               return (
                 <span
-                  key={`empty-${index}`}
-                  aria-hidden="true"
-                  className="aspect-square min-w-0 rounded-[0.38rem]"
-                  style={{ gridColumn, gridRow }}
+                  key={cell.date}
+                  role="img"
+                  aria-label={`${formatDay(cell.date)} — upcoming.`}
+                  className={`${styles.etchedMark} ${styles.upcomingMark} aspect-square min-w-0 rounded-[0.38rem]`}
+                  style={sharedStyle}
+                  data-contribution-cell
+                  data-contribution-date={cell.date}
+                  data-contribution-state="upcoming"
+                  data-contribution-upcoming
                 />
               );
             }
 
+            if (cell.state === 'unavailable') {
+              return (
+                <span
+                  key={cell.date}
+                  role="img"
+                  aria-label={`${formatDay(cell.date)} — activity unavailable.`}
+                  className={`${styles.etchedMark} ${styles.unavailableMark} aspect-square min-w-0 rounded-[0.38rem]`}
+                  style={sharedStyle}
+                  data-contribution-cell
+                  data-contribution-date={cell.date}
+                  data-contribution-state="unavailable"
+                  data-contribution-unavailable
+                />
+              );
+            }
+
+            const day = cell.day;
             const label = labelForDay(day, unit);
             const isSelected = day.date === selected?.date;
-            const isLatest = day.date === days.at(-1)?.date;
+            const isToday = day.date === today;
 
             return (
               <button
                 key={day.date}
                 type="button"
-                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isLatest ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
-                style={{ gridColumn, gridRow }}
+                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isToday ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
+                style={sharedStyle}
                 aria-label={label}
                 aria-pressed={isSelected}
+                data-contribution-cell
                 data-contribution-date={day.date}
+                data-contribution-state="recorded"
                 data-paper-activity-mark
                 onPointerEnter={(event) => showTooltip(day.date, event.clientX, event.clientY)}
                 onPointerMove={(event) => {
@@ -215,7 +310,10 @@ export function ActivityGrid({ days, unit }: { days: ActivityGridDay[]; unit: st
         </div>
       </div>
 
-      <div className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden" aria-live="polite">
+      <div
+        className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden"
+        aria-live="polite"
+      >
         {selectedLabel}
       </div>
 

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -5,7 +5,6 @@ import {
   motion,
   useAnimate,
   useMotionValue,
-  useReducedMotion,
   useSpring,
   useTransform,
 } from 'framer-motion';
@@ -17,6 +16,22 @@ import {
   useState,
 } from 'react';
 import styles from './activity-scoreboard.module.css';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+function useReducedMotionPreference(): boolean {
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(REDUCED_MOTION_QUERY);
+    const update = () => setReduceMotion(media.matches);
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  return reduceMotion;
+}
 
 function countdownToUtcMidnight() {
   const now = new Date();
@@ -43,7 +58,7 @@ type DigitTurn = {
 };
 
 function PaperDigit({ digit, index }: { digit: string; index: number }) {
-  const reduceMotion = useReducedMotion();
+  const reduceMotion = useReducedMotionPreference();
   const [displayed, setDisplayed] = useState(digit);
   const [turn, setTurn] = useState<DigitTurn | null>(null);
   const sequence = useRef(0);
@@ -162,7 +177,7 @@ function ScoreDigits({ value }: { value: number }) {
     () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
     [value],
   );
-  const reduceMotion = useReducedMotion();
+  const reduceMotion = useReducedMotionPreference();
   const previousValue = useRef(value);
   const [scope, animate] = useAnimate();
 
@@ -250,7 +265,7 @@ export function ActivityScoreboard({
   yearTotal: number | null;
   updating: boolean;
 }) {
-  const reduceMotion = useReducedMotion();
+  const reduceMotion = useReducedMotionPreference();
   const [countdown, setCountdown] = useState('--:--:--');
   const pointerX = useMotionValue(0);
   const pointerY = useMotionValue(0);

--- a/lib/github-activity-utils.ts
+++ b/lib/github-activity-utils.ts
@@ -5,6 +5,21 @@ export type ContributionGridDay = {
   count: number;
 };
 
+export type FourWeekContributionCell<T extends ContributionGridDay> =
+  | {
+      date: string;
+      state: 'recorded';
+      day: T;
+    }
+  | {
+      date: string;
+      state: 'upcoming';
+    }
+  | {
+      date: string;
+      state: 'unavailable';
+    };
+
 export function dateKeyInTimeZone(date: Date, timeZone = DISPLAY_TIME_ZONE): string {
   const parts = new Intl.DateTimeFormat('en-CA', {
     timeZone,
@@ -25,6 +40,40 @@ export function getRecentDateKeys(now = new Date(), length = 7): string[] {
   return Array.from({ length: safeLength }, (_, index) => {
     const date = new Date(Date.UTC(year, month - 1, day - (safeLength - 1 - index)));
     return date.toISOString().slice(0, 10);
+  });
+}
+
+export function getFourWeekDateKeys(now = new Date()): string[] {
+  const [year, month, day] = dateKeyInTimeZone(now)
+    .split('-')
+    .map(Number);
+  const today = new Date(Date.UTC(year, month - 1, day));
+  const daysSinceMonday = (today.getUTCDay() + 6) % 7;
+  const currentMonday = new Date(Date.UTC(year, month - 1, day - daysSinceMonday));
+  const firstMonday = new Date(currentMonday);
+  firstMonday.setUTCDate(firstMonday.getUTCDate() - 21);
+
+  return Array.from({ length: 28 }, (_, index) => {
+    const date = new Date(firstMonday);
+    date.setUTCDate(firstMonday.getUTCDate() + index);
+    return date.toISOString().slice(0, 10);
+  });
+}
+
+export function buildFourWeekContributionCells<T extends ContributionGridDay>(
+  days: T[],
+  now = new Date(),
+): FourWeekContributionCell<T>[] {
+  const today = dateKeyInTimeZone(now);
+  const byDate = new Map(days.map((day) => [day.date, day]));
+
+  return getFourWeekDateKeys(now).map((date) => {
+    if (date > today) return { date, state: 'upcoming' };
+
+    const day = byDate.get(date);
+    if (!day) return { date, state: 'unavailable' };
+
+    return { date, state: 'recorded', day };
   });
 }
 

--- a/lib/github-home.test.ts
+++ b/lib/github-home.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   alignContributionDaysToWeekColumns,
+  buildFourWeekContributionCells,
+  getFourWeekDateKeys,
   getRecentDateKeys,
   parsePublicContributionHtml,
   parsePublicContributionTotal,
@@ -68,6 +70,40 @@ describe('getRecentDateKeys', () => {
   });
 });
 
+describe('four-week contribution field', () => {
+  const now = new Date('2026-07-31T08:00:00Z');
+
+  it('renders three completed Monday-Sunday weeks plus the current week', () => {
+    const dates = getFourWeekDateKeys(now);
+
+    expect(dates).toHaveLength(28);
+    expect(dates[0]).toBe('2026-07-06');
+    expect(dates[20]).toBe('2026-07-26');
+    expect(dates[21]).toBe('2026-07-27');
+    expect(dates.at(-1)).toBe('2026-08-02');
+  });
+
+  it('keeps future dates upcoming and missing past data unavailable', () => {
+    const cells = buildFourWeekContributionCells([], now);
+
+    expect(cells.slice(0, 26).every((cell) => cell.state === 'unavailable')).toBe(true);
+    expect(cells.slice(26).map((cell) => cell.state)).toEqual(['upcoming', 'upcoming']);
+  });
+
+  it('preserves a recorded zero without using zero for missing data', () => {
+    const cells = buildFourWeekContributionCells([{ date: '2026-07-31', count: 0 }], now);
+    const today = cells.find((cell) => cell.date === '2026-07-31');
+    const yesterday = cells.find((cell) => cell.date === '2026-07-30');
+
+    expect(today).toEqual({
+      date: '2026-07-31',
+      state: 'recorded',
+      day: { date: '2026-07-31', count: 0 },
+    });
+    expect(yesterday).toEqual({ date: '2026-07-30', state: 'unavailable' });
+  });
+});
+
 describe('alignContributionDaysToWeekColumns', () => {
   it('pads the first and last weeks so columns run Sunday through Saturday', () => {
     const days = [
@@ -88,11 +124,12 @@ describe('alignContributionDaysToWeekColumns', () => {
   });
 });
 
-describe('unavailable GitHub activity', () => {
-  it('carries no numeric summaries or synthetic contribution days', () => {
-    expect(createUnavailableGitHubHomeData(new Date('2026-07-31T00:00:00Z'))).toMatchObject({
+describe('createUnavailableGitHubHomeData', () => {
+  it('keeps a cold-cache upstream failure free of manufactured zero activity', () => {
+    const activity = createUnavailableGitHubHomeData(new Date('2026-07-31T08:00:00Z'));
+
+    expect(activity).toMatchObject({
       source: 'unavailable',
-      generatedAt: '2026-07-31T00:00:00.000Z',
       total: null,
       today: null,
       weekTotal: null,

--- a/tests/e2e/activity-paper-marks.spec.ts
+++ b/tests/e2e/activity-paper-marks.spec.ts
@@ -26,7 +26,10 @@ for (const theme of ['light', 'dark'] as const) {
     const marks = grid.locator('[data-paper-activity-mark]');
     await expect(section).toBeVisible({ timeout: 15_000 });
     await expect(grid).toBeVisible();
-    await expect(marks).toHaveCount(21);
+    await expect(grid.locator('[data-contribution-cell]')).toHaveCount(28);
+    const recordedCount = await marks.count();
+    expect(recordedCount).toBeGreaterThanOrEqual(22);
+    expect(recordedCount).toBeLessThanOrEqual(28);
 
     const mark = marks.nth(8);
     const resting = await mark.evaluate((element) => {

--- a/tests/e2e/restored-home-time-contracts.spec.ts
+++ b/tests/e2e/restored-home-time-contracts.spec.ts
@@ -8,16 +8,26 @@ async function waitForHydratedHomepage(page: Page) {
   return dashboard;
 }
 
-test('homepage keeps the requested 21-day activity window', async ({ page }) => {
+test('homepage keeps the exact four-week Monday-Sunday activity field', async ({ page }) => {
   await page.goto('/');
   const dashboard = await waitForHydratedHomepage(page);
+  const grid = dashboard.locator('[data-contribution-week-grid]');
 
-  await expect(dashboard.getByText('21 days · UTC', { exact: true })).toBeVisible();
-  await expect(dashboard.locator('[data-contribution-date]')).toHaveCount(21);
-  await expect(dashboard.locator('[data-contribution-week-grid]')).toHaveAttribute(
+  await expect(dashboard.getByText('4 weeks · UTC', { exact: true })).toBeVisible();
+  await expect(grid.locator('[data-contribution-cell]')).toHaveCount(28);
+  await expect(grid).toHaveAttribute('data-calendar-weeks', '4');
+  await expect(grid).toHaveAttribute(
     'aria-label',
-    'GitHub contribution calendar for the last 21 days',
+    'GitHub contribution calendar for three completed weeks and the current week',
   );
+
+  const upcoming = grid.locator('[data-contribution-upcoming]');
+  const upcomingCount = await upcoming.count();
+  expect(upcomingCount).toBeGreaterThanOrEqual(0);
+  expect(upcomingCount).toBeLessThanOrEqual(6);
+  if (upcomingCount > 0) {
+    await expect(upcoming.first()).toHaveAttribute('aria-label', /— upcoming\.$/);
+  }
 });
 
 test('Time Machine uses the intended monospaced controls', async ({ page }) => {


### PR DESCRIPTION
## Result

Replace the drifting 21-day contribution field with one fixed four-week UTC calendar while keeping the unavailable-state correction from #502 intact.

- render exactly four Monday–Sunday columns: three completed weeks plus the current week;
- show future dates as quiet, noninteractive upcoming cells;
- distinguish missing past data from an explicit recorded zero;
- add compact month labels across week boundaries;
- send the existing 35-day activity window to the client so week transitions remain complete;
- keep the current retry, cache, diagnostics-redaction, and unavailable behavior unchanged;
- subscribe directly to the reduced-motion media query so the existing scoreboard motion contract remains stable after hydration.

## Exact candidate

- base: `main` at `38909884ae61861a59d45be59cbaf20930e7e042`
- head: `preview/github-activity-four-week-calendar` at `d98701b1abdad2c4cd6937092561f68c65bae518`
- relation: 1 commit ahead, 0 behind
- changed files: 10

## Boundaries

This PR does not add browser storage, shared persistence, a new cache, or a new upstream request. It projects the existing contribution data into a fixed calendar and returns the already-computed 35-day window from the page/API.

## Browser corrections made during preview review

- compact all contribution cells at short desktop heights to preserve the no-overflow homepage contract;
- replace the fragile Framer reduced-motion preference hook with a direct `matchMedia` subscription after the new grid exposed stale preference initialization in both Chromium and WebKit.

## Verification

- Vercel production build for the exact head: ready;
- preview runtime errors: none;
- GitHub Actions run #668: queued for lint, typecheck, unit tests, production build, and Chromium/WebKit regressions;
- focused screenshot artifacts will be reviewed before merge.

The PR remains draft until the Actions run and screenshots are green.

## Recovery

Revert the squash merge. No migration, credential, environment, or deployment-control change is introduced.