### PR TITLE
Rollback failed Space reviews without clobbering newer state

### DIFF
--- a/app/lib/fsrs-adapter.test.ts
+++ b/app/lib/fsrs-adapter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Rating, State } from 'ts-fsrs';
+import type { ReviewState } from './review-types';
+import { retrievabilityNow, reviewOnce } from './fsrs-adapter';
+
+const nowMs = Date.UTC(2026, 6, 31, 12, 0, 0);
+
+describe('reviewOnce', () => {
+  it('rejects ratings outside the FSRS response range', () => {
+    expect(() => reviewOnce(undefined, 0 as Rating, nowMs)).toThrow('Invalid rating: 0');
+    expect(() => reviewOnce(undefined, 5 as Rating, nowMs)).toThrow('Invalid rating: 5');
+  });
+
+  it('schedules a new card from the supplied review time', () => {
+    const next = reviewOnce(undefined, Rating.Good, nowMs);
+
+    expect(next.reps).toBe(1);
+    expect(next.last_review).toBe(nowMs);
+    expect(next.due).toBeGreaterThan(nowMs);
+    expect(Number.isFinite(next.stability)).toBe(true);
+    expect(Number.isFinite(next.difficulty)).toBe(true);
+  });
+
+  it('does not mutate an existing review state', () => {
+    const current: ReviewState = {
+      due: nowMs,
+      stability: 3,
+      difficulty: 5,
+      scheduled_days: 3,
+      learning_steps: 0,
+      reps: 4,
+      lapses: 1,
+      state: State.Review,
+      last_review: nowMs - 3 * 86_400_000,
+    };
+    const snapshot = structuredClone(current);
+
+    const next = reviewOnce(current, Rating.Easy, nowMs);
+
+    expect(current).toEqual(snapshot);
+    expect(next.last_review).toBe(nowMs);
+    expect(next.reps).toBeGreaterThan(current.reps);
+    expect(next.due).toBeGreaterThan(nowMs);
+  });
+});
+
+describe('retrievabilityNow', () => {
+  it('returns a bounded value for a scheduled card', () => {
+    const review = reviewOnce(undefined, Rating.Good, nowMs);
+    const retrievability = retrievabilityNow(review, nowMs);
+
+    expect(retrievability).toBeGreaterThanOrEqual(0);
+    expect(retrievability).toBeLessThanOrEqual(1);
+  });
+});

--- a/app/lib/fsrs-adapter.ts
+++ b/app/lib/fsrs-adapter.ts
@@ -4,98 +4,72 @@ import {
   Rating,
   State,
   type Card,
-  type RecordLogItem,
   type FSRS,
   generatorParameters,
 } from "ts-fsrs";
 import type { ReviewState } from "./review-types";
 
+type ReviewRating = Rating.Again | Rating.Hard | Rating.Good | Rating.Easy;
 
-export const F: FSRS = fsrs(generatorParameters({
-  request_retention: 0.9,
-  maximum_interval: 36500,
-  w: [0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61],
-  enable_fuzz: false,
-  enable_short_term: true,
-}));
+export const F: FSRS = fsrs(
+  generatorParameters({
+    request_retention: 0.9,
+    maximum_interval: 36500,
+    w: [0.4, 0.6, 2.4, 5.8, 4.93, 0.94, 0.86, 0.01, 1.49, 0.14, 0.94, 2.18, 0.05, 0.34, 1.26, 0.29, 2.61],
+    enable_fuzz: false,
+    enable_short_term: true,
+  }),
+);
 
