### PR TITLE
Refine stale refresh and activity selection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,9 +5,9 @@ import { getGitHubHomeData } from '@/lib/github-home';
 import { ArrowRight, ArrowUpRight, Brain, Images, Palette, Snowflake } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { connection } from 'next/server';
-import { Suspense } from 'react';
 import styles from './page.module.css';
+
+export const revalidate = 30;
 
 export const metadata: Metadata = {
   title: 'Leo · GitHub activity',
@@ -26,36 +26,7 @@ const scrapbookDestinations = [
   { id: 'snow-globe', href: '/snow-globe', label: 'Snow globe', icon: Snowflake },
 ] as const;
 
-function HomeActivityFallback() {
-  return (
-    <div
-      className="flex min-w-0 flex-col gap-4 sm:gap-5"
-      aria-label="Loading GitHub activity"
-      data-home-activity-loading
-    >
-      <div
-        className="grid min-w-0 items-stretch gap-3.5 sm:gap-4"
-        style={{
-          gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 24rem), 1fr))',
-        }}
-      >
-        <div className="min-h-[15.5rem] rounded-[1.25rem] border border-border/70 bg-card shadow-[0_16px_38px_rgba(24,24,26,0.08)] [@media(max-height:780px)]:min-h-[14.5rem]" />
-        <div className="min-h-[15.5rem] rounded-[1.25rem] border border-border/70 bg-card shadow-[0_16px_38px_rgba(24,24,26,0.08)] [@media(max-height:780px)]:min-h-[14.5rem]" />
-      </div>
-      <div className="grid grid-cols-1 gap-2.5 md:grid-cols-3" aria-hidden="true">
-        {Array.from({ length: 3 }, (_, index) => (
-          <div
-            key={index}
-            className="min-h-28 rounded-[1.1rem] border border-border/65 bg-card/75"
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
 async function HomeActivityContent() {
-  await connection();
   const activity = await getGitHubHomeData();
   const initialActivity =
     activity.source === 'unavailable'
@@ -165,7 +136,9 @@ async function HomeActivityContent() {
   );
 }
 
-export default function Page() {
+export default async function Page() {
+  const homeActivity = await HomeActivityContent();
+
   return (
     <ViewportPageShell
       className="relative bg-background text-foreground"
@@ -178,9 +151,7 @@ export default function Page() {
       />
 
       <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-start px-4 py-4 sm:px-6 sm:py-5 lg:px-8 lg:py-6">
-        <Suspense fallback={<HomeActivityFallback />}>
-          <HomeActivityContent />
-        </Suspense>
+        {homeActivity}
       </div>
     </ViewportPageShell>
   );

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -38,6 +38,21 @@ function timestampOrNow(value: string) {
   return Number.isFinite(timestamp) ? timestamp : Date.now();
 }
 
+function latestRecordedDate(activity: ActivitySnapshot) {
+  return activity.source === 'unavailable' ? '' : (activity.days.at(-1)?.date ?? '');
+}
+
+function formatScoreDate(date: string, current: boolean) {
+  const parsed = new Date(`${date}T00:00:00Z`);
+  const formatted = new Intl.DateTimeFormat('en-US', {
+    weekday: current ? undefined : 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(parsed);
+  return current ? `Today · ${formatted}` : formatted;
+}
+
 function UnavailableActivity() {
   return (
     <section
@@ -55,7 +70,7 @@ function UnavailableActivity() {
         Activity is temporarily unavailable
       </h2>
       <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
-        The page will retry while it remains open. Contribution totals and calendar cells appear only after GitHub supplies a valid snapshot.
+        The page will retry while it remains open. Contribution totals and calendar cells appear after GitHub supplies a valid snapshot.
       </p>
     </section>
   );
@@ -63,14 +78,18 @@ function UnavailableActivity() {
 
 export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
   const initialSnapshotAt = timestampOrNow(initial.generatedAt);
+  const initialLatestDate = latestRecordedDate(initial);
   const [activity, setActivity] = useState<ActivitySnapshot>(initial);
   const [updating, setUpdating] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(initialLatestDate);
+  const [previewDate, setPreviewDate] = useState<string | null>(null);
   const inFlight = useRef<AbortController | null>(null);
   const newestSnapshotAt = useRef(initial.source === 'unavailable' ? 0 : initialSnapshotAt);
   const nextAllowedAt = useRef(
     initial.source === 'unavailable' ? 0 : initialSnapshotAt + REFRESH_INTERVAL_MS,
   );
   const consecutiveFailures = useRef(0);
+  const previousLatestDate = useRef(initialLatestDate);
 
   useEffect(() => {
     let mounted = true;
@@ -161,6 +180,28 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
     };
   }, []);
 
+  useEffect(() => {
+    const latestDate = latestRecordedDate(activity);
+    setPreviewDate(null);
+    setSelectedDate((current) => {
+      if (!latestDate || activity.source === 'unavailable') return '';
+      const currentStillExists = activity.days.some((day) => day.date === current);
+      if (!current || current === previousLatestDate.current || !currentStillExists) {
+        return latestDate;
+      }
+      return current;
+    });
+    previousLatestDate.current = latestDate;
+  }, [activity]);
+
+  const latestDate = latestRecordedDate(activity);
+  const displayDate = previewDate ?? selectedDate ?? latestDate;
+  const displayDay =
+    activity.source === 'unavailable'
+      ? undefined
+      : (activity.days.find((day) => day.date === displayDate) ?? activity.days.at(-1));
+  const displayIsToday = Boolean(displayDay && displayDay.date === latestDate);
+
   return (
     <div
       className="relative grid min-w-0 items-stretch gap-3.5 sm:gap-4"
@@ -174,12 +215,16 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
         {updating ? 'Updating GitHub activity' : ''}
       </span>
 
-      {activity.source === 'unavailable' ? (
+      {activity.source === 'unavailable' || !displayDay ? (
         <UnavailableActivity />
       ) : (
         <>
           <ActivityScoreboard
-            today={activity.today}
+            score={displayDay.count}
+            scoreDate={displayDay.date}
+            scoreLabel={formatScoreDate(displayDay.date, displayIsToday)}
+            scoreIsToday={displayIsToday}
+            todayActivity={activity.today}
             weekTotal={activity.weekTotal}
             yearTotal={activity.yearTotal}
             updating={updating}
@@ -188,6 +233,9 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
             days={activity.days}
             unit={activity.unit}
             generatedAt={activity.generatedAt}
+            selectedDate={selectedDate}
+            onSelectedDateChange={setSelectedDate}
+            onPreviewDateChange={setPreviewDate}
           />
         </>
       )}

--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -71,12 +71,16 @@ export function ActivityGrid({
   days,
   unit,
   generatedAt,
-  unavailableMessage = 'GitHub activity is temporarily unavailable.',
+  selectedDate,
+  onSelectedDateChange,
+  onPreviewDateChange,
 }: {
   days: ActivityGridDay[];
   unit: string;
   generatedAt: string;
-  unavailableMessage?: string;
+  selectedDate: string;
+  onSelectedDateChange: (date: string) => void;
+  onPreviewDateChange: (date: string | null) => void;
 }) {
   const calendarDate = useMemo(() => referenceDate(generatedAt), [generatedAt]);
   const today = dateKeyInTimeZone(calendarDate);
@@ -89,6 +93,13 @@ export function ActivityGrid({
     [cells],
   );
   const maximum = Math.max(...recordedDays.map((day) => day.count), 0);
+  const [tooltipDate, setTooltipDate] = useState<string | null>(null);
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const [finePointer, setFinePointer] = useState(false);
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const hideTimer = useRef<number | null>(null);
+  const positionFrame = useRef<number | null>(null);
+  const pendingPosition = useRef({ x: 12, y: 12 });
   const weekLabels = useMemo(
     () =>
       Array.from({ length: WEEK_COUNT }, (_, index) =>
@@ -96,16 +107,8 @@ export function ActivityGrid({
       ),
     [cells],
   );
-  const latestRecordedDate = recordedDays.at(-1)?.date ?? '';
-  const [selectedDate, setSelectedDate] = useState(latestRecordedDate);
-  const [tooltipDate, setTooltipDate] = useState<string | null>(null);
-  const [tooltipVisible, setTooltipVisible] = useState(false);
-  const [finePointer, setFinePointer] = useState(false);
-  const previousLatest = useRef(latestRecordedDate);
-  const sectionRef = useRef<HTMLElement | null>(null);
-  const hideTimer = useRef<number | null>(null);
-  const positionFrame = useRef<number | null>(null);
-  const pendingPosition = useRef({ x: 12, y: 12 });
+  const tooltipDay = recordedDays.find((day) => day.date === tooltipDate);
+  const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
 
   useEffect(() => {
     const media = window.matchMedia('(hover: hover) and (pointer: fine)');
@@ -121,28 +124,6 @@ export function ActivityGrid({
       if (positionFrame.current !== null) window.cancelAnimationFrame(positionFrame.current);
     };
   }, []);
-
-  useEffect(() => {
-    setSelectedDate((current) => {
-      if (
-        !current ||
-        current === previousLatest.current ||
-        !recordedDays.some((day) => day.date === current)
-      ) {
-        return latestRecordedDate;
-      }
-      return current;
-    });
-    previousLatest.current = latestRecordedDate;
-  }, [latestRecordedDate, recordedDays]);
-
-  const selected = recordedDays.find((day) => day.date === selectedDate);
-  const tooltipDay = recordedDays.find((day) => day.date === tooltipDate);
-  const selectedLabel = useMemo(
-    () => (selected ? labelForDay(selected, unit) : unavailableMessage),
-    [selected, unit, unavailableMessage],
-  );
-  const tooltipLabel = tooltipDay ? labelForDay(tooltipDay, unit) : '';
 
   const placeTooltip = (clientX: number, clientY: number) => {
     pendingPosition.current = {
@@ -185,7 +166,7 @@ export function ActivityGrid({
     >
       <div className="flex items-center justify-between gap-4">
         <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          4 weeks · UTC
+          4 weeks · pick a day
         </span>
         <div
           className="flex items-center gap-1.5 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground"
@@ -276,45 +257,49 @@ export function ActivityGrid({
 
             const day = cell.day;
             const label = labelForDay(day, unit);
-            const isSelected = day.date === selected?.date;
+            const isSelected = day.date === selectedDate;
             const isToday = day.date === today;
 
             return (
               <button
                 key={day.date}
                 type="button"
-                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isToday ? 'outline outline-2 outline-offset-2 outline-foreground/20' : ''} ${isSelected ? 'brightness-[1.04] dark:brightness-110' : ''}`}
+                className={`${styles.paperMark} aspect-square min-w-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${activityClass(day.count, maximum)} ${isToday ? 'outline outline-1 outline-offset-2 outline-foreground/15' : ''} ${isSelected ? 'outline outline-2 outline-offset-2 outline-foreground/45 brightness-[1.04] dark:brightness-110' : ''}`}
                 style={sharedStyle}
                 aria-label={label}
                 aria-pressed={isSelected}
+                aria-controls="github-activity-scoreboard"
                 data-contribution-cell
                 data-contribution-date={day.date}
                 data-contribution-state="recorded"
+                data-contribution-selected={isSelected ? 'true' : 'false'}
                 data-paper-activity-mark
-                onPointerEnter={(event) => showTooltip(day.date, event.clientX, event.clientY)}
+                onPointerEnter={(event) => {
+                  onPreviewDateChange(day.date);
+                  showTooltip(day.date, event.clientX, event.clientY);
+                }}
                 onPointerMove={(event) => {
                   if (finePointer) placeTooltip(event.clientX, event.clientY);
                 }}
-                onPointerLeave={hideTooltip}
+                onPointerLeave={() => {
+                  onPreviewDateChange(null);
+                  hideTooltip();
+                }}
                 onFocus={(event) => {
-                  setSelectedDate(day.date);
+                  onPreviewDateChange(day.date);
                   if (!event.currentTarget.matches(':focus-visible')) return;
                   const rect = event.currentTarget.getBoundingClientRect();
                   showTooltip(day.date, rect.left + rect.width / 2, rect.bottom);
                 }}
-                onBlur={hideTooltip}
-                onClick={() => setSelectedDate(day.date)}
+                onBlur={() => {
+                  onPreviewDateChange(null);
+                  hideTooltip();
+                }}
+                onClick={() => onSelectedDateChange(day.date)}
               />
             );
           })}
         </div>
-      </div>
-
-      <div
-        className="mt-2 flex min-h-8 items-center justify-center rounded-lg border border-border/70 bg-background/55 px-3 py-1.5 text-center font-mono text-[10px] font-medium text-muted-foreground md:hidden"
-        aria-live="polite"
-      >
-        {selectedLabel}
       </div>
 
       {finePointer && tooltipLabel ? (

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -172,7 +172,7 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
   );
 }
 
-function ScoreDigits({ value }: { value: number }) {
+function ScoreDigits({ value, label }: { value: number; label: string }) {
   const digits = useMemo(
     () => String(Math.max(0, Math.floor(value))).slice(-4).padStart(4, '0').split(''),
     [value],
@@ -214,16 +214,12 @@ function ScoreDigits({ value }: { value: number }) {
     <div
       ref={scope}
       className={`${styles.counter} flex min-w-0 gap-1.5 sm:gap-2`}
-      aria-label={`${value} contributions today`}
+      aria-label={`${value} contributions on ${label}`}
       data-paper-counter
       data-reduced-motion={reduceMotion ? 'true' : 'false'}
       data-wind-scoreboard
     >
-      <span
-        aria-hidden="true"
-        className={styles.counterShadow}
-        data-paper-counter-shadow
-      />
+      <span aria-hidden="true" className={styles.counterShadow} data-paper-counter-shadow />
       {digits.map((digit, index) => (
         <div
           key={index}
@@ -255,12 +251,20 @@ function Metric({ label, value, title }: { label: string; value: string; title?:
 }
 
 export function ActivityScoreboard({
-  today,
+  score,
+  scoreDate,
+  scoreLabel,
+  scoreIsToday,
+  todayActivity,
   weekTotal,
   yearTotal,
   updating,
 }: {
-  today: number;
+  score: number;
+  scoreDate: string;
+  scoreLabel: string;
+  scoreIsToday: boolean;
+  todayActivity: number;
   weekTotal: number;
   yearTotal: number | null;
   updating: boolean;
@@ -325,6 +329,7 @@ export function ActivityScoreboard({
 
   return (
     <motion.section
+      id="github-activity-scoreboard"
       initial={false}
       whileHover={
         reduceMotion
@@ -343,6 +348,7 @@ export function ActivityScoreboard({
       onPointerCancel={settlePaperLight}
       className={`${styles.scorecard} group relative flex h-full min-h-[15.5rem] flex-col overflow-hidden rounded-[1.25rem] border border-border/75 bg-card text-card-foreground shadow-[0_16px_38px_rgba(24,24,26,0.11)] transition-[border-color,box-shadow] duration-300 hover:border-border hover:shadow-[0_24px_52px_rgba(24,24,26,0.17)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.3)] dark:hover:shadow-[0_26px_58px_rgba(0,0,0,0.42)] [@media(max-height:780px)]:min-h-[14.5rem]`}
       data-activity-scoreboard
+      data-activity-score-date={scoreDate}
       data-paper-light-motion={reduceMotion ? 'reduced' : 'full'}
     >
       <motion.span
@@ -375,13 +381,17 @@ export function ActivityScoreboard({
 
       <div className="relative z-10 border-b border-border/70 bg-muted/70 px-4 py-2.5 transition-colors duration-300 group-hover:bg-muted/85 [@media(max-height:780px)]:py-2">
         <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
-          <span>Today</span>
-          <span className="tabular-nums">UTC reset {countdown}</span>
+          <span className="truncate" aria-live="polite">
+            {scoreLabel}
+          </span>
+          <span className="shrink-0 tabular-nums">
+            {scoreIsToday ? `UTC reset ${countdown}` : 'UTC total'}
+          </span>
         </div>
       </div>
 
       <div className="relative z-10 grid flex-1 grid-cols-[minmax(0,1fr)_minmax(5.75rem,0.36fr)] items-center gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_minmax(6.75rem,0.34fr)] sm:gap-4 sm:p-5 [@media(max-height:780px)]:gap-2.5 [@media(max-height:780px)]:p-3.5">
-        <ScoreDigits value={today} />
+        <ScoreDigits value={score} label={scoreLabel} />
         <div className="grid content-center gap-2">
           <Metric label="7D" value={weekTotal.toLocaleString('en-GB')} />
           <Metric
@@ -389,7 +399,7 @@ export function ActivityScoreboard({
             value={yearTotal?.toLocaleString('en-GB') ?? '—'}
             title="Rolling-year total reported by GitHub's contribution calendar"
           />
-          <ScrapbookPet activity={today} updating={updating} />
+          <ScrapbookPet activity={todayActivity} updating={updating} />
         </div>
       </div>
     </motion.section>

--- a/components/proxy/proxy-live-refresh.tsx
+++ b/components/proxy/proxy-live-refresh.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useTransition } from 'react';
 
 const REFRESH_INTERVAL_MS = 60_000;
+const INITIAL_REFRESH_DELAY_MS = 2_500;
 
 export function ProxyLiveRefresh() {
   const router = useRouter();
@@ -15,6 +16,7 @@ export function ProxyLiveRefresh() {
       startTransition(() => router.refresh());
     };
 
+    const initialRefresh = window.setTimeout(refresh, INITIAL_REFRESH_DELAY_MS);
     const interval = window.setInterval(refresh, REFRESH_INTERVAL_MS);
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible') refresh();
@@ -22,6 +24,7 @@ export function ProxyLiveRefresh() {
 
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => {
+      window.clearTimeout(initialRefresh);
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };

--- a/components/proxy/usage-dashboard-container.tsx
+++ b/components/proxy/usage-dashboard-container.tsx
@@ -1,6 +1,7 @@
 import type { ProxyHealthPayload, ProxyHealthSample } from '@/app/lib/proxy-health-store';
 import { readProxyHealth } from '@/app/lib/proxy-health-store';
 import { unstable_cache } from 'next/cache';
+import { connection } from 'next/server';
 import { UsageDashboard } from './usage-dashboard';
 
 const readCachedProxyHealth = unstable_cache(
@@ -48,6 +49,7 @@ function StateCard({ title, body, requestId }: { title: string; body: string; re
 }
 
 export async function UsageDashboardContainer() {
+  await connection();
   const result = await readCachedProxyHealth();
 
   if (result.status === 'configuration-error') {

--- a/components/proxy/usage-dashboard-container.tsx
+++ b/components/proxy/usage-dashboard-container.tsx
@@ -1,8 +1,13 @@
-import { connection } from 'next/server';
-
 import type { ProxyHealthPayload, ProxyHealthSample } from '@/app/lib/proxy-health-store';
 import { readProxyHealth } from '@/app/lib/proxy-health-store';
+import { unstable_cache } from 'next/cache';
 import { UsageDashboard } from './usage-dashboard';
+
+const readCachedProxyHealth = unstable_cache(
+  () => readProxyHealth('bandwagon-la', 35),
+  ['proxy-dashboard-bandwagon-la-v2'],
+  { revalidate: 60 },
+);
 
 function usageLimitBytes() {
   const gb = Number(process.env.PROXY_USAGE_30D_LIMIT_GB ?? '1024');
@@ -35,26 +40,39 @@ function StateCard({ title, body, requestId }: { title: string; body: string; re
     <section className="rounded-2xl border bg-background p-5 shadow-sm" role="status">
       <h2 className="text-xl font-bold">{title}</h2>
       <p className="mt-2 text-sm text-muted-foreground">{body}</p>
-      {requestId ? <p className="mt-3 font-mono text-xs text-muted-foreground">Request {requestId}</p> : null}
+      {requestId ? (
+        <p className="mt-3 font-mono text-xs text-muted-foreground">Request {requestId}</p>
+      ) : null}
     </section>
   );
 }
 
 export async function UsageDashboardContainer() {
-  await connection();
-
-  const result = await readProxyHealth('bandwagon-la', 35);
+  const result = await readCachedProxyHealth();
 
   if (result.status === 'configuration-error') {
-    return <StateCard title="Proxy configuration missing" body={result.message} requestId={result.requestId} />;
+    return (
+      <StateCard
+        title="Proxy configuration missing"
+        body={result.message}
+        requestId={result.requestId}
+      />
+    );
   }
 
   if (result.status === 'error') {
-    return <StateCard title="Proxy data unavailable" body={result.message} requestId={result.requestId} />;
+    return (
+      <StateCard title="Proxy data unavailable" body={result.message} requestId={result.requestId} />
+    );
   }
 
   if (result.status === 'empty') {
-    return <StateCard title="No report has arrived" body="The database connection succeeded, but this host has no stored report yet." />;
+    return (
+      <StateCard
+        title="No report has arrived"
+        body="The database connection succeeded, but this host has no stored report yet."
+      />
+    );
   }
 
   const { report, samples } = result;

--- a/components/proxy/usage-page.tsx
+++ b/components/proxy/usage-page.tsx
@@ -1,10 +1,8 @@
 import ViewportPageShell from '@/components/viewport-page-shell';
-import { Suspense } from 'react';
 import { ProxyLiveRefresh } from './proxy-live-refresh';
 import { UsageDashboardContainer } from './usage-dashboard-container';
-import { UsageDashboardSkeleton } from './usage-dashboard-skeleton';
 
-export function UsagePage() {
+export async function UsagePage() {
   return (
     <ViewportPageShell
       className="bg-[#dfdbd2] text-[#1b1b1f] dark:bg-[#15171b] dark:text-[#f1ede5]"
@@ -20,9 +18,7 @@ export function UsagePage() {
             <h1 className="mt-0.5 text-xl font-bold tracking-tight">Usage</h1>
           </div>
         </div>
-        <Suspense fallback={<UsageDashboardSkeleton />}>
-          <UsageDashboardContainer />
-        </Suspense>
+        <UsageDashboardContainer />
       </div>
     </ViewportPageShell>
   );

--- a/tests/e2e/activity-scoreboard-selection.spec.ts
+++ b/tests/e2e/activity-scoreboard-selection.spec.ts
@@ -8,13 +8,16 @@ test('the contribution calendar previews and locks days on the scoreboard', asyn
   const dashboard = page.locator('[data-home-activity-dashboard]:visible').last();
   const scoreboard = dashboard.locator('[data-activity-scoreboard]');
   const cells = dashboard.locator('[data-contribution-week-grid] button');
+  const previewCell = dashboard
+    .locator('[data-contribution-week-grid] button:not([data-contribution-selected="true"])')
+    .first();
 
   await expect(scoreboard).toBeVisible({ timeout: 15_000 });
   await expect(cells.first()).toBeVisible();
+  await expect(previewCell).toBeVisible();
   await expect(page.locator('[data-home-activity-loading]')).toHaveCount(0);
 
   const initialDate = await scoreboard.getAttribute('data-activity-score-date');
-  const previewCell = cells.filter({ hasNot: page.locator('[data-contribution-selected="true"]') }).first();
   const previewDate = await previewCell.getAttribute('data-contribution-date');
 
   expect(initialDate).toBeTruthy();

--- a/tests/e2e/activity-scoreboard-selection.spec.ts
+++ b/tests/e2e/activity-scoreboard-selection.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+test('the contribution calendar previews and locks days on the scoreboard', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const dashboard = page.locator('[data-home-activity-dashboard]:visible').last();
+  const scoreboard = dashboard.locator('[data-activity-scoreboard]');
+  const cells = dashboard.locator('[data-contribution-week-grid] button');
+
+  await expect(scoreboard).toBeVisible({ timeout: 15_000 });
+  await expect(cells.first()).toBeVisible();
+  await expect(page.locator('[data-home-activity-loading]')).toHaveCount(0);
+
+  const initialDate = await scoreboard.getAttribute('data-activity-score-date');
+  const previewCell = cells.filter({ hasNot: page.locator('[data-contribution-selected="true"]') }).first();
+  const previewDate = await previewCell.getAttribute('data-contribution-date');
+
+  expect(initialDate).toBeTruthy();
+  expect(previewDate).toBeTruthy();
+  expect(previewDate).not.toBe(initialDate);
+
+  await previewCell.hover();
+  await expect(scoreboard).toHaveAttribute('data-activity-score-date', previewDate!);
+
+  await page.mouse.move(8, 8);
+  await expect(scoreboard).toHaveAttribute('data-activity-score-date', initialDate!);
+
+  await previewCell.click();
+  await page.mouse.move(8, 8);
+  await expect(scoreboard).toHaveAttribute('data-activity-score-date', previewDate!);
+  await expect(previewCell).toHaveAttribute('aria-pressed', 'true');
+});


### PR DESCRIPTION
## What changed
- serve the homepage from a 30-second cached snapshot and refresh activity client-side without a loading-card placeholder
- cache proxy dashboard data while keeping the current dashboard visible during request-bound refreshes
- let contribution cells preview the animated scoreboard on hover and lock a day on click or tap
- keep the small desktop tooltip as a pointer aid while removing the separate mobile selection readout
- add an end-to-end test for scoreboard preview and selection persistence

## Intended behavior
The existing cached view remains visible. Fresh data replaces it once available, and the counter animation handles the change. The calendar and scoreboard now behave as one instrument.