### PR TITLE
Make navigation feedback continuously smooth

### DIFF
--- a/app/navigation-feedback.css
+++ b/app/navigation-feedback.css
@@ -19,6 +19,7 @@
 .navigation-rail {
   height: 2px;
   overflow: hidden;
+  contain: paint;
   background: linear-gradient(90deg, rgb(0 0 0 / 0.04), rgb(0 0 0 / 0.1), rgb(0 0 0 / 0.04));
 }
 
@@ -30,12 +31,16 @@
   height: 100%;
   width: 100%;
   transform-origin: left center;
-  transition: transform 140ms cubic-bezier(0.22, 0.72, 0.28, 1);
   will-change: transform;
   background: linear-gradient(90deg, #595161, #83788f 72%, #b3a8bd);
   box-shadow:
     0 0 8px rgb(111 104 120 / 0.42),
     0 1px 0 rgb(255 255 255 / 0.32) inset;
+}
+
+.navigation-feedback:is([data-navigation-state='completing'], [data-navigation-state='failed'])
+  .navigation-progress {
+  transition: transform 120ms cubic-bezier(0.22, 0.72, 0.28, 1);
 }
 
 .dark .navigation-progress {
@@ -73,6 +78,15 @@
   .navigation-feedback,
   .navigation-progress {
     transition-duration: 1ms;
+  }
+
+  .navigation-feedback:is(
+      [data-navigation-state='running'],
+      [data-navigation-state='slow'],
+      [data-navigation-state='settling']
+    )
+    .navigation-progress {
+    transform: scaleX(0.18) !important;
   }
 
   .navigation-progress {

--- a/components/navigation-feedback.tsx
+++ b/components/navigation-feedback.tsx
@@ -4,12 +4,16 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import {
   NAVIGATION_COMPLETION_HOLD_MS,
+  NAVIGATION_FAILURE_STATUS_MS,
   NAVIGATION_FADE_MS,
   NAVIGATION_HISTORY_STORAGE_KEY,
+  NAVIGATION_INITIAL_PROGRESS,
   NAVIGATION_MIN_VISIBLE_MS,
-  NAVIGATION_TICK_MS,
+  NAVIGATION_PROGRESS_CAP,
+  NAVIGATION_SLOW_STATUS_MS,
   createNavigationDurationHistory,
   estimateNavigationDuration,
+  estimatedNavigationProgress,
   idleNavigationProgressState,
   parseNavigationDurationHistory,
   recordNavigationDuration,
@@ -21,6 +25,10 @@ const IDLE_PREFETCH_ROUTES = ['/', '/time', '/gallery', '/blog', '/atelier'];
 const NAVIGATION_START_EVENT = 'scrapbook:navigation-start';
 const NAVIGATION_CANCEL_EVENT = 'scrapbook:navigation-cancel';
 const NAVIGATION_ERROR_EVENT = 'scrapbook:navigation-error';
+const NAVIGATION_PROGRESS_SNAPSHOT_MS = 180;
+const NAVIGATION_ANIMATION_MIN_MS = 720;
+const NAVIGATION_ANIMATION_ESTIMATE_MULTIPLIER = 2.4;
+const NAVIGATION_ANIMATION_OFFSETS = [0, 0.08, 0.18, 0.32, 0.5, 0.72, 1] as const;
 
 type NavigationStartDetail = {
   href: string;
@@ -102,6 +110,29 @@ function persistDurationHistory(history: ReturnType<typeof createNavigationDurat
   }
 }
 
+function navigationAnimationDuration(estimateMs: number) {
+  return Math.min(
+    NAVIGATION_FAILURE_STATUS_MS,
+    Math.max(NAVIGATION_ANIMATION_MIN_MS, estimateMs * NAVIGATION_ANIMATION_ESTIMATE_MULTIPLIER),
+  );
+}
+
+function renderedProgress(element: HTMLElement | null) {
+  if (!element?.parentElement) return NAVIGATION_INITIAL_PROGRESS;
+  const railWidth = element.parentElement.getBoundingClientRect().width;
+  if (railWidth <= 0) return NAVIGATION_INITIAL_PROGRESS;
+  const progressWidth = element.getBoundingClientRect().width;
+  return Math.min(1, Math.max(NAVIGATION_INITIAL_PROGRESS, progressWidth / railWidth));
+}
+
+function progressKeyframes(startProgress: number, estimateMs: number) {
+  const duration = navigationAnimationDuration(estimateMs);
+  return NAVIGATION_ANIMATION_OFFSETS.map((offset) => ({
+    offset,
+    transform: `scaleX(${estimatedNavigationProgress(offset * duration, estimateMs, startProgress)})`,
+  }));
+}
+
 export function NavigationFeedback() {
   const router = useRouter();
   const pathname = usePathname();
@@ -110,6 +141,13 @@ export function NavigationFeedback() {
   const activeNavigation = useRef<ActiveNavigation | null>(null);
   const historyRef = useRef(createNavigationDurationHistory());
   const prefetched = useRef(new Set<string>());
+  const progressElement = useRef<HTMLDivElement | null>(null);
+  const progressAnimation = useRef<Animation | null>(null);
+  const animationOrigin = useRef(NAVIGATION_INITIAL_PROGRESS);
+  const completionFrame = useRef<number | null>(null);
+  const progressSnapshotTimer = useRef<number | null>(null);
+  const slowTimer = useRef<number | null>(null);
+  const failureTimer = useRef<number | null>(null);
   const completionTimer = useRef<number | null>(null);
   const fadeTimer = useRef<number | null>(null);
   const resetTimer = useRef<number | null>(null);
@@ -130,10 +168,31 @@ export function NavigationFeedback() {
   }, []);
 
   const clearPhaseTimers = useCallback(() => {
-    for (const timer of [completionTimer, fadeTimer, resetTimer]) {
+    for (const timer of [
+      progressSnapshotTimer,
+      slowTimer,
+      failureTimer,
+      completionTimer,
+      fadeTimer,
+      resetTimer,
+    ]) {
       if (timer.current !== null) window.clearTimeout(timer.current);
       timer.current = null;
     }
+  }, []);
+
+  const clearCompletionFrame = useCallback(() => {
+    if (completionFrame.current !== null) window.cancelAnimationFrame(completionFrame.current);
+    completionFrame.current = null;
+  }, []);
+
+  const freezeProgressAnimation = useCallback(() => {
+    const element = progressElement.current;
+    const currentProgress = renderedProgress(element);
+    progressAnimation.current?.cancel();
+    progressAnimation.current = null;
+    if (element) element.style.transform = `scaleX(${currentProgress})`;
+    return currentProgress;
   }, []);
 
   const scheduleFade = useCallback(() => {
@@ -153,6 +212,12 @@ export function NavigationFeedback() {
       if (kind !== 'history' && href === current) return;
 
       clearPhaseTimers();
+      clearCompletionFrame();
+      const startProgress = progressElement.current
+        ? freezeProgressAnimation()
+        : NAVIGATION_INITIAL_PROGRESS;
+      animationOrigin.current = startProgress;
+
       const now = performance.now();
       const label = rawLabel ?? destinationLabel(href);
       activeNavigation.current = {
@@ -168,16 +233,28 @@ export function NavigationFeedback() {
         label,
         kind,
         estimateMs: estimateNavigationDuration(historyRef.current, href),
+        startProgress,
         now,
       });
+
+      progressSnapshotTimer.current = window.setTimeout(() => {
+        dispatch({ type: 'tick', now: performance.now() });
+      }, NAVIGATION_PROGRESS_SNAPSHOT_MS);
+      slowTimer.current = window.setTimeout(() => {
+        dispatch({ type: 'tick', now: performance.now() });
+      }, NAVIGATION_SLOW_STATUS_MS);
+      failureTimer.current = window.setTimeout(() => {
+        dispatch({ type: 'tick', now: performance.now() });
+      }, NAVIGATION_FAILURE_STATUS_MS);
     },
-    [clearPhaseTimers],
+    [clearCompletionFrame, clearPhaseTimers, freezeProgressAnimation],
   );
 
   const settleNavigation = useCallback(() => {
     const active = activeNavigation.current;
     if (!active) return;
     activeNavigation.current = null;
+    clearPhaseTimers();
 
     const now = performance.now();
     const durationMs = Math.max(0, now - active.startedAt);
@@ -204,14 +281,16 @@ export function NavigationFeedback() {
     }
 
     scheduleFade();
-  }, [scheduleFade]);
+  }, [clearPhaseTimers, scheduleFade]);
 
   const cancelNavigation = useCallback(() => {
     activeNavigation.current = null;
     clearPhaseTimers();
+    clearCompletionFrame();
+    freezeProgressAnimation();
     dispatch({ type: 'cancel' });
     resetTimer.current = window.setTimeout(() => dispatch({ type: 'reset' }), NAVIGATION_FADE_MS);
-  }, [clearPhaseTimers]);
+  }, [clearCompletionFrame, clearPhaseTimers, freezeProgressAnimation]);
 
   useEffect(() => {
     if (previousRouteKey.current === routeKey) return;
@@ -220,12 +299,63 @@ export function NavigationFeedback() {
   }, [routeKey, settleNavigation]);
 
   useEffect(() => {
-    if (state.phase !== 'running' && state.phase !== 'slow') return;
-    const interval = window.setInterval(() => {
-      dispatch({ type: 'tick', now: performance.now() });
-    }, NAVIGATION_TICK_MS);
-    return () => window.clearInterval(interval);
-  }, [state.phase]);
+    const element = progressElement.current;
+    if (!element || state.startedAt === 0) return;
+
+    progressAnimation.current?.cancel();
+    progressAnimation.current = null;
+    const startProgress = animationOrigin.current;
+    element.style.transform = `scaleX(${startProgress})`;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const animation = element.animate(progressKeyframes(startProgress, state.estimateMs), {
+      duration: navigationAnimationDuration(state.estimateMs),
+      easing: 'linear',
+      fill: 'forwards',
+    });
+    progressAnimation.current = animation;
+
+    return () => {
+      if (progressAnimation.current !== animation) return;
+      const currentProgress = renderedProgress(element);
+      animation.cancel();
+      progressAnimation.current = null;
+      element.style.transform = `scaleX(${currentProgress})`;
+    };
+  }, [state.estimateMs, state.startedAt]);
+
+  useEffect(() => {
+    const element = progressElement.current;
+    if (!element) return;
+
+    if (state.phase === 'completing') {
+      const currentProgress = freezeProgressAnimation();
+      element.style.transform = `scaleX(${currentProgress})`;
+      clearCompletionFrame();
+      completionFrame.current = window.requestAnimationFrame(() => {
+        element.style.transform = 'scaleX(1)';
+        completionFrame.current = null;
+      });
+      return;
+    }
+
+    if (state.phase === 'failed') {
+      const currentProgress = freezeProgressAnimation();
+      element.style.transform = `scaleX(${currentProgress})`;
+      clearCompletionFrame();
+      completionFrame.current = window.requestAnimationFrame(() => {
+        element.style.transform = `scaleX(${Math.max(currentProgress, NAVIGATION_PROGRESS_CAP)})`;
+        completionFrame.current = null;
+      });
+      return;
+    }
+
+    if (state.phase === 'fading') {
+      clearCompletionFrame();
+      freezeProgressAnimation();
+    }
+  }, [clearCompletionFrame, freezeProgressAnimation, state.phase]);
 
   useEffect(() => {
     const prefetch = (href: string) => {
@@ -284,6 +414,8 @@ export function NavigationFeedback() {
       const detail = (event as CustomEvent<NavigationErrorDetail>).detail;
       activeNavigation.current = null;
       clearPhaseTimers();
+      clearCompletionFrame();
+      freezeProgressAnimation();
       dispatch({ type: 'fail', message: detail?.message });
     };
 
@@ -322,13 +454,24 @@ export function NavigationFeedback() {
       if (windowWithIdle.cancelIdleCallback) windowWithIdle.cancelIdleCallback(idleId);
       else window.clearTimeout(idleId);
     };
-  }, [beginNavigation, cancelNavigation, clearPhaseTimers, pathname, router]);
+  }, [
+    beginNavigation,
+    cancelNavigation,
+    clearCompletionFrame,
+    clearPhaseTimers,
+    freezeProgressAnimation,
+    pathname,
+    router,
+  ]);
 
   useEffect(
     () => () => {
       clearPhaseTimers();
+      clearCompletionFrame();
+      progressAnimation.current?.cancel();
+      progressAnimation.current = null;
     },
-    [clearPhaseTimers],
+    [clearCompletionFrame, clearPhaseTimers],
   );
 
   if (state.phase === 'idle') return null;