-// Convert ReviewState to Card
-function toCard(r: ReviewState | undefined, nowMs: number): Card {
-  // For new or undefined cards, create an empty card
-  if (!r || (r.state === State.New && r.reps === 0)) {
+function toCard(review: ReviewState | undefined, nowMs: number): Card {
+  if (!review || (review.state === State.New && review.reps === 0)) {
     const emptyCard = createEmptyCard(new Date(nowMs));
-    // IMPORTANT: Set the due date to now for new cards
     emptyCard.due = new Date(nowMs);
     return emptyCard;
   }
-  
-  // Convert existing state
+
   return {
-    state: r.state,
-    due: new Date(r.due),
-    last_review: r.last_review ? new Date(r.last_review) : null,
-    stability: r.stability,
-    difficulty: r.difficulty,
-    scheduled_days: r.scheduled_days,
-    learning_steps: r.learning_steps ?? 0,
-    reps: r.reps,
-    lapses: r.lapses,
+    state: review.state,
+    due: new Date(review.due),
+    last_review: review.last_review ? new Date(review.last_review) : null,
+    stability: review.stability,
+    difficulty: review.difficulty,
+    scheduled_days: review.scheduled_days,
+    learning_steps: review.learning_steps ?? 0,
+    reps: review.reps,
+    lapses: review.lapses,
   } as Card;
 }
 
-// Convert Card to ReviewState
-function fromCard(c: Card): ReviewState {
+function fromCard(card: Card): ReviewState {
   return {
-    state: c.state,
-    due: c.due.getTime(),
-    last_review: c.last_review ? c.last_review.getTime() : null,
-    stability: c.stability,
-    difficulty: c.difficulty,
-    scheduled_days: c.scheduled_days,
-    learning_steps: c.learning_steps,
-    reps: c.reps,
-    lapses: c.lapses,
+    state: card.state,
+    due: card.due.getTime(),
+    last_review: card.last_review ? card.last_review.getTime() : null,
+    stability: card.stability,
+    difficulty: card.difficulty,
+    scheduled_days: card.scheduled_days,
+    learning_steps: card.learning_steps,
+    reps: card.reps,
+    lapses: card.lapses,
   };
 }
 
-export function reviewOnce(r: ReviewState | undefined, rating: Rating, nowMs: number): ReviewState {
-  if (rating < 1 || rating > 4) {
+export function reviewOnce(review: ReviewState | undefined, rating: Rating, nowMs: number): ReviewState {
+  if (rating < Rating.Again || rating > Rating.Easy) {
     throw new Error(`Invalid rating: ${rating}`);
   }
-  
-  const card = toCard(r, nowMs);
-  
-  const reviewTime = new Date(nowMs);
-  
-  const schedulingCards = F.repeat(card, reviewTime);
-  const selected = schedulingCards[rating as Rating.Again | Rating.Hard | Rating.Good | Rating.Easy];
-  
+
+  const schedulingCards = F.repeat(toCard(review, nowMs), new Date(nowMs));
+  const selected = schedulingCards[rating as ReviewRating];
+
   if (!selected) {
     throw new Error(`No scheduling card for rating ${rating}`);
   }
-  
+
   return fromCard(selected.card);
 }
 
-// Get retrievability for sorting
-export function retrievabilityNow(r: ReviewState | undefined, nowMs: number): number {
-  const card = toCard(r, nowMs);
-  return F.get_retrievability(card, new Date(nowMs), false);
-}
-
-// Debug helper with more detail
-export function debugCard(r: ReviewState | undefined, label: string = ""): void {
-  if (!r) {
-    console.log(`${label} - No review state`);
-    return;
-  }
-  
-  const stateNames = ["New", "Learning", "Review", "Relearning"];
-  console.log(
-    `${label} - State: ${stateNames[r.state]} (${r.state}), ` +
-    `Reps: ${r.reps}, Lapses: ${r.lapses}, ` +
-    `Due: ${new Date(r.due).toLocaleString()}, ` +
-    `Stability: ${r.stability?.toFixed(2)}, ` +
-    `Difficulty: ${r.difficulty?.toFixed(2)} `
-  );
+export function retrievabilityNow(review: ReviewState | undefined, nowMs: number): number {
+  return F.get_retrievability(toCard(review, nowMs), new Date(nowMs), false);
 }

--- a/app/lib/review-overrides.test.ts
+++ b/app/lib/review-overrides.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { State } from 'ts-fsrs';
+import type { ReviewState } from './review-types';
+import { rollbackFailedReview } from './review-overrides';
+
+function review(due: number, reps: number): ReviewState {
+  return {
+    due,
+    stability: 1,
+    difficulty: 5,
+    scheduled_days: 1,
+    learning_steps: 0,
+    reps,
+    lapses: 0,
+    state: State.Review,
+    last_review: due - 1000,
+  };
+}
+
+describe('rollbackFailedReview', () => {
+  it('removes a failed optimistic override when no earlier override existed', () => {
+    const failed = review(2000, 1);
+    expect(rollbackFailedReview({ item: failed }, 'item', failed, undefined)).toEqual({});
+  });
+
+  it('restores the previous override after a failed save', () => {
+    const previous = review(1000, 1);
+    const failed = review(2000, 2);
+    expect(rollbackFailedReview({ item: failed }, 'item', failed, previous)).toEqual({ item: previous });
+  });
+
+  it('does not overwrite a newer optimistic review', () => {
+    const previous = review(1000, 1);
+    const failed = review(2000, 2);
+    const newer = review(3000, 3);
+    const overrides = { item: newer };
+
+    expect(rollbackFailedReview(overrides, 'item', failed, previous)).toBe(overrides);
+  });
+});

--- a/app/lib/review-overrides.ts
+++ b/app/lib/review-overrides.ts
@@ -1,0 +1,22 @@
+import type { ReviewState } from './review-types';
+
+export type ReviewOverrides = Record<string, ReviewState>;
+
+export function rollbackFailedReview(
+  overrides: ReviewOverrides,
+  itemId: string,
+  failedReview: ReviewState,
+  previousOverride: ReviewState | undefined,
+): ReviewOverrides {
+  if (overrides[itemId] !== failedReview) {
+    return overrides;
+  }
+
+  if (previousOverride) {
+    return { ...overrides, [itemId]: previousOverride };
+  }
+
+  const next = { ...overrides };
+  delete next[itemId];
+  return next;
+}

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -6,10 +6,11 @@ import { parseQuery } from '@/app/lib/searchlang';
 import { searchItems } from '@/app/lib/item-search';
 import type { Item } from '@/app/lib/item-types';
 import type { ReviewState } from '@/app/lib/review-types';
+import { rollbackFailedReview } from '@/app/lib/review-overrides';
 import { ResultsClient } from './space-results-client';
 import { Rating } from 'ts-fsrs';
 import { useNow } from '@/app/lib/hooks/useNow';
-import { reviewOnce, debugCard } from '@/app/lib/fsrs-adapter';
+import { reviewOnce } from '@/app/lib/fsrs-adapter';
 import { useItems } from '@/app/lib/contexts/item-context';
 import { createClient } from '@/utils/supabase/client';
 import { SpaceHeader } from './space-header';
@@ -40,6 +41,7 @@ export function SpaceView() {
 
   const query = useMemo(() => parseQuery(tagsParam), [tagsParam]);
   const [mutations, setMutations] = useState<Record<string, ReviewState>>({});
+  const [mutationError, setMutationError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
 
   const [previousTagsParam, setPreviousTagsParam] = useState(tagsParam);
@@ -138,10 +140,11 @@ export function SpaceView() {
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      const current = mutations[id] ?? allItems.find((item) => item.id === id)?.review;
-      debugCard(current, 'BEFORE');
+      const previousOverride = mutations[id];
+      const current = previousOverride ?? allItems.find((item) => item.id === id)?.review;
       const next = reviewOnce(current, rating, nowMs);
-      debugCard(next, 'AFTER');
+
+      setMutationError(null);
       setMutations((previous) => ({ ...previous, [id]: next }));
 
       const { error: reviewError } = await supabase.from('reviews').upsert({
@@ -159,7 +162,11 @@ export function SpaceView() {
         suspended: next.suspended || false,
       });
 
-      if (reviewError) console.error('Failed to save review:', reviewError);
+      if (reviewError) {
+        console.error('Failed to save review:', reviewError);
+        setMutations((previous) => rollbackFailedReview(previous, id, next, previousOverride));
+        setMutationError("That review wasn't saved. The previous schedule has been restored.");
+      }
     },
     [allItems, mutations, nowMs, supabase],
   );
@@ -200,10 +207,25 @@ export function SpaceView() {
           </section>
 
           {error ? (
-            <div className="material-paper relative mb-4 flex items-center justify-between gap-3 overflow-hidden rounded-xl border px-4 py-3 text-sm" role="alert">
+            <div
+              className="material-paper relative mb-4 flex items-center justify-between gap-3 overflow-hidden rounded-xl border px-4 py-3 text-sm"
+              role="alert"
+            >
               <span className="min-w-0">{error}</span>
               <Button variant="outline" size="sm" className="shrink-0 rounded-lg" onClick={() => void reload()}>
                 Try again
+              </Button>
+            </div>
+          ) : null}
+
+          {mutationError ? (
+            <div
+              className="material-paper relative mb-4 flex items-center justify-between gap-3 overflow-hidden rounded-xl border px-4 py-3 text-sm"
+              role="alert"
+            >
+              <span className="min-w-0">{mutationError}</span>
+              <Button variant="outline" size="sm" className="shrink-0 rounded-lg" onClick={() => setMutationError(null)}>
+                Dismiss
               </Button>
             </div>
           ) : null}
@@ -244,7 +266,13 @@ export function SpaceView() {
 
           {hasMore ? (
             <div className="mt-4 flex justify-center">
-              <Button variant="outline" size="sm" className="rounded-lg" disabled={loadingMore} onClick={() => void loadMore()}>
+              <Button
+                variant="outline"
+                size="sm"
+                className="rounded-lg"
+                disabled={loadingMore}
+                onClick={() => void loadMore()}
+              >
                 {loadingMore ? 'Opening drawer…' : 'Open more clippings'}
               </Button>
             </div>


### PR DESCRIPTION
## Problem

Space applied FSRS review results optimistically, then only logged a Supabase upsert failure. A failed write therefore remained visible as if it had been saved. The review path also logged full scheduling state before and after every review through an exported debug helper.

A naive rollback would introduce a second bug: an earlier failed request could overwrite a newer optimistic review for the same item.

## Change

- remove the exported `debugCard` helper and per-review console diagnostics;
- add `rollbackFailedReview`, which restores an earlier override only when the failed review object is still the active override;
- remove the failed override entirely when the item previously relied on its server-loaded review;
- show a bounded dismissible error when persistence fails;
- keep developer error logging for the actual Supabase failure;
- validate FSRS ratings at the adapter boundary and explicitly narrow the scheduling-card index;
- add deterministic tests for invalid ratings, new/existing card scheduling, input immutability, retrievability bounds, basic rollback, previous-override restoration, and newer-review protection.

## Concurrency boundary

Rollback uses object identity intentionally. If another review has already replaced the failed optimistic state, the older failure returns the current overrides unchanged.

## Exact candidate

- base: `main` at `4c6fc4b5b6537b617ec51be1aba897d07a82d6b4`;
- head: `fix/space-review-rollback` at `8e6c7a17f711b509ba0d9b48a6c838844754ece0`;
- the branch was replayed cleanly after #512 merged.

## Validation requested

- lint;
- typecheck;
- unit tests;
- production build;
- Chromium and WebKit regressions;
- existing Space review/enrollment UI remains available;
- failed review feedback is exposed through an accessible alert.