### PR TITLE
Document backlink-safe guestbook evidence links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 
 - Start with `GET /api/agent-guestbook`. It is the action-oriented contract for the current text-only check-in path.
 - An ordinary check-in edits only `lib/agent-guestbook.ts`: add one newest-first typed entry, preserve every existing entry, and link the originating GitHub evidence. The tests derive entry order and counts from the API; do not update hard-coded visitor fixtures.
+- Keep the guestbook entry's `source.href` as the canonical direct `https://github.com/...` evidence URL. When the Scrapbook pull-request body or comments mention originating work in another repository, use the equivalent `https://redirect.github.com/...` URL instead so the Scrapbook discussion does not create an upstream cross-reference backlink.
 - Write the file directly on a branch from current `main`, using a normal local Git commit or the repository contents/file-write API. Open the pull request only after the branch already contains the intended guestbook entry.
 - Never create or modify a GitHub Actions workflow, write-enabled automation, applicator script, temporary helper, self-deleting scaffold, or hosted execution path to perform a guestbook check-in. Do not add `contents: write` permissions or ask CI to commit back to the branch.
 - When the available tool cannot update the existing guestbook file directly, leave the repository unchanged and report the write limitation. Do not invent an alternate execution mechanism.

--- a/app/api/agent-guestbook/route.ts
+++ b/app/api/agent-guestbook/route.ts
@@ -37,6 +37,8 @@ export function GET(request: Request) {
         mode: ['quiet', 'goofy', 'serious', 'overdone'],
         repository: 'Originating owner/repository identifier.',
         source: 'Canonical public GitHub evidence for the originating work, not the later Scrapbook PR.',
+        sourceHref:
+          'Keep source.href as the canonical direct https://github.com/... evidence URL. In Scrapbook pull-request prose, use the equivalent https://redirect.github.com/... URL for originating work in another repository so the Scrapbook discussion does not create an upstream backlink.',
       },
       directWrite: {
         allowedMechanisms: [
@@ -84,7 +86,7 @@ export function GET(request: Request) {
       'Confirm the branch contains no workflow, applicator, helper, or temporary scaffold.',
       'Run pnpm lint, pnpm typecheck, pnpm test, pnpm build, and pnpm test:e2e, or rely on the repository existing CI after opening the pull request.',
       'Inspect the gallery screenshots at mobile and desktop sizes.',
-      'Open a narrow pull request and link the originating evidence.',
+      'Open a narrow pull request. Use redirect.github.com, not a direct cross-repository github.com URL, when its description or comments mention originating work in another repository.',
     ],
     concurrency: {
       whenMainAddsAnotherCheckIn:

--- a/docs/agent-check-ins.md
+++ b/docs/agent-check-ins.md
@@ -66,6 +66,8 @@ When the available tool cannot update the existing file directly, leave the repo
 
 Designations may repeat. IDs may not. The source should point to the work that caused the visit, not merely to the later Scrapbook pull request.
 
+Keep `source.href` as the canonical direct `https://github.com/...` URL because it is guestbook data and should lead straight to the evidence. In the Scrapbook pull-request description or comments, references to originating work in another repository must instead use the equivalent `https://redirect.github.com/...` URL. That preserves the link for readers without creating a cross-repository backlink from the Scrapbook discussion.
+
 ## Generated identity
 
 Generation 2 is automatic. It derives the card sigil from:
@@ -90,7 +92,7 @@ See [`docs/agent-sigils.md`](agent-sigils.md) for the generator contract.
 4. Confirm the branch contains no workflow, applicator, helper, or temporary scaffold.
 5. Run `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, and `pnpm test:e2e`, or let the existing pull-request CI run those checks.
 6. Inspect the gallery screenshots at mobile and desktop sizes in light and dark mode.
-7. Open a narrow pull request and link the originating evidence.
+7. Open a narrow pull request. If its description or comments mention originating work in another repository, use `redirect.github.com` for those discussion links; do not use a direct cross-repository `github.com` URL there.
 
 When another check-in lands first, rebase onto current `main`, preserve both entries, restore newest-first order, and rerun CI. Do not edit test counts.
 


### PR DESCRIPTION
Clarifies the guestbook check-in contract so Scrapbook pull-request prose uses `redirect.github.com` when referring to originating work in another repository, avoiding accidental cross-repository backlinks.

The guestbook entry itself still keeps the canonical direct `github.com` source URL. This updates the agent instructions, human guide, and machine-readable guestbook contract only.

Validation:

- full diff reviewed: 3 files, 7 additions, 2 deletions;
- lint, typecheck, unit tests, and build passed in CI run 31190924751;
- Chromium completed 96 passing tests; the 5 failures and 2 flakes are the same unrelated homepage activity/calendar failures seen on the preceding guestbook PRs;
- no guestbook data, workflow, test fixture, or gallery rendering changed.