@@ -340,12 +483,17 @@ export function NavigationFeedback() {
     <div
       className="navigation-feedback pointer-events-none fixed inset-x-0 top-0 z-[100]"
       data-navigation-feedback=""
+      data-navigation-href={state.href}
       data-navigation-kind={state.kind}
       data-navigation-progress={state.progress.toFixed(3)}
       data-navigation-state={state.phase}
     >
       <div className="navigation-rail" aria-hidden="true">
-        <div className="navigation-progress" style={{ transform: `scaleX(${state.progress})` }} />
+        <div
+          ref={progressElement}
+          className="navigation-progress"
+          style={{ transform: `scaleX(${state.progress})` }}
+        />
       </div>
       {(showSlowStatus || showFailureStatus) && (
         <div

--- a/lib/navigation-progress.test.ts
+++ b/lib/navigation-progress.test.ts
@@ -22,6 +22,7 @@ function startNavigation(
     label: string;
     kind: 'link' | 'programmatic' | 'history';
     estimateMs: number;
+    startProgress: number;
   }> = {},
 ) {
   return transitionNavigationProgress(idleNavigationProgressState, {
@@ -30,17 +31,23 @@ function startNavigation(
     label: overrides.label ?? 'time',
     kind: overrides.kind ?? 'link',
     estimateMs: overrides.estimateMs ?? 900,
+    startProgress: overrides.startProgress,
     now,
   });
 }
 
-function restartNavigation(state: ReturnType<typeof startNavigation>, now = 2_000) {
+function restartNavigation(
+  state: ReturnType<typeof startNavigation>,
+  now = 2_000,
+  startProgress?: number,
+) {
   return transitionNavigationProgress(state, {
     type: 'start',
     href: '/gallery',
     label: 'gallery',
     kind: 'link',
     estimateMs: 900,
+    startProgress,
     now,
   });
 }
@@ -62,30 +69,42 @@ describe('adaptive navigation progress', () => {
     expect(completed.progress).toBe(1);
   });
 
-  it('starts fresh when a second navigation begins during the completion hold', () => {
+  it('preserves the rendered origin when a second navigation begins while settling', () => {
+    const started = startNavigation();
+    const settled = transitionNavigationProgress(started, { type: 'settle', now: 1_080 });
+    const restarted = restartNavigation(settled, 2_000, 0.61);
+    const advanced = transitionNavigationProgress(restarted, { type: 'tick', now: 2_100 });
+
+    expect(settled.phase).toBe('settling');
+    expect(restarted.phase).toBe('running');
+    expect(restarted.progress).toBe(0.61);
+    expect(advanced.progress).toBeGreaterThanOrEqual(restarted.progress);
+  });
+
+  it('preserves the rendered origin during the completion hold', () => {
     const started = startNavigation();
     const completed = transitionNavigationProgress(started, { type: 'settle', now: 1_300 });
-    const restarted = restartNavigation(completed);
+    const restarted = restartNavigation(completed, 2_000, 0.84);
     const advanced = transitionNavigationProgress(restarted, { type: 'tick', now: 2_100 });
 
     expect(completed.phase).toBe('completing');
     expect(completed.progress).toBe(1);
     expect(restarted.phase).toBe('running');
-    expect(restarted.progress).toBe(NAVIGATION_INITIAL_PROGRESS);
+    expect(restarted.progress).toBe(0.84);
     expect(advanced.progress).toBeGreaterThanOrEqual(restarted.progress);
   });
 
-  it('starts fresh when a second navigation begins during the fade', () => {
+  it('preserves the rendered origin during the fade', () => {
     const started = startNavigation();
     const completed = transitionNavigationProgress(started, { type: 'settle', now: 1_300 });
     const fading = transitionNavigationProgress(completed, { type: 'fade' });
-    const restarted = restartNavigation(fading);
+    const restarted = restartNavigation(fading, 2_000, 0.96);
     const advanced = transitionNavigationProgress(restarted, { type: 'tick', now: 2_100 });
 
     expect(fading.phase).toBe('fading');
     expect(fading.progress).toBe(1);
     expect(restarted.phase).toBe('running');
-    expect(restarted.progress).toBe(NAVIGATION_INITIAL_PROGRESS);
+    expect(restarted.progress).toBe(0.96);
     expect(advanced.progress).toBeGreaterThanOrEqual(restarted.progress);
   });
 
@@ -95,6 +114,14 @@ describe('adaptive navigation progress', () => {
     const restarted = restartNavigation(advanced);
 
     expect(restarted.progress).toBe(advanced.progress);
+  });
+
+  it('does not tick backwards when a replacement begins above the normal running cap', () => {
+    const restarted = startNavigation(2_000, { startProgress: 1 });
+    const advanced = transitionNavigationProgress(restarted, { type: 'tick', now: 2_100 });
+
+    expect(restarted.progress).toBe(1);
+    expect(advanced.progress).toBe(1);
   });
 
   it('advances a medium navigation monotonically from its duration estimate', () => {

--- a/lib/navigation-progress.ts
+++ b/lib/navigation-progress.ts
@@ -57,6 +57,7 @@ export type NavigationProgressAction =
       label: string;
       kind: NavigationKind;
       estimateMs: number;
+      startProgress?: number;
       now: number;
     }
   | { type: 'tick'; now: number }
@@ -219,7 +220,7 @@ export function estimatedNavigationProgress(
     NAVIGATION_INITIAL_PROGRESS +
     (NAVIGATION_PROGRESS_CAP - NAVIGATION_INITIAL_PROGRESS) * (1 - Math.exp(-2.2 * ratio));
 
-  return Math.min(NAVIGATION_PROGRESS_CAP, Math.max(previousProgress, estimated));
+  return Math.max(previousProgress, Math.min(NAVIGATION_PROGRESS_CAP, estimated));
 }
 
 export function transitionNavigationProgress(
@@ -228,15 +229,15 @@ export function transitionNavigationProgress(
 ): NavigationProgressState {
   switch (action.type) {
     case 'start': {
-      const replacesActiveNavigation = state.phase === 'running' || state.phase === 'slow';
+      const inheritedProgress =
+        action.startProgress ??
+        (state.phase === 'idle' ? NAVIGATION_INITIAL_PROGRESS : state.progress);
       return {
         phase: 'running',
         href: action.href,
         label: action.label,
         kind: action.kind,
-        progress: replacesActiveNavigation
-          ? Math.max(state.progress, NAVIGATION_INITIAL_PROGRESS)
-          : NAVIGATION_INITIAL_PROGRESS,
+        progress: Math.min(1, Math.max(NAVIGATION_INITIAL_PROGRESS, inheritedProgress)),
         estimateMs: clampDuration(action.estimateMs),
         startedAt: action.now,
         minVisibleUntil: action.now + NAVIGATION_MIN_VISIBLE_MS,

--- a/tests/e2e/navigation-feedback.spec.ts
+++ b/tests/e2e/navigation-feedback.spec.ts
@@ -1,0 +1,287 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const feedback = (page: Page) => page.locator('[data-navigation-feedback]');
+const progress = (page: Page) => page.locator('.navigation-progress');
+
+async function startNavigationFeedback(page: Page, href = '/time', label = 'time') {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        ({ destination, destinationLabel }) => {
+          window.dispatchEvent(
+            new CustomEvent('scrapbook:navigation-start', {
+              detail: { href: destination, label: destinationLabel },
+            }),
+          );
+          return document
+            .querySelector('[data-navigation-feedback]')
+            ?.getAttribute('data-navigation-href');
+        },
+        { destination: href, destinationLabel: label },
+      ),
+    )
+    .toBe(href);
+}
+
+async function settleNavigation(page: Page, href: string) {
+  await page.evaluate((destination) => window.history.pushState({}, '', destination), href);
+}
+
+function expectMonotonicReplacement(result: { before: number; samples: number[] }) {
+  expect(result.samples[0]).toBeGreaterThanOrEqual(result.before - 1);
+  for (let index = 1; index < result.samples.length; index += 1) {
+    expect(result.samples[index]).toBeGreaterThanOrEqual(result.samples[index - 1] - 0.5);
+  }
+}
+
+async function sampleReplacement(page: Page, href: string) {
+  const result = await progress(page).evaluate(
+    (element, destination) =>
+      new Promise<{ before: number; samples: number[] }>((resolve) => {
+        const before = element.getBoundingClientRect().width;
+        const samples: number[] = [];
+
+        window.dispatchEvent(
+          new CustomEvent('scrapbook:navigation-start', {
+            detail: { href: destination, label: destination.slice(1) },
+          }),
+        );
+
+        const sample = () => {
+          samples.push(element.getBoundingClientRect().width);
+          if (samples.length >= 12) resolve({ before, samples });
+          else requestAnimationFrame(sample);
+        };
+        requestAnimationFrame(sample);
+      }),
+    href,
+  );
+
+  await expect(feedback(page)).toHaveAttribute('data-navigation-href', href);
+  expectMonotonicReplacement(result);
+}
+
+async function navigateAndSampleReplacementDuringFade(page: Page, replacementHref: string) {
+  const result = await page.evaluate(
+    ({ replacementDestination }) =>
+      new Promise<{ before: number; samples: number[] } | null>((resolve) => {
+        let finished = false;
+        let timeout = 0;
+        const observerRef: { current: MutationObserver | null } = { current: null };
+
+        const finish = (value: { before: number; samples: number[] } | null) => {
+          if (finished) return;
+          finished = true;
+          window.clearTimeout(timeout);
+          observerRef.current?.disconnect();
+          resolve(value);
+        };
+
+        const observeFade = () => {
+          const feedbackElement = document.querySelector<HTMLElement>('[data-navigation-feedback]');
+          const progressElement = document.querySelector<HTMLElement>('.navigation-progress');
+          if (
+            finished ||
+            !feedbackElement ||
+            !progressElement ||
+            feedbackElement.dataset.navigationState !== 'fading'
+          ) {
+            return;
+          }
+
+          const before = progressElement.getBoundingClientRect().width;
+          const samples: number[] = [];
+          window.dispatchEvent(
+            new CustomEvent('scrapbook:navigation-start', {
+              detail: {
+                href: replacementDestination,
+                label: replacementDestination.slice(1),
+              },
+            }),
+          );
+
+          const sample = () => {
+            samples.push(progressElement.getBoundingClientRect().width);
+            if (samples.length >= 12) finish({ before, samples });
+            else requestAnimationFrame(sample);
+          };
+          requestAnimationFrame(sample);
+        };
+
+        const observer = new MutationObserver(observeFade);
+        observerRef.current = observer;
+        observer.observe(document.documentElement, {
+          subtree: true,
+          childList: true,
+          attributes: true,
+          attributeFilter: ['data-navigation-state'],
+        });
+        timeout = window.setTimeout(() => finish(null), 5_000);
+
+        const timeLink = document.querySelector<HTMLAnchorElement>('[data-site-time]');
+        if (!timeLink) {
+          finish(null);
+          return;
+        }
+
+        // Use a real hydrated internal navigation; the observer stays inside the page lifecycle.
+        timeLink.click();
+        observeFade();
+      }),
+    { replacementDestination: replacementHref },
+  );
+
+  expect(result).not.toBeNull();
+  if (!result) throw new Error('A real internal navigation never entered the fade phase');
+  await expect(feedback(page)).toHaveAttribute('data-navigation-href', replacementHref);
+  expectMonotonicReplacement(result);
+}
+
+async function cancelNavigationFeedback(page: Page) {
+  await page.evaluate(() => window.dispatchEvent(new Event('scrapbook:navigation-cancel')));
+  await expect(feedback(page)).toBeHidden();
+}
+
+test('navigation progress advances on a continuous compositor timeline', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.goto('/');
+
+  // Establish that the client listener has hydrated, then measure a fresh navigation entirely in-page.
+  await startNavigationFeedback(page, '/time');
+  await cancelNavigationFeedback(page);
+
+  const measurement = await page.evaluate(
+    () =>
+      new Promise<{
+        initialTime: number;
+        finalTime: number;
+        initialWidth: number;
+        finalWidth: number;
+        playState: AnimationPlayState;
+        keyframes: Array<{ offset: number | null; transform: string }>;
+        transitionDuration: string;
+      } | null>((resolve) => {
+        window.dispatchEvent(
+          new CustomEvent('scrapbook:navigation-start', {
+            detail: { href: '/gallery', label: 'gallery' },
+          }),
+        );
+
+        const deadline = performance.now() + 1_500;
+        const waitForAnimation = () => {
+          const element = document.querySelector<HTMLElement>('.navigation-progress');
+          const animation = element?.getAnimations()[0];
+          if (!element || !animation) {
+            if (performance.now() >= deadline) {
+              resolve(null);
+              return;
+            }
+            requestAnimationFrame(waitForAnimation);
+            return;
+          }
+
+          const effect = animation.effect as KeyframeEffect | null;
+          const keyframes = (effect?.getKeyframes() ?? []).map((keyframe) => ({
+            offset: keyframe.computedOffset ?? keyframe.offset ?? null,
+            transform: String(keyframe.transform ?? ''),
+          }));
+          const initialTime = Number(animation.currentTime ?? 0);
+          const initialWidth = element.getBoundingClientRect().width;
+          const transitionDuration = getComputedStyle(element).transitionDuration;
+
+          window.setTimeout(() => {
+            requestAnimationFrame(() => {
+              resolve({
+                initialTime,
+                finalTime: Number(animation.currentTime ?? 0),
+                initialWidth,
+                finalWidth: element.getBoundingClientRect().width,
+                playState: animation.playState,
+                keyframes,
+                transitionDuration,
+              });
+            });
+          }, 320);
+        };
+
+        requestAnimationFrame(waitForAnimation);
+      }),
+  );
+
+  expect(measurement).not.toBeNull();
+  if (!measurement) throw new Error('Navigation compositor animation did not start');
+  expect(measurement.playState).toBe('running');
+  expect(measurement.finalTime).toBeGreaterThan(measurement.initialTime + 100);
+  expect(measurement.finalWidth).toBeGreaterThan(measurement.initialWidth + 1);
+  expect(measurement.transitionDuration).toBe('0s');
+  expect(measurement.keyframes).toHaveLength(7);
+  expect(new Set(measurement.keyframes.map((keyframe) => keyframe.transform)).size).toBe(7);
+  for (let index = 1; index < measurement.keyframes.length; index += 1) {
+    expect(measurement.keyframes[index].offset).toBeGreaterThan(
+      measurement.keyframes[index - 1].offset ?? -1,
+    );
+  }
+
+  await cancelNavigationFeedback(page);
+});
+
+test('replacement during settling preserves the rendered width', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.goto('/');
+  await startNavigationFeedback(page, '/time');
+  await settleNavigation(page, '/time');
+  await expect(feedback(page)).toHaveAttribute('data-navigation-state', 'settling');
+
+  await sampleReplacement(page, '/gallery');
+  await cancelNavigationFeedback(page);
+});
+
+test('replacement during the completion hold never jumps backwards', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.goto('/');
+  await startNavigationFeedback(page, '/time');
+  await page.waitForTimeout(240);
+  await settleNavigation(page, '/time');
+  await expect(feedback(page)).toHaveAttribute('data-navigation-state', 'completing');
+
+  await sampleReplacement(page, '/gallery');
+  await cancelNavigationFeedback(page);
+});
+
+test('replacement during the fade never jumps backwards', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.goto('/');
+  await expect(page.locator('[data-site-nav-ready="true"]')).toBeVisible({ timeout: 15_000 });
+
+  // Confirm the feedback listener is hydrated before starting the real Link navigation.
+  await startNavigationFeedback(page, '/gallery');
+  await cancelNavigationFeedback(page);
+
+  await navigateAndSampleReplacementDuringFade(page, '/gallery');
+  await cancelNavigationFeedback(page);
+});
+
+test('reduced motion keeps navigation progress static and animation-free', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/');
+  await startNavigationFeedback(page);
+
+  await expect(progress(page)).toBeVisible();
+  expect(await progress(page).evaluate((element) => element.getAnimations().length)).toBe(0);
+
+  const widths = await progress(page).evaluate(
+    (element) =>
+      new Promise<number[]>((resolve) => {
+        const samples: number[] = [];
+        const sample = () => {
+          samples.push(element.getBoundingClientRect().width);
+          if (samples.length >= 8) resolve(samples);
+          else requestAnimationFrame(sample);
+        };
+        requestAnimationFrame(sample);
+      }),
+  );
+  expect(new Set(widths.map((width) => Math.round(width * 10) / 10)).size).toBe(1);
+
+  await cancelNavigationFeedback(page);
+});


### PR DESCRIPTION
Closes #463

## Result

Replace the production navigation rail's 100 ms React interval with one compositor-driven transform animation while preserving the existing adaptive duration model and lifecycle semantics.

- sample the existing exponential progress curve into seven Web Animations keyframes;
- keep JavaScript work to one-shot snapshot, slow-status, failure, completion, fade, and reset timers;
- derive every replacement navigation's origin from the mounted rail's rendered width;
- preserve monotonic width during running, settling, completion hold, fade, cancellation, and failure;
- keep completion and failure as short transform-only transitions;
- keep reduced-motion navigation animation-free;
- contain paint to the existing 2 px rail.

## Fresh replay

This is a current-main replay of the corrected design previously explored in closed draft #465. It does not restack that stale branch wholesale.

- base: `main` at `a4d00441659a8e3362417cc7c006d7035dff5177`;
- head: `perf/issue-463-smooth-navigation-feedback-v2` at `84def8e5e862b5178fb881f9c09875676c106227`;
- relation: one commit ahead, zero behind;
- changed files: five.

The unrelated timezone-picker test workaround from #465 is deliberately excluded.

## Replacement-lifecycle correction

The original #465 review found that replacements during settling, completion, or fade could restart at 18% and jump backwards. This replay includes the corrected contract:

- read the live rendered width before cancelling the current animation;
- pass that explicit start progress into the reducer;
- allow a replacement origin above the normal running cap without a later tick moving backwards;
- test replacements during settling, completion hold, and fade in Chromium and WebKit.

## Verification

Draft while GitHub CI and the Vercel preview run. Required gate:

- lint;
- typecheck;
- unit tests;
- production build;
- full Chromium and WebKit regressions;
- focused continuous-frame, replacement-lifecycle, and reduced-motion assertions.

## Recovery

Revert the squash merge. No route, data, credential, cache, persistence, or deployment configuration changes are introduced.