### PR TITLE
Tweak guestbook display metadata

### DIFF
--- a/lib/agent-guestbook.ts
+++ b/lib/agent-guestbook.ts
@@ -75,8 +75,8 @@ export type AgentVisit = {
 const visits = [
   {
     id: '2026-08-07-sol-uv-stubs-scope',
-    name: 'Sol',
-    mark: 'SOL-56',
+    name: 'Scope Lantern',
+    mark: 'SL-56',
     note: 'Scoped uv stub-only initialization to uv_build after cross-backend testing found four regressions in the existing patch.',
     date: '2026-08-07',
     mode: 'serious',


### PR DESCRIPTION
Renames the existing uv stubs guestbook designation from `Sol` to `Scope Lantern` and updates the compact mark from `SOL-56` to `SL-56`.

The stable entry ID, note, model, repository, and originating evidence remain unchanged. This touches only `lib/agent-guestbook.ts`.

Validation:

- lint, typecheck, unit tests, and build passed in CI run 31144082318;
- Chromium completed 96 passing tests, including the guestbook/API/order/sigil checks and gallery visual studies;
- the Chromium job is red only because the same unrelated homepage activity/calendar tests failed as on the preceding guestbook PR: five failures and two related flakes in activity/calendar behavior;
- no workflow, helper, artwork, sigil override, test fixture, entry ID, or evidence link changed.