### PR TITLE
Make the public resume accurate, accessible, and discoverable

### DIFF
--- a/app/lib/resume-data.ts
+++ b/app/lib/resume-data.ts
@@ -5,231 +5,149 @@ export type ResumeItem = {
 
 export type ResumeSection = {
   title: string;
-  meta: string; // e.g. "Remote | June 2025 - Present"
+  meta: string;
   items: ResumeItem[];
 };
 
 export type ResumeColumns = [ResumeSection[], ResumeSection[], ResumeSection[]];
 
 export const resumeColumns: ResumeColumns = [
-  // Column 1
   [
     {
-      title:
-        "Next.js (By Vercel) | Open Source Contributor (We are not affiliated with Vercel, we just think this is a nice way to learn!)",
-      meta: "Remote | June 2025 - Present",
+      title: "Next.js | Open Source Contributor",
+      meta: "Remote | 2025",
       items: [
         {
           bullet:
-            "Fixed dark mode styling in Next.js development tools, improving accessibility for 4.9M+ developers, merged in #80025.",
+            "Fixed dark-mode styling in Next.js developer tooling, merged in #80025.",
           note:
-            "The Process: While a simple CSS fix, the real work was navigating a massive, unfamiliar codebase, understanding its design system, and successfully justifying the change to the maintainers. It was a perfect first exercise in contributing to a major open-source project.",
+            "The work required tracing an unfamiliar design system, reproducing the contrast failure, and matching the maintainers' existing conventions rather than introducing a one-off style.",
         },
         {
           bullet:
-            "Identified and resolved critical UX issue causing unreadable white-on-white text in dropdowns.",
-          note: "As above.",
-        },
-        {
-          bullet:
-            "Contributed production code using existing design system variables consistent with framework standards.",
-          note: "...As above.",
-        },
-        {
-          bullet:
-            "Improved Next.js App Router internals by refactoring an unhandled redirect handler to use direct dispatch methods, aligning with architectural best practices and addressing an existing TODO in #80075.",
+            "Refactored an unhandled redirect pathway to use direct dispatch methods, merged in #80075.",
           note:
-            "Exploration: This PR was an exploration into core framework architecture. By addressing a long-standing TODO in the codebase, I practiced refactoring critical pathways to improve performance and adhere to internal best practices, learning a ton about the framework's internals along the way.",
+            "This was a focused architecture exercise in following a redirect through the App Router and replacing an old indirection without changing observable behavior.",
         },
         {
           bullet:
-            "Analyzed Next.js internal architecture to diagnose call stack limitations in static export functionality for sites with 100k+ pages, then proposed and implemented a proactive warning system that prevents build scalability failures in #80037.",
+            "Traced static-export scaling limits and added a proactive warning for very large route counts, merged in #80037.",
           note:
-            "Proactive Problem-Solving: This PR addresses a fundamental scalability issue for large SSG sites. The goal was to trace the export pipeline and implement a proactive warning system to prevent silent, hard-to-debug build failures for developers working at enterprise scale.",
-        },
-        {
-          bullet:
-            "Engaged with and guided developers to scalable patterns and best practices.",
-          note:
-            "I tried my hand a bit at engaging in some discussions/commenting on issues, but... wow, it's a lot to keep up with.",
+            "The change turned a difficult late-build failure mode into an earlier, actionable diagnostic for large static sites.",
         },
       ],
     },
     {
-      title: "Git Inline (Front-End Visualization)",
-      meta: "npmjs.com/package/git-inline | Jan 2025 - Present",
+      title: "Git Inline | React Visualization Library",
+      meta: "Open source | 2025",
       items: [
         {
           bullet:
-            "Published open-source NPM React component library to visualize Git history, adding lilconfig to resolve JavaScript bundler issues.",
+            "Published a React component library for rendering compact Git history directly inside product interfaces.",
           note:
-            "I think it's quite a nice idea, and I want to continue working on it, but we got derailed due to wondering how we'd get user configs nice and ergonomic when they're setting up their GitHub urls and whatnot, and I just got kinda bored and didn't want to implement the API caching... which, IMO, is absolutely necessary. So it's at version 0.0.1 right now, because I also found other things that were more interesting. But this is still interesting! There're just a lot of competiting priorities.",
+            "The experiment focused on making repository history legible without sending users to a separate developer tool.",
+        },
+        {
+          bullet:
+            "Added configuration discovery with lilconfig to resolve bundler and consumer setup problems.",
         },
       ],
     },
   ],
-
-  // Column 2
   [
     {
-      title: "Glossless (AI Pose-Inference Tool)",
-      meta: "glossless.app | June 2024 - Present",
+      title: "Glossless | AI Pose-Reference Tool",
+      meta: "glossless.app | 2024–present",
       items: [
         {
           bullet:
-            "Engineered a pipeline allowing users to go from image upload to a lit, posed 3D mannequin in seconds vs workflows that take minutes in traditional software..",
+            "Built a browser-based workflow that turns an uploaded image into a lit, posed, editable 3D mannequin.",
           note:
-            "Artists needing pose references shouldn't have to fight complex 3D software. This entire project is architected around collapsing the time it takes to get a useful, well-lit reference, making it an ergonomic, lightweight alternative to the status quo.",
+            "The product is designed around reducing the setup cost of traditional 3D pose-reference workflows for artists.",
         },
         {
           bullet:
-            "Productionized ML research models (Bizarre Pose Estimator, VideoPose3D) to GPU-powered, auto-scaling API on Modal, refactoring 2021 command-line research code and resolving legacy PyTorch/NumPy dependency conflicts.",
+            "Productionized legacy pose-estimation research models as a containerized, autoscaling GPU service on Modal.",
           note:
-            "The Challenge: The original research code was powerful but production-hostile. It was a tangle of CLI dependencies and version conflicts. The main work was refactoring this into a containerized, reliable, and scalable web service that could form the backbone of a real product.",
+            "The work included removing command-line assumptions and resolving older PyTorch and NumPy dependency constraints.",
         },
         {
           bullet:
-            "Optimized serverless performance, slashing P95 cold-start latency by 78% (from 45s to 10s) by implementing memory snapshots and caching model binaries.",
-          note:
-            "Insight: A 45-second cold start is a dealbreaker for an interactive tool. The key to this 78% reduction was a two-stage loading process and implementing Modal's memory snapshots, proving that thoughtful serverless architecture can deliver a near-native user experience.",
+            "Reduced reported P95 cold-start latency from 45 seconds to 10 seconds through staged loading, cached model binaries, and memory snapshots.",
         },
         {
           bullet:
-            "Architected a cost-effective alternative inference pipeline using a multimodal LLM (Llama 3.2) on Cloudflare Workers AI, reducing per-inference costs by 94.7%(∼19x).",
-          note:
-            "The Trade-off: Instead of relying solely on the expensive GPU model, this pipeline uses a cost-effective multimodal LLM as a \"sanity check\" and validation layer. It's a novel approach that improves robustness while dramatically reducing cost—a critical consideration for any real-world AI product.",
-        },
-        {
-          bullet:
-            "Developed lightweight and stable 60fps+ real-time 3D editor and AI system using React, Three.js, and Supabase, featuring a bidirectionally synchronized canvas, interactive joint manipulation, and a routing gateway that sends photos to MediaPipe and illustrations to the custom COCO API..",
-          note:
-            "Architectural Goal: Performance and stability were non-negotiable. Many web-based 3D tools lag or crash browsers under load. This editor was architected from the ground up to be lightweight, delivering a stable 60fps+ experience by creating a hybrid system that intelligently routes different image types to the optimal model (client-side MediaPipe vs. custom backend).",
+            "Built a React, Three.js, and Supabase editor with bidirectional joint manipulation and model routing for photos and illustrations.",
         },
       ],
     },
     {
-      title: "Scrapbook (Full-Stack Blog)",
-      meta:
-        "github.com/teamleaderleo/scrapbook | teamleaderleo.com | May 2024 - Present",
+      title: "Scrapbook | Personal Software Lab",
+      meta: "teamleaderleo.com | 2024–present",
       items: [
         {
           bullet:
-            "Built CMS with Next.js and TypeScript for optimized CRUD operations and responsive design.",
+            "Built and maintains a Next.js 16 personal site combining public utilities, interactive experiments, a private Supabase-backed workspace, and a repository-backed agent journal.",
           note:
-            "The blog part is it. We're still working on trying out different designs/libraries, but I personally just prefer dense information and non-functional art. So... everything and nothing.",
+            "Scrapbook is intentionally a living system: useful public surfaces stay polished while experiments are isolated, measured, or retired when they stop earning their complexity.",
         },
         {
           bullet:
-            "Cut hosting costs by 85% via database migration from Vercel to Supabase (with 100% data integrity via pg dump).",
-          note:
-            "Vercel's database pricing was getting expensive as the project grew. Migrated everything to Supabase using pg_dump to ensure 100% data integrity. The migration went smoothly and now I get way more database features for a fraction of the cost.",
+            "Designed typed note, reference, code, review, and artifact workflows with explicit public/private boundaries and FSRS-based scheduling.",
         },
         {
           bullet:
-            "Reduced request latency from 300ms to 50ms through optimized queries, indexing, and TanStack Query caching.",
-          note:
-            "The original setup was doing way too many database round trips. I added proper indexing on frequently queried columns, restructured some of the more complex queries, and implemented aggressive caching with TanStack Query. The 50ms response time made the whole app feel snappy.",
+            "Hardened GitHub activity ingestion with bounded parsing, stale-data fallback, retry backoff, and privacy-safe public diagnostics.",
         },
         {
           bullet:
-            "Built novel bidirectional looping infinite scrolling system with Three.js and React Three Fiber, preserving native browser functionality while solving edge-case behaviours with accessibility-focused DOM overrides",
-          note:
-            "The Challenge: The goal was to build an infinite scroll system that didn't break the web. Most libraries hijack the scrollbar and disable native browser functionality. This implementation was a deep dive into custom DOM manipulation to preserve features like browser history and scroll restoration, making it feel seamless and native.",
+            "Published a journal-only RSS feed and a centralized Site Atlas for discoverable public navigation without reviving retired content systems.",
         },
         {
           bullet:
-            "Built rich text editor with TipTap and Zustand with persistent drafts, keyboard shortcuts, and stateful editing.",
-          note:
-            "This is in the App portion. It was really, really hard to achieve even half of the Discord-level usability, because there is just so much state management.",
+            "Established CI gates covering ESLint, TypeScript, unit tests, production builds, and Chromium/WebKit browser regressions.",
         },
         {
           bullet:
-            "Offloaded image processing to Go microservice (Docker, Lambda, REST API Gateway) for distributed backend.",
-          note:
-            "Architectural Decision: This was an exercise in building a decoupled, distributed system. Offloading image processing to a dedicated Go microservice (detailed in the Potato Image Compressor project) improved the main app's scalability and maintainability, separating concerns for a more robust backend.",
-        },
-        {
-          bullet:
-            "Ensured type-safe client-server JSON data with Zod schema validation and Next.js Server Actions.",
-          note:
-            "This is pretty basic. I used Drizzle, too. Like, it's just adding more types and stuff..",
-        },
-        {
-          bullet:
-            "Used Claude LLM API to auto-suggest tags and categorize content, improving metadata search UX.",
-          note:
-            "I turned this off for now, but it was nice when I tried it a while ago. Rather than making users manually tag everything, I integrated Claude's API to analyze content and suggest relevant tags. It's surprisingly good at understanding context and suggesting useful categorization that actually improves search and organization.",
-        },
-        {
-          bullet:
-            "Integrated OAuth 2.0 with GitHub/Google/email for secure user login and personalized content access.",
-          note:
-            "This was just to prove that I could. I want to disable it, but... idk.",
-        },
-        {
-          bullet:
-            "Added real-time WebSocket telemetry with error handling for system monitoring and analytics.",
-          note:
-            "This was also just to prove that I could. It isn't on, because I don't really have anything that necessitates it.",
-        },
-        {
-          bullet:
-            "Developed full-stack features from DB schema to Tailwind CSS UI, iterating on Figma designs and peer feedback.",
-          note:
-            "I asked my mom to look at my previous versions. I also tried really hard to match up to Discord's design system earlier on, but I realized that I have my own tastes, and I want to try out a bunch of new animation and 3D libraries.",
-        },
-        {
-          bullet:
-            "Built Playwright/Vitest testing pipeline to troubleshoot and debug async state issues for CI stability.",
-          note:
-            "We don't really have a use for this, but we did it to prove that we could.",
+            "Continuously removes unused routes, APIs, and legacy data layers through evidence-backed dependency audits while preserving recovery through Git history.",
         },
       ],
     },
   ],
-
-  // Column 3
   [
     {
-      title: "Potato Image Compressor (Back-End).",
-      meta:
-        "github.com/teamleaderleo/potato-quality-image-compressor | April 2025",
+      title: "Potato Image Compressor | Go Backend",
+      meta: "Open source | 2025",
       items: [
         {
           bullet:
-            "Built a Dockerized image processing pipeline in Go using goroutines and sync primitives.",
+            "Built a Dockerized image-processing pipeline in Go using goroutines, worker pools, semaphores, and mutexes.",
           note:
-            "This was a fun project. I wanted to learn Go, and I thought it would be a good idea to build an image processing pipeline. It was simpler when I initially added it a few months into the Scrapbook project, and it was a couple months later that I really thought to dig deep and make this bigger and better and faster and flashier. I used goroutines with worker pools and sync primitives (both semaphores and mutexes) to make it concurrent and efficient. Oh, and I wanted to try out gRPC too. It's not the most complex thing, but it was a good exercise in Go.",
+            "The project was a practical exercise in bounded concurrency, resource ownership, and separating processing logic from transport concerns.",
         },
         {
           bullet:
-            "Boosted throughput by 6.3x over baseline, validated via k6 load testing.",
-          note:
-            "I wanted to use k6 because it seemed like some sort of industry standard, but I ended up doing the bulk of the testing with shell scripts... which seems like what k6 kinda does anyway, at least for my case here. Anyway, the baseline was also this supremely naive, sequential little thing. Which I don't think I even had? Like, I'm pretty sure it was already async/await (in go terms) from the start..",
+            "Measured a 6.3× throughput improvement against a sequential baseline using repeatable load tests.",
         },
         {
           bullet:
-            "Designed modular algorithm architecture with swappable compression strategies (e.g., libvips).",
-          note:
-            "This was a fun challenge. I wanted to make the image processing pipeline more flexible and extensible, so I designed it with a modular architecture in mind. This way, I could easily swap out different compression strategies (like libvips) without having to rewrite a lot of code. It was a good exercise in software design principles.",
+            "Exposed processing through HTTP and gRPC adapters and instrumented the service with Prometheus, Grafana, and shell tooling.",
         },
         {
           bullet:
-            "Used Adapter Pattern to expose logic via HTTP/gRPC, tracking metrics via Prometheus/Grafana + shell tooling.",
-          note:
-            "This was another interesting challenge. I wanted to make the image processing pipeline accessible over the network, so I used the Adapter Pattern to expose its functionality via HTTP and gRPC. I also set up monitoring and metrics tracking using Prometheus and Grafana, along with some shell tooling to make it easier to work with. It was a good way to learn about distributed systems and observability.",
+            "Designed swappable compression strategies so processing implementations can change without rewriting transport code.",
         },
       ],
     },
     {
-      title: "Fold Single-Line Comments.",
-      meta: "fold-single-line-comments | Feb 2025",
+      title: "Fold Single-Line Comments | VS Code Extension",
+      meta: "Open source | 2025",
       items: [
         {
           bullet:
-            "Published VS Code extension solving 1000-day-old StackOverflow issue now used by 70+ developers.",
+            "Published a VS Code extension for folding contiguous single-line comments, addressing a long-standing community request.",
           note:
-            "This was a fun little project. I saw a StackOverflow question that had been open for 1000 days about how to fold single-line comments in VS Code. I thought it was a neat idea, so I built an extension that does just that. It's simple but effective, and it's nice to see other developers finding it useful.",
+            "The project is deliberately small: one specific editor friction point, a bounded implementation, and a public release that other developers can use.",
         },
       ],
     },

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
 import OsuResumeSelector from "@/components/osu-resume-selector";
 import { resumeColumns } from "../lib/resume-data";
+
+export const metadata: Metadata = {
+  title: "Resume | teamleaderleo",
+  description: "Selected engineering work, open-source contributions, and personal software projects.",
+  alternates: { canonical: "/resume" },
+};
 
 export default function ResumePage() {
   return <OsuResumeSelector resumeColumns={resumeColumns} />;

--- a/components/osu-resume-selector.tsx
+++ b/components/osu-resume-selector.tsx
@@ -1,145 +1,117 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import SiteNav from "@/components/site-nav";
-
-interface ResumeItem {
-  bullet: string;
-  note?: string;
-}
-
-interface ResumeSection {
-  title: string;
-  meta: string;
-  items: ResumeItem[];
-}
+import type { ResumeColumns } from "@/app/lib/resume-data";
 
 interface OsuResumeSelectorProps {
-  resumeColumns: ResumeSection[][];
+  resumeColumns: ResumeColumns;
+}
+
+function getSectionOffset(index: number, selectedIndex: number): number {
+  const distance = Math.abs(index - selectedIndex);
+  if (distance === 0) return 12;
+  if (distance === 1) return 6;
+  if (distance === 2) return 3;
+  return 0;
 }
 
 export default function OsuResumeSelector({ resumeColumns }: OsuResumeSelectorProps) {
-  // Flatten the columns into a single array
   const resumeSections = resumeColumns.flat();
-  
-  const [hoveredIndex, setHoveredIndex] = useState(0);
-  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
-  useEffect(() => {
-    // Load anime.js
-    const script = document.createElement('script');
-    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/animejs/3.2.1/anime.min.js';
-    script.async = true;
-    document.body.appendChild(script);
+  if (resumeSections.length === 0) {
+    return (
+      <main className="flex min-h-screen flex-col bg-sidebar-background">
+        <SiteNav />
+        <p className="m-auto p-6 text-sm text-muted-foreground">No resume sections are available.</p>
+      </main>
+    );
+  }
 
-    return () => {
-      if (document.body.contains(script)) {
-        document.body.removeChild(script);
-      }
-    };
-  }, []);
-
-  const handleMouseEnter = (index: number) => {
-    setHoveredIndex(index);
-    
-    if (!(window as any).anime) return;
-
-    // Animate list items
-    itemRefs.current.forEach((item, i) => {
-      if (!item) return;
-      
-      const distance = Math.abs(i - index);
-      const isHovered = i === index;
-      
-      (window as any).anime({
-        targets: item,
-        translateX: isHovered ? 15 : distance <= 2 ? 8 - (distance * 3) : 0,
-        duration: 250,
-        easing: 'easeOutCubic',
-      });
-    });
-  };
-
-  const currentSection = resumeSections[hoveredIndex];
+  const safeSelectedIndex = Math.min(selectedIndex, resumeSections.length - 1);
+  const currentSection = resumeSections[safeSelectedIndex];
 
   return (
-    <main className="flex flex-col h-screen bg-sidebar-background" style={{ scrollbarGutter: 'stable' }}>
+    <main className="flex min-h-screen flex-col bg-sidebar-background lg:h-screen lg:overflow-hidden">
       <SiteNav />
-      
-      <div className="flex flex-1 overflow-hidden min-h-0">
-        {/* Left side - List */}
-        <div className="w-1/2 border-r border-sidebar-border flex flex-col overflow-y-auto">
-          <div className="flex-1 pl-6 pr-6 pt-3">
+
+      <div className="grid flex-1 lg:min-h-0 lg:grid-cols-[minmax(20rem,0.9fr)_minmax(0,1.1fr)]">
+        <nav
+          aria-label="Resume sections"
+          className="border-b border-sidebar-border lg:overflow-y-auto lg:border-b-0 lg:border-r"
+        >
+          <div className="space-y-1 p-3 sm:p-5">
             {resumeSections.map((section, index) => {
-              const isHovered = hoveredIndex === index;
-              
+              const isSelected = safeSelectedIndex === index;
+              const offset = getSectionOffset(index, safeSelectedIndex);
+
               return (
-                <div
-                  key={index}
-                  ref={(el) => { itemRefs.current[index] = el; }}
-                  className="relative"
-                  onMouseEnter={() => handleMouseEnter(index)}
-                  style={{ zIndex: isHovered ? 10 : 1 }}
+                <button
+                  key={`${section.title}-${section.meta}`}
+                  type="button"
+                  aria-pressed={isSelected}
+                  aria-controls="resume-detail"
+                  data-resume-section={index}
+                  className={`w-full cursor-pointer rounded border-l-4 p-4 text-left transition-[background-color,border-color,color,transform] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar-background ${
+                    isSelected
+                      ? "border-l-primary-foreground bg-accent text-primary-foreground dark:border-l-sidebar-primary-foreground dark:bg-sidebar-accent dark:text-sidebar-primary-foreground"
+                      : "border-l-transparent border-b border-border text-foreground hover:bg-muted/50 dark:border-sidebar-border dark:text-sidebar-foreground dark:hover:bg-sidebar-accent/50"
+                  }`}
+                  style={{ transform: `translateX(${offset}px)` }}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  onFocus={() => setSelectedIndex(index)}
+                  onClick={() => setSelectedIndex(index)}
                 >
-                  <div
-                    className={`
-                      p-4 cursor-pointer transition-all duration-200
-                      ${isHovered ? 'bg-accent dark:bg-sidebar-accent rounded border-l-4 border-l-primary-foreground dark:border-l-sidebar-primary-foreground' : 'border-b border-border dark:border-sidebar-border hover:bg-muted/50 dark:hover:bg-sidebar-accent/50'}
-                    `}
-                  >
-                    <div className="flex items-baseline justify-between gap-4">
-                      <h2 className={`text-base font-semibold transition-colors duration-200 ${
-                        isHovered ? 'text-primary-foreground dark:text-sidebar-primary-foreground' : 'text-foreground dark:text-sidebar-foreground'
-                      }`}>
-                        {section.title}
-                      </h2>
-                      <span className="text-muted-foreground text-xs whitespace-nowrap">
-                        {section.meta}
-                      </span>
-                    </div>
-                  </div>
-                </div>
+                  <span className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+                    <span className="text-sm font-semibold sm:text-base">{section.title}</span>
+                    <span className="text-xs text-muted-foreground sm:whitespace-nowrap">
+                      {section.meta}
+                    </span>
+                  </span>
+                </button>
               );
             })}
           </div>
-        </div>
+        </nav>
 
-        {/* Right side - Details */}
-        <div className="w-1/2 p-6 overflow-y-auto">
-          <div>
-            {/* Section header */}
-            <div className="mb-6 pb-4 border-b-2 border-primary dark:border-sidebar-primary">
-              <h2 className="text-xl font-bold text-foreground dark:text-sidebar-foreground mb-1.5">
-                {currentSection.title}
-              </h2>
-              <p className="text-muted-foreground text-sm">{currentSection.meta}</p>
-            </div>
+        <section
+          id="resume-detail"
+          aria-live="polite"
+          className="p-4 sm:p-6 lg:overflow-y-auto lg:p-8"
+        >
+          <header className="mb-6 border-b-2 border-primary pb-4 dark:border-sidebar-primary">
+            <h1
+              data-resume-detail-title
+              className="mb-1.5 text-xl font-bold text-foreground dark:text-sidebar-foreground sm:text-2xl"
+            >
+              {currentSection.title}
+            </h1>
+            <p className="text-sm text-muted-foreground">{currentSection.meta}</p>
+          </header>
 
-            {/* Section content */}
-            <div className="space-y-4">
-              {currentSection.items.map((item, i) => (
-                <div 
-                  key={i}
-                  className="text-sm"
-                >
-                  <div className="flex items-start gap-2.5">
-                    <span className="text-foreground dark:text-sidebar-foreground mt-1">•</span>
-                    <div className="flex-1">
-                      <div className="text-foreground dark:text-sidebar-foreground leading-relaxed">
-                        {item.bullet}
-                      </div>
-                      {item.note && (
-                        <div className="mt-2.5 pl-4 border-l-2 border-muted text-sm text-foreground dark:text-sidebar-foreground leading-relaxed">
-                          {item.note}
-                        </div>
-                      )}
-                    </div>
+          <div className="space-y-5">
+            {currentSection.items.map((item) => (
+              <article key={item.bullet} className="text-sm">
+                <div className="flex items-start gap-2.5">
+                  <span aria-hidden="true" className="mt-1 text-foreground dark:text-sidebar-foreground">
+                    •
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="leading-relaxed text-foreground dark:text-sidebar-foreground">
+                      {item.bullet}
+                    </p>
+                    {item.note ? (
+                      <p className="mt-2.5 border-l-2 border-muted pl-4 leading-relaxed text-muted-foreground">
+                        {item.note}
+                      </p>
+                    ) : null}
                   </div>
                 </div>
-              ))}
-            </div>
+              </article>
+            ))}
           </div>
-        </div>
+        </section>
       </div>
     </main>
   );

--- a/lib/site-navigation.test.ts
+++ b/lib/site-navigation.test.ts
@@ -10,15 +10,16 @@ describe('site navigation registry', () => {
   it('exposes the visible destinations and keeps retired writing surfaces hidden', () => {
     const hrefs = siteNavigationItems.map((item) => item.href);
     expect(hrefs).toEqual(
-      expect.arrayContaining(['/', '/space', '/time', '/gallery', '/atelier', '/snow-globe']),
+      expect.arrayContaining(['/', '/space', '/time', '/gallery', '/resume', '/atelier', '/snow-globe']),
     );
     expect(hrefs).not.toContain('/blog');
     expect(hrefs).not.toContain('/journal');
   });
 
-  it('keeps tools and labs reachable without promoting them into the primary row', () => {
+  it('keeps tools, secondary places, and labs out of the primary row', () => {
     const primaryIds = primaryNavigationItems.map((item) => item.id);
     expect(primaryIds).toEqual(['home', 'space', 'gallery']);
+    expect(primaryIds).not.toContain('resume');
     expect(primaryIds).not.toContain('proxy');
     expect(primaryIds).not.toContain('snow-globe');
     expect(primaryIds).not.toContain('activity-lab');
@@ -42,9 +43,10 @@ describe('site navigation registry', () => {
     expect(isNavigationItemActive('/github', github!)).toBe(false);
   });
 
-  it('returns the active place for nested routes', () => {
+  it('returns the active place for registered routes', () => {
     expect(getActiveNavigationItem('/space/review')?.id).toBe('space');
     expect(getActiveNavigationItem('/gallery')?.id).toBe('gallery');
+    expect(getActiveNavigationItem('/resume')?.id).toBe('resume');
     expect(getActiveNavigationItem('/snow-globe')?.id).toBe('snow-globe');
     expect(getActiveNavigationItem('/blog/about')).toBeUndefined();
     expect(getActiveNavigationItem('/unknown')).toBeUndefined();

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -124,7 +124,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'glossless',
         href: 'https://glossless.app/',
         label: 'Glossless',
-        description: 'Writing tool.',
+        description: 'AI-assisted 3D pose-reference tool.',
         group: 'connections',
         external: true,
       },

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -49,6 +49,13 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         primary: true,
       },
       {
+        id: 'resume',
+        href: '/resume',
+        label: 'Resume',
+        description: 'Selected engineering work and open-source projects.',
+        group: 'places',
+      },
+      {
         id: 'atelier',
         href: '/atelier',
         label: 'Atelier',

--- a/tests/e2e/resume.spec.ts
+++ b/tests/e2e/resume.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+test('resume sections can be selected with the keyboard', async ({ page }) => {
+  await page.goto('/resume');
+
+  await expect(page.locator('[data-resume-detail-title]')).toHaveText(/Next\.js/);
+
+  const gitInline = page.getByRole('button', { name: /Git Inline/ });
+  await gitInline.focus();
+  await page.keyboard.press('Enter');
+
+  await expect(gitInline).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-resume-detail-title]')).toHaveText(/Git Inline/);
+});
+
+test('resume remains usable without horizontal overflow on mobile', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/resume');
+
+  await page.getByRole('button', { name: /Scrapbook/ }).click();
+  await expect(page.locator('[data-resume-detail-title]')).toHaveText(/Scrapbook/);
+
+  const metrics = await page.evaluate(() => ({
+    viewport: window.innerWidth,
+    documentWidth: document.documentElement.scrollWidth,
+    bodyWidth: document.body.scrollWidth,
+  }));
+  expect(metrics.documentWidth).toBeLessThanOrEqual(metrics.viewport + 1);
+  expect(metrics.bodyWidth).toBeLessThanOrEqual(metrics.viewport + 1);
+});
+
+test('Site Atlas exposes the resume without promoting it to primary navigation', async ({ page }) => {
+  await page.goto('/');
+  await page.locator('[data-site-atlas-trigger]').click();
+
+  await expect(page.locator('[data-site-atlas-link="resume"]')).toHaveAttribute('href', '/resume');
+  await expect(page.locator('[data-site-primary-link="resume"]')).toHaveCount(0);
+});


### PR DESCRIPTION
## Why

The public resume still described Scrapbook as a full-stack blog/CMS and claimed live Claude tagging, WebSocket telemetry, and legacy login features that have now been retired or were never meaningfully operated. Its selector also injected Anime.js from cdnjs at runtime, depended on `window as any`, was hover-oriented, and locked the page into a desktop-only 50/50 layout.

## Change

- replace stale, self-undermining resume copy with six concise project sections grounded in existing repository/project evidence;
- describe current Scrapbook work: public utilities and experiments, private Space workflows, FSRS scheduling, hardened GitHub activity ingestion, journal RSS, CI, and evidence-backed retirement;
- remove runtime Anime.js/CDN injection and imperative element animation;
- use local CSS transforms and semantic buttons;
- support mouse, keyboard focus/activation, and touch selection;
- stack naturally on mobile and retain independent desktop scrolling;
- add page metadata and canonical URL;
- expose Resume in the Site Atlas without adding it to primary navigation;
- correct the Atlas description of Glossless;
- add unit/browser coverage for registration, keyboard selection, mobile overflow, and Atlas discovery.

## Claim boundary

No new externally sourced metrics were invented. The rewrite removes several stale metrics and retains only two historical measurements already present in the repository data: Glossless cold-start reduction from 45s to 10s and the Potato compressor's 6.3× sequential-baseline throughput result.

## Validation requested

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit regressions;
- keyboard selection updates the detail panel;
- 390px viewport has no horizontal overflow;
- Site Atlas contains `/resume`, while primary navigation does not.