### PR TITLE
Refine visual instruments and utilities

### DIFF
--- a/app/proxy-dashboard/page.tsx
+++ b/app/proxy-dashboard/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Signal · Leo',
-  description: 'A cached, read-only view of one small network path.',
+  description: 'Proxy bandwidth and latency dashboard.',
   alternates: { canonical: '/proxy-dashboard' },
   robots: { index: false, follow: false },
 };

--- a/app/snow-globe/page.tsx
+++ b/app/snow-globe/page.tsx
@@ -4,7 +4,8 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Snow globe · Leo',
-  description: 'A small dimensional winter scene with an automatic orbit and simulated snow.',
+  description:
+    'A dimensional winter reading room with an automatic turn and simulated snow.',
   alternates: { canonical: '/snow-globe' },
 };
 
@@ -14,10 +15,8 @@ export default function SnowGlobePage() {
       className="bg-background text-foreground"
       contentClassName="flex min-h-[calc(100dvh-3rem)] min-w-0 flex-col overflow-x-hidden"
     >
-      <div className="mx-auto flex min-h-0 w-full max-w-6xl flex-1 flex-col px-4 py-5 sm:px-6 sm:py-7 lg:px-8">
-        <header className="mb-4 sm:mb-6">
-          <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">Snow globe</h1>
-        </header>
+      <div className="mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col px-3 py-3 sm:px-5 sm:py-5 lg:px-7">
+        <h1 className="sr-only">Snow globe</h1>
         <SnowGlobe />
       </div>
     </ViewportPageShell>

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -55,7 +55,34 @@ type DigitTurn = {
   id: number;
   from: string;
   to: string;
+  target: string;
+  remaining: string[];
+  direction: DigitDirection;
+  step: number;
 };
+
+type DigitDirection = 1 | -1;
+
+function digitSequence(from: string, to: string, direction: DigitDirection) {
+  if (from === to) return [];
+
+  const sequence: string[] = [];
+  let current = Number(from);
+  const target = Number(to);
+  for (let step = 0; step < 9 && current !== target; step += 1) {
+    current = (current + direction + 10) % 10;
+    sequence.push(String(current));
+  }
+  return sequence;
+}
+
+function digitDirection(from: string, to: string): DigitDirection {
+  const start = Number(from);
+  const target = Number(to);
+  const forward = (target - start + 10) % 10;
+  const backward = (start - target + 10) % 10;
+  return forward <= backward ? 1 : -1;
+}
 
 function scoreDigits(value: number) {
   return String(Math.max(0, Math.floor(value)))
@@ -64,8 +91,15 @@ function scoreDigits(value: number) {
     .split('');
 }
 
-function PaperDigit({ digit, index }: { digit: string; index: number }) {
-  const reduceMotion = useReducedMotionPreference();
+function PaperDigit({
+  digit,
+  index,
+  reduceMotion,
+}: {
+  digit: string;
+  index: number;
+  reduceMotion: boolean;
+}) {
   const [displayed, setDisplayed] = useState(digit);
   const [turn, setTurn] = useState<DigitTurn | null>(null);
   const sequence = useRef(0);
@@ -81,19 +115,31 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
     }
 
     if (turn || digit === displayed) return;
+    const direction = digitDirection(displayed, digit);
+    const path = digitSequence(displayed, digit, direction);
+    const [next, ...remaining] = path;
+    if (!next) return;
     sequence.current += 1;
-    setTurn({ id: sequence.current, from: displayed, to: digit });
+    setTurn({
+      id: sequence.current,
+      from: displayed,
+      to: next,
+      target: digit,
+      remaining,
+      direction,
+      step: 0,
+    });
   }, [digit, displayed, reduceMotion, turn]);
 
-  // A selected day is an atomic snapshot, not an odometer count. Changed
-  // columns therefore turn together so the rack never implies intermediate
-  // contribution totals that did not exist.
-  const delay = 0.045;
+  const delay = turn?.step === 0 ? 0.018 + index * 0.014 : 0.012;
+  const turnDirection = turn?.direction ?? 1;
 
   return (
     <motion.span
       className={styles.digit}
       data-paper-digit
+      data-paper-digit-step={turn?.step}
+      data-paper-digit-remaining={turn?.remaining.length}
       initial={
         reduceMotion
           ? false
@@ -127,14 +173,14 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
             className={`${styles.sheet} ${styles.departing}`}
             initial={{ rotateX: 0, y: 0, opacity: 1 }}
             animate={{
-              rotateX: [0, -24, -103],
-              y: [0, -2, -12],
+              rotateX: [0, turnDirection * -28, turnDirection * -102],
+              y: [0, turnDirection * -1.5, turnDirection * -8],
               opacity: [1, 1, 0],
             }}
             transition={{
-              duration: 0.46,
+              duration: 0.15,
               delay,
-              times: [0, 0.42, 1],
+              times: [0, 0.45, 1],
               ease: [0.55, 0.06, 0.68, 0.19],
             }}
           >
@@ -145,34 +191,53 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
             key={`arrive-${turn.id}`}
             aria-hidden="true"
             className={`${styles.sheet} ${styles.arriving}`}
-            initial={{ rotateX: 88, y: '20%', opacity: 0.2, scale: 0.955 }}
+            initial={{
+              rotateX: turnDirection * 88,
+              y: `${turnDirection * 13}%`,
+              opacity: 0.25,
+              scale: 0.975,
+            }}
             animate={{
-              rotateX: [88, -9, 2, 0],
-              y: ['20%', '-2.5%', '0.7%', '0%'],
-              opacity: [0.2, 1, 1, 1],
-              scale: [0.955, 1.018, 0.997, 1],
+              rotateX: [turnDirection * 88, turnDirection * -7, 0],
+              y: [`${turnDirection * 13}%`, `${turnDirection * -1.5}%`, '0%'],
+              opacity: [0.25, 1, 1],
+              scale: [0.975, 1.008, 1],
             }}
             transition={{
-              duration: 0.62,
-              delay: delay + 0.16,
-              times: [0, 0.58, 0.82, 1],
+              duration: 0.2,
+              delay: delay + 0.07,
+              times: [0, 0.72, 1],
               ease: [0.22, 1, 0.36, 1],
             }}
             onAnimationComplete={() => {
               setDisplayed(turn.to);
-              setTurn(null);
+              if (digit !== turn.target || turn.remaining.length === 0) {
+                setTurn(null);
+                return;
+              }
+
+              const [next, ...remaining] = turn.remaining;
+              sequence.current += 1;
+              setTurn({
+                ...turn,
+                id: sequence.current,
+                from: turn.to,
+                to: next,
+                remaining,
+                step: turn.step + 1,
+              });
             }}
           >
             <motion.span
               className={styles.number}
-              initial={{ opacity: 0.35, scale: 1.12 }}
+              initial={{ opacity: 0.45, scale: 1.045 }}
               animate={{
                 opacity: 1,
-                scale: [1.12, 0.97, 1],
+                scale: [1.045, 0.985, 1],
               }}
               transition={{
-                duration: 0.34,
-                delay: delay + 0.34,
+                duration: 0.15,
+                delay: delay + 0.09,
                 times: [0, 0.7, 1],
                 ease: [0.16, 1, 0.3, 1],
               }}
@@ -186,12 +251,16 @@ function PaperDigit({ digit, index }: { digit: string; index: number }) {
   );
 }
 
-function ScoreDigits({ value, label }: { value: number; label: string }) {
-  const digits = useMemo(
-    () => scoreDigits(value),
-    [value]
-  );
-  const reduceMotion = useReducedMotionPreference();
+function ScoreDigits({
+  value,
+  label,
+  reduceMotion,
+}: {
+  value: number;
+  label: string;
+  reduceMotion: boolean;
+}) {
+  const digits = useMemo(() => scoreDigits(value), [value]);
   const previousValue = useRef(value);
   const [scope, animate] = useAnimate();
 
@@ -203,8 +272,8 @@ function ScoreDigits({ value, label }: { value: number; label: string }) {
       (total, digit, index) => total + Number(digit !== previousDigits[index]),
       0
     );
-    const direction = value > previous ? -1 : 1;
-    const travel = 1.1 + changedColumns * 0.42;
+    const rackDirection = value > previous ? -1 : 1;
+    const travel = 0.55 + changedColumns * 0.2;
     previousValue.current = value;
     if (reduceMotion || !scope.current) return;
 
@@ -212,20 +281,25 @@ function ScoreDigits({ value, label }: { value: number; label: string }) {
       animate(
         scope.current,
         {
-          y: [0, direction * travel, direction * -0.35, 0],
-          rotateZ: [0, direction * changedColumns * 0.07, direction * -0.08, 0],
+          y: [0, rackDirection * travel, rackDirection * -0.2, 0],
+          rotateZ: [
+            0,
+            rackDirection * changedColumns * 0.035,
+            rackDirection * -0.04,
+            0,
+          ],
         },
-        { duration: 0.72, times: [0, 0.32, 0.72, 1], ease: [0.2, 0.8, 0.2, 1] }
+        { duration: 0.38, times: [0, 0.3, 0.7, 1], ease: [0.2, 0.8, 0.2, 1] }
       ),
       animate(
         '[data-paper-counter-binding]',
         { scaleX: [1, 1.055, 0.985, 1] },
-        { duration: 0.68, ease: [0.2, 0.8, 0.2, 1] }
+        { duration: 0.36, ease: [0.2, 0.8, 0.2, 1] }
       ),
       animate(
         '[data-paper-counter-shadow]',
         { scaleX: [1, 1.025, 0.99, 1], y: [0, 1, -0.5, 0] },
-        { duration: 0.72, ease: [0.2, 0.8, 0.2, 1] }
+        { duration: 0.38, ease: [0.2, 0.8, 0.2, 1] }
       ),
     ];
 
@@ -252,7 +326,7 @@ function ScoreDigits({ value, label }: { value: number; label: string }) {
           data-activity-digit
           className={`${styles.digitSlot} relative aspect-[0.78] min-w-0 flex-1 font-mono text-[clamp(2rem,5vw,4.25rem)] font-semibold leading-none tabular-nums`}
         >
-          <PaperDigit digit={digit} index={index} />
+          <PaperDigit digit={digit} index={index} reduceMotion={reduceMotion} />
         </div>
       ))}
     </div>
@@ -327,9 +401,7 @@ export function ActivityScoreboard({
           <span className="truncate" aria-live="polite">
             {scoreLabel}
           </span>
-          <span className="shrink-0 tabular-nums">
-            UTC reset {countdown}
-          </span>
+          <span className="shrink-0 tabular-nums">UTC reset {countdown}</span>
         </div>
       </div>
 
@@ -339,7 +411,11 @@ export function ActivityScoreboard({
             <p className="mb-2 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
               Activity on the desk
             </p>
-            <ScoreDigits value={score} label={scoreLabel} />
+            <ScoreDigits
+              value={score}
+              label={scoreLabel}
+              reduceMotion={reduceMotion}
+            />
           </div>
           <div className="grid grid-cols-2 gap-2">
             <Metric label="7D" value={weekTotal.toLocaleString('en-GB')} />

--- a/components/paper-creature.tsx
+++ b/components/paper-creature.tsx
@@ -75,10 +75,11 @@ export function PaperCreature({
         aria-hidden="true"
       >
         <motion.path
-          d="M23 28 5 20l12 15 10-1Z"
+          d="M24 23 4 26l17 8 7-4Z"
           className="fill-[#b7adbf] stroke-[#4d4852] dark:fill-[#696270] dark:stroke-[#ded8e3]"
           strokeWidth="2"
           strokeLinejoin="round"
+          data-paper-creature-tail
           animate={
             reduceMotion
               ? undefined
@@ -99,6 +100,13 @@ export function PaperCreature({
           }
           style={{ transformOrigin: '24px 30px' }}
         />
+        <path
+          d="m7 26 15 3"
+          className="fill-none stroke-[#6b6470]/70 dark:stroke-[#c9c2d0]/70"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+          data-paper-creature-tail-fold
+        />
 
         <path
           d="M22 17h25c9 0 15 6 15 14v2H20v-6c0-4 1-7 2-10Z"
@@ -112,12 +120,20 @@ export function PaperCreature({
           strokeWidth="2"
           strokeLinejoin="round"
         />
-        <path
-          d="m29 17 4-8 5 8 5-8 4 8"
-          className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#eeeaf2] dark:stroke-[#eeeaf2]"
-          strokeWidth="2"
-          strokeLinejoin="round"
-        />
+        <g data-paper-creature-back-plates>
+          <path
+            d="m24 17 4.5-7 4.5 7Z"
+            className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#ded8e3] dark:stroke-[#eeeaf2]"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+          />
+          <path
+            d="m32 17 4.5-9.5 4.5 9.5Z"
+            className="fill-[#eee7f1] stroke-[#4d4852] dark:fill-[#c9c2d0] dark:stroke-[#eeeaf2]"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+          />
+        </g>
 
         {!sleeping ? (
           <path

--- a/components/proxy/usage-dashboard.tsx
+++ b/components/proxy/usage-dashboard.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import type { ProxyHealthPayload, ProxyHealthSample, StoredProxyHealth } from '@/app/lib/proxy-health-store';
+import type {
+  ProxyHealthPayload,
+  ProxyHealthSample,
+  StoredProxyHealth,
+} from '@/app/lib/proxy-health-store';
 import { getUsageWeekWindow } from '@/lib/proxy-usage-window';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
@@ -67,7 +71,9 @@ function formatBytes(value: number | null | undefined) {
 
 function formatMs(value: number | null | undefined) {
   if (!isFiniteNumber(value)) return '—';
-  return value > 0 && value < 10 ? `${value.toFixed(1)} ms` : `${Math.round(value)} ms`;
+  return value > 0 && value < 10
+    ? `${value.toFixed(1)} ms`
+    : `${Math.round(value)} ms`;
 }
 
 function formatPercent(value: number | null | undefined) {
@@ -93,7 +99,11 @@ function formatDate(value: string | null | undefined) {
   if (!value) return '—';
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
 }
 
 function redacted(text: string) {
@@ -105,7 +115,9 @@ function redacted(text: string) {
 function safeErrors(payload: ProxyHealthPayload | undefined) {
   const errors = payload?.errors;
   if (!Array.isArray(errors)) return [];
-  return errors.filter((error): error is string => typeof error === 'string').map(redacted);
+  return errors
+    .filter((error): error is string => typeof error === 'string')
+    .map(redacted);
 }
 
 function sum(values: Bucket[]) {
@@ -113,11 +125,20 @@ function sum(values: Bucket[]) {
 }
 
 function floorUtcHour(date: Date) {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours()));
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours()
+    )
+  );
 }
 
 function floorUtcDay(date: Date) {
-  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
 }
 
 function dayKey(date: Date) {
@@ -127,7 +148,9 @@ function dayKey(date: Date) {
 function dayLabel(date: Date, short = false) {
   return date.toLocaleDateString(
     'en-US',
-    short ? { day: 'numeric', timeZone: 'UTC' } : { month: 'short', day: 'numeric', timeZone: 'UTC' },
+    short
+      ? { day: 'numeric', timeZone: 'UTC' }
+      : { month: 'short', day: 'numeric', timeZone: 'UTC' }
   );
 }
 
@@ -147,19 +170,24 @@ function sumMs(...values: Array<number | null | undefined>) {
 function providerRows(value: unknown): ProviderBucket[] {
   if (!Array.isArray(value)) return [];
   return value
-    .map((item) => {
+    .map(item => {
       if (!item || typeof item !== 'object') return null;
       const row = item as { checked_at?: unknown; bytes?: unknown };
-      if (typeof row.checked_at !== 'string' || !isFiniteNumber(row.bytes)) return null;
+      if (typeof row.checked_at !== 'string' || !isFiniteNumber(row.bytes))
+        return null;
       const date = new Date(row.checked_at);
       if (Number.isNaN(date.getTime())) return null;
       return { checkedAt: date.toISOString(), bytes: row.bytes };
     })
     .filter((item): item is ProviderBucket => item !== null)
-    .sort((left, right) => Date.parse(left.checkedAt) - Date.parse(right.checkedAt));
+    .sort(
+      (left, right) => Date.parse(left.checkedAt) - Date.parse(right.checkedAt)
+    );
 }
 
-function providerUsage(payload: ProxyHealthPayload | undefined): ProviderUsage | null {
+function providerUsage(
+  payload: ProxyHealthPayload | undefined
+): ProviderUsage | null {
   const usage = payload?.provider?.usage;
   if (!usage || usage.source === 'disabled') return null;
   return {
@@ -167,7 +195,10 @@ function providerUsage(payload: ProxyHealthPayload | undefined): ProviderUsage |
     limitBytes: isFiniteNumber(usage.limit_bytes) ? usage.limit_bytes : null,
     resetAt: typeof usage.reset_at === 'string' ? usage.reset_at : null,
     suspended: typeof usage.suspended === 'boolean' ? usage.suspended : null,
-    policyViolation: typeof usage.policy_violation === 'boolean' ? usage.policy_violation : null,
+    policyViolation:
+      typeof usage.policy_violation === 'boolean'
+        ? usage.policy_violation
+        : null,
     lastRawAt: typeof usage.last_raw_at === 'string' ? usage.last_raw_at : null,
     daily: providerRows(usage.daily),
     hourly: providerRows(usage.hourly),
@@ -175,12 +206,26 @@ function providerUsage(payload: ProxyHealthPayload | undefined): ProviderUsage |
 }
 
 function providerPercent(provider: ProviderUsage | null) {
-  if (!provider || !isFiniteNumber(provider.usedBytes) || !isFiniteNumber(provider.limitBytes) || provider.limitBytes <= 0) return null;
-  return Math.min(100, Math.max(0, (provider.usedBytes / provider.limitBytes) * 100));
+  if (
+    !provider ||
+    !isFiniteNumber(provider.usedBytes) ||
+    !isFiniteNumber(provider.limitBytes) ||
+    provider.limitBytes <= 0
+  )
+    return null;
+  return Math.min(
+    100,
+    Math.max(0, (provider.usedBytes / provider.limitBytes) * 100)
+  );
 }
 
 function providerSummary(provider: ProviderUsage | null) {
-  if (!provider || !isFiniteNumber(provider.usedBytes) || !isFiniteNumber(provider.limitBytes)) return '—';
+  if (
+    !provider ||
+    !isFiniteNumber(provider.usedBytes) ||
+    !isFiniteNumber(provider.limitBytes)
+  )
+    return '—';
   return `${formatBytes(provider.usedBytes)} / ${formatBytes(provider.limitBytes)}`;
 }
 
@@ -189,7 +234,13 @@ function providerAttention(provider: ProviderUsage | null) {
 }
 
 function dailyRoom(provider: ProviderUsage | null) {
-  if (!provider || !isFiniteNumber(provider.usedBytes) || !isFiniteNumber(provider.limitBytes) || !provider.resetAt) return null;
+  if (
+    !provider ||
+    !isFiniteNumber(provider.usedBytes) ||
+    !isFiniteNumber(provider.limitBytes) ||
+    !provider.resetAt
+  )
+    return null;
   const reset = Date.parse(provider.resetAt);
   if (!Number.isFinite(reset)) return null;
   const daysLeft = Math.max(1, Math.ceil((reset - Date.now()) / DAY_MS));
@@ -197,40 +248,70 @@ function dailyRoom(provider: ProviderUsage | null) {
 }
 
 function sampleTotal(sample: ProxyHealthSample) {
-  if (!isFiniteNumber(sample.rxBytes) || !isFiniteNumber(sample.txBytes)) return null;
+  if (!isFiniteNumber(sample.rxBytes) || !isFiniteNumber(sample.txBytes))
+    return null;
   return sample.rxBytes + sample.txBytes;
 }
 
-function averageLatency(points: LatencyPoint[], latestDate: Date, windowMs: number) {
+function averageLatency(
+  points: LatencyPoint[],
+  latestDate: Date,
+  windowMs: number
+) {
   const values = points
-    .filter((point) => point.date.getTime() >= latestDate.getTime() - windowMs)
-    .map((point) => point.value);
+    .filter(point => point.date.getTime() >= latestDate.getTime() - windowMs)
+    .map(point => point.value);
   if (values.length === 0) return null;
   return values.reduce((total, value) => total + value, 0) / values.length;
 }
 
-function buildLatencyPoints(samples: ProxyHealthSample[], getValue: (sample: ProxyHealthSample) => number | null) {
+function buildLatencyPoints(
+  samples: ProxyHealthSample[],
+  getValue: (sample: ProxyHealthSample) => number | null
+) {
   return samples
-    .map((sample) => ({ date: new Date(sample.checkedAt), value: getValue(sample) }))
-    .filter((point): point is LatencyPoint => isFiniteNumber(point.value) && !Number.isNaN(point.date.getTime()))
+    .map(sample => ({
+      date: new Date(sample.checkedAt),
+      value: getValue(sample),
+    }))
+    .filter(
+      (point): point is LatencyPoint =>
+        isFiniteNumber(point.value) && !Number.isNaN(point.date.getTime())
+    )
     .sort((left, right) => left.date.getTime() - right.date.getTime());
 }
 
 function latestDateFrom(...groups: LatencyPoint[][]) {
-  const values = groups.flatMap((group) => group.map((point) => point.date.getTime())).filter(Number.isFinite);
+  const values = groups
+    .flatMap(group => group.map(point => point.date.getTime()))
+    .filter(Number.isFinite);
   return values.length > 0 ? new Date(Math.max(...values)) : new Date();
 }
 
 function buildLocalUsage(samples: ProxyHealthSample[]): LocalUsage {
   const counters = samples
-    .map((sample) => ({ date: new Date(sample.checkedAt), total: sampleTotal(sample), mode: sample.mode }))
-    .filter((point): point is { date: Date; total: number; mode: string | null } => isFiniteNumber(point.total) && !Number.isNaN(point.date.getTime()))
+    .map(sample => ({
+      date: new Date(sample.checkedAt),
+      total: sampleTotal(sample),
+      mode: sample.mode,
+    }))
+    .filter(
+      (point): point is { date: Date; total: number; mode: string | null } =>
+        isFiniteNumber(point.total) && !Number.isNaN(point.date.getTime())
+    )
     .sort((left, right) => left.date.getTime() - right.date.getTime());
 
-  const primaryPoints = buildLatencyPoints(samples, (sample) => sample.shanghaiBandwagonMs);
-  const relayPoints = buildLatencyPoints(samples, (sample) => sample.wgLatencyMs);
-  const totalPoints = buildLatencyPoints(samples, (sample) => sumMs(sample.shanghaiBandwagonMs, sample.wgLatencyMs));
-  const latest = counters.at(-1)?.date ?? latestDateFrom(primaryPoints, relayPoints, totalPoints);
+  const primaryPoints = buildLatencyPoints(
+    samples,
+    sample => sample.shanghaiBandwagonMs
+  );
+  const relayPoints = buildLatencyPoints(samples, sample => sample.wgLatencyMs);
+  const totalPoints = buildLatencyPoints(samples, sample =>
+    sumMs(sample.shanghaiBandwagonMs, sample.wgLatencyMs)
+  );
+  const latest =
+    counters.at(-1)?.date ??
+    latestDateFrom(primaryPoints, relayPoints, totalPoints);
   const monthStart = floorUtcDay(new Date(latest.getTime() - 29 * DAY_MS));
   const weekStart = floorUtcDay(new Date(latest.getTime() - 6 * DAY_MS));
   const hourStart = floorUtcHour(new Date(latest.getTime() - 23 * HOUR_MS));
@@ -268,12 +349,17 @@ function buildLocalUsage(samples: ProxyHealthSample[]): LocalUsage {
     const weekBucket = week.get(key);
     if (monthBucket) monthBucket.bytes += delta;
     if (weekBucket) weekBucket.bytes += delta;
-    const hourIndex = Math.floor((floorUtcHour(current.date).getTime() - hourStart.getTime()) / HOUR_MS);
-    if (hourIndex >= 0 && hourIndex < dayBuckets.length) dayBuckets[hourIndex].bytes += delta;
+    const hourIndex = Math.floor(
+      (floorUtcHour(current.date).getTime() - hourStart.getTime()) / HOUR_MS
+    );
+    if (hourIndex >= 0 && hourIndex < dayBuckets.length)
+      dayBuckets[hourIndex].bytes += delta;
   }
 
   for (const point of totalPoints) {
-    const hourIndex = Math.floor((floorUtcHour(point.date).getTime() - hourStart.getTime()) / HOUR_MS);
+    const hourIndex = Math.floor(
+      (floorUtcHour(point.date).getTime() - hourStart.getTime()) / HOUR_MS
+    );
     if (hourIndex >= 0 && hourIndex < latencyRaw.length) {
       latencyRaw[hourIndex].total += point.value;
       latencyRaw[hourIndex].count += 1;
@@ -295,7 +381,7 @@ function buildLocalUsage(samples: ProxyHealthSample[]): LocalUsage {
     totalLatency: sumMs(primary, relay),
     primary24h: averageLatency(primaryPoints, latest, DAY_MS),
     totalLatency24h: averageLatency(totalPoints, latest, DAY_MS),
-    latencyBuckets: latencyRaw.map((bucket) => ({
+    latencyBuckets: latencyRaw.map(bucket => ({
       label: bucket.label,
       value: bucket.count > 0 ? bucket.total / bucket.count : null,
     })),
@@ -306,13 +392,15 @@ function providerDailyBuckets(
   provider: ProviderUsage | null,
   count: number,
   longLabels: boolean,
-  start?: Date,
+  start?: Date
 ) {
   if (!provider || provider.daily.length === 0) return [];
   const rows = start
-    ? provider.daily.filter((bucket) => Date.parse(bucket.checkedAt) >= start.getTime())
+    ? provider.daily.filter(
+        bucket => Date.parse(bucket.checkedAt) >= start.getTime()
+      )
     : provider.daily;
-  return rows.slice(-count).map((bucket) => {
+  return rows.slice(-count).map(bucket => {
     const date = new Date(bucket.checkedAt);
     return { label: dayLabel(date, !longLabels), bytes: bucket.bytes };
   });
@@ -320,15 +408,21 @@ function providerDailyBuckets(
 
 function providerHourlyBuckets(provider: ProviderUsage | null) {
   if (!provider || provider.hourly.length === 0) return [];
-  return provider.hourly.slice(-24).map((bucket) => ({
+  return provider.hourly.slice(-24).map(bucket => ({
     label: hourLabel(new Date(bucket.checkedAt)),
     bytes: bucket.bytes,
   }));
 }
 
-function buildActivity(local: LocalUsage, provider: ProviderUsage | null): Activity {
+function buildActivity(
+  local: LocalUsage,
+  provider: ProviderUsage | null
+): Activity {
   const month = providerDailyBuckets(provider, 30, false);
-  const latestProviderAt = provider?.daily.at(-1)?.checkedAt ?? provider?.lastRawAt ?? local.latestCheckedAt;
+  const latestProviderAt =
+    provider?.daily.at(-1)?.checkedAt ??
+    provider?.lastRawAt ??
+    local.latestCheckedAt;
   const weekWindow = getUsageWeekWindow(provider?.resetAt, latestProviderAt);
   const week = providerDailyBuckets(provider, 7, true, weekWindow.start);
   const day = providerHourlyBuckets(provider);
@@ -351,17 +445,35 @@ function buildActivity(local: LocalUsage, provider: ProviderUsage | null): Activ
 }
 
 function paceLabel(room: number | null, average: number) {
-  if (!isFiniteNumber(room) || room <= 0) return 'pace unknown';
-  if (average > room * 1.15) return 'pace warm';
-  return 'pace safe';
+  if (!isFiniteNumber(room) || room <= 0) return 'allowance unavailable';
+  if (average > room * 1.15) return 'above daily allowance';
+  return 'within daily allowance';
 }
 
-function Card({ title, value, children, className = '' }: { title: string; value?: string; children: ReactNode; className?: string }) {
+function Card({
+  title,
+  value,
+  children,
+  className = '',
+}: {
+  title: string;
+  value?: string;
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <section className={`rounded-xl border bg-background/80 p-3 shadow-sm ${className}`}>
-      <div className="mb-2 flex items-center justify-between gap-3">
-        <h2 className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{title}</h2>
-        {value ? <div className="text-xs font-medium text-muted-foreground">{value}</div> : null}
+    <section
+      className={`rounded-[1.35rem] border border-border/70 bg-background/70 p-4 ${className}`}
+    >
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+          {title}
+        </h2>
+        {value ? (
+          <div className="font-mono text-[11px] font-semibold tabular-nums text-foreground">
+            {value}
+          </div>
+        ) : null}
       </div>
       {children}
     </section>
@@ -370,32 +482,52 @@ function Card({ title, value, children, className = '' }: { title: string; value
 
 function PinnedValue({ value }: { value: string | null }) {
   if (!value) return null;
-  return <div className="absolute left-2 top-2 z-10 rounded-full border bg-background/95 px-2 py-1 text-[11px] shadow-sm backdrop-blur">{value}</div>;
+  return (
+    <div className="absolute left-2 top-2 z-10 rounded-md border border-border/70 bg-background/95 px-2 py-1 font-mono text-[10px] shadow-sm backdrop-blur">
+      {value}
+    </div>
+  );
 }
 
-function Bars({ buckets, height = 'h-28', labelEvery = 1, minBarPercent = 14 }: { buckets: Bucket[]; height?: string; labelEvery?: number; minBarPercent?: number }) {
+function Bars({
+  buckets,
+  height = 'h-28',
+  labelEvery = 1,
+  minBarPercent = 14,
+}: {
+  buckets: Bucket[];
+  height?: string;
+  labelEvery?: number;
+  minBarPercent?: number;
+}) {
   const [selected, setSelected] = useState<string | null>(null);
-  const maximum = Math.max(1, ...buckets.map((bucket) => bucket.bytes));
+  const maximum = Math.max(1, ...buckets.map(bucket => bucket.bytes));
 
   return (
-    <div className={`relative grid ${height} grid-rows-[minmax(0,1fr)_auto] gap-1 rounded-lg border bg-muted/30 p-2`}>
+    <div
+      className={`relative grid ${height} grid-rows-[minmax(0,1fr)_auto] gap-1 rounded-xl border border-border/60 bg-background/35 p-2`}
+    >
       <PinnedValue value={selected} />
       <div className="flex min-h-0 items-end gap-1">
         {buckets.map((bucket, index) => {
           const hasValue = bucket.bytes > 0;
           const tooltip = `${bucket.label}: ${formatBytes(bucket.bytes)}`;
-          const barHeight = hasValue ? `${Math.max(minBarPercent, (bucket.bytes / maximum) * 100)}%` : '2px';
+          const barHeight = hasValue
+            ? `${Math.max(minBarPercent, (bucket.bytes / maximum) * 100)}%`
+            : '2px';
           return (
             <button
               key={`${bucket.label}-${index}`}
               type="button"
-              className="group relative flex h-full min-w-0 flex-1 items-end justify-center rounded-md px-0.5 transition-colors hover:bg-[#b8b5ff]/10 focus:bg-[#b8b5ff]/10 focus:outline-none focus:ring-1 focus:ring-[#cbc8ff]"
-              onClick={() => setSelected((current) => (current === tooltip ? null : tooltip))}
+              className="group relative flex h-full min-w-0 flex-1 items-end justify-center rounded-md px-0.5 transition-colors hover:bg-[#8d8af1]/10 focus:bg-[#8d8af1]/10 focus:outline-none focus:ring-1 focus:ring-[#aaa7ff]"
+              onClick={() =>
+                setSelected(current => (current === tooltip ? null : tooltip))
+              }
               title={tooltip}
               aria-label={tooltip}
             >
               <span
-                className={`block w-full max-w-10 rounded-t transition-all duration-150 ${hasValue ? 'bg-[#b8b5ff] shadow-[0_0_14px_rgba(184,181,255,0.26)] group-hover:bg-[#cbc8ff]' : 'bg-[#b8b5ff]/25'}`}
+                className={`block w-full max-w-10 rounded-t-sm transition-all duration-150 ${hasValue ? 'bg-[#8d8af1] shadow-[0_0_16px_rgba(141,138,241,0.22)] group-hover:bg-[#aaa7ff]' : 'bg-[#8d8af1]/20'}`}
                 style={{ height: barHeight }}
               />
             </button>
@@ -405,7 +537,16 @@ function Bars({ buckets, height = 'h-28', labelEvery = 1, minBarPercent = 14 }: 
       <div className="flex gap-1">
         {buckets.map((bucket, index) => {
           const show = index % labelEvery === 0 || index === buckets.length - 1;
-          return <div key={`${bucket.label}-${index}`} className="min-w-0 flex-1 text-center text-[10px] leading-none text-muted-foreground"><span className="whitespace-nowrap">{show ? bucket.label : ''}</span></div>;
+          return (
+            <div
+              key={`${bucket.label}-${index}`}
+              className="min-w-0 flex-1 text-center font-mono text-[8px] leading-none text-muted-foreground"
+            >
+              <span className="whitespace-nowrap">
+                {show ? bucket.label : ''}
+              </span>
+            </div>
+          );
         })}
       </div>
     </div>
@@ -414,57 +555,111 @@ function Bars({ buckets, height = 'h-28', labelEvery = 1, minBarPercent = 14 }: 
 
 function MetricBars({ buckets }: { buckets: MetricBucket[] }) {
   const [selected, setSelected] = useState<string | null>(null);
-  const values = buckets.map((bucket) => bucket.value).filter(isFiniteNumber);
-  if (values.length === 0) return <div className="flex h-24 items-center justify-center rounded-lg border bg-muted/30 text-xs text-muted-foreground">no data</div>;
+  const values = buckets.map(bucket => bucket.value).filter(isFiniteNumber);
+  if (values.length === 0)
+    return (
+      <div className="flex h-32 items-center justify-center rounded-xl border border-border/60 bg-background/35 text-xs text-muted-foreground">
+        no data
+      </div>
+    );
 
   const minimum = Math.min(...values);
   const maximum = Math.max(...values);
   const spread = maximum - minimum;
-  const padding = spread > 0 ? Math.max(spread * 0.15, 0.2) : Math.max(maximum * 0.002, 0.5);
+  const padding =
+    spread > 0 ? Math.max(spread * 0.15, 0.2) : Math.max(maximum * 0.002, 0.5);
   const lower = minimum - padding;
   const upper = maximum + padding;
   const range = Math.max(0.1, upper - lower);
 
   return (
-    <div className="relative grid h-24 grid-cols-[minmax(0,1fr)_2.25rem] grid-rows-[minmax(0,1fr)_auto] gap-x-1 gap-y-1 rounded-lg border bg-muted/30 p-2">
+    <div className="relative grid h-32 grid-cols-[minmax(0,1fr)_2.25rem] grid-rows-[minmax(0,1fr)_auto] gap-x-1 gap-y-1 rounded-xl border border-border/60 bg-background/35 p-2">
       <PinnedValue value={selected} />
       <div className="flex min-h-0 items-end gap-1">
         {buckets.map((bucket, index) => {
           const value = bucket.value;
           const hasValue = isFiniteNumber(value);
-          const normalized = hasValue ? Math.min(1, Math.max(0, (value - lower) / range)) : 0;
+          const normalized = hasValue
+            ? Math.min(1, Math.max(0, (value - lower) / range))
+            : 0;
           const tooltip = `${bucket.label}: ${formatMs(value)}`;
           return (
             <button
               key={`${bucket.label}-${index}`}
               type="button"
-              className="group relative flex h-full min-w-0 flex-1 items-end justify-center rounded-md px-0.5 transition-colors hover:bg-[#b8b5ff]/10 focus:bg-[#b8b5ff]/10 focus:outline-none focus:ring-1 focus:ring-[#cbc8ff]"
-              onClick={() => setSelected((current) => (current === tooltip ? null : tooltip))}
+              className="group relative flex h-full min-w-0 flex-1 items-end justify-center rounded-md px-0.5 transition-colors hover:bg-[#8d8af1]/10 focus:bg-[#8d8af1]/10 focus:outline-none focus:ring-1 focus:ring-[#aaa7ff]"
+              onClick={() =>
+                setSelected(current => (current === tooltip ? null : tooltip))
+              }
               title={tooltip}
               aria-label={tooltip}
             >
               <span
-                className={`block w-full max-w-10 rounded-t transition-all duration-150 ${hasValue ? 'bg-[#b8b5ff] shadow-[0_0_14px_rgba(184,181,255,0.26)] group-hover:bg-[#cbc8ff]' : 'bg-[#b8b5ff]/25'}`}
-                style={{ height: hasValue ? `${Math.max(14, normalized * 100)}%` : '2px' }}
+                className={`block w-full max-w-10 rounded-t-sm transition-all duration-150 ${hasValue ? 'bg-[#8d8af1] shadow-[0_0_16px_rgba(141,138,241,0.22)] group-hover:bg-[#aaa7ff]' : 'bg-[#8d8af1]/20'}`}
+                style={{
+                  height: hasValue
+                    ? `${Math.max(14, normalized * 100)}%`
+                    : '2px',
+                }}
               />
             </button>
           );
         })}
       </div>
-      <div className="row-span-2 flex flex-col justify-between text-right text-[9px] leading-none text-muted-foreground"><span>{formatMs(upper)}</span><span>{formatMs(lower)}</span></div>
+      <div className="row-span-2 flex flex-col justify-between text-right text-[9px] leading-none text-muted-foreground">
+        <span>{formatMs(upper)}</span>
+        <span>{formatMs(lower)}</span>
+      </div>
       <div className="flex gap-1">
-        {buckets.map((bucket, index) => <div key={`${bucket.label}-${index}`} className="min-w-0 flex-1 text-center text-[10px] leading-none text-muted-foreground">{index % 4 === 0 || index === buckets.length - 1 ? bucket.label : ''}</div>)}
+        {buckets.map((bucket, index) => (
+          <div
+            key={`${bucket.label}-${index}`}
+            className="min-w-0 flex-1 text-center text-[10px] leading-none text-muted-foreground"
+          >
+            {index % 4 === 0 || index === buckets.length - 1
+              ? bucket.label
+              : ''}
+          </div>
+        ))}
       </div>
     </div>
   );
 }
 
-function StatusPill({ mode, errors }: { mode: string | null; errors: string[] }) {
-  const warning = errors.length > 0 || mode === 'degraded' || mode === 'unknown';
+function StatusPill({
+  mode,
+  errors,
+}: {
+  mode: string | null;
+  errors: string[];
+}) {
+  const warning =
+    errors.length > 0 || mode === 'degraded' || mode === 'unknown';
   const fallback = mode === 'fallback';
-  const label = errors.length > 0 ? 'Needs attention' : fallback ? 'Backup path' : warning ? 'Degraded' : 'Normal';
-  const className = warning ? 'border-red-400/50 bg-red-400/15' : fallback ? 'border-amber-400/50 bg-amber-400/15' : 'border-[#b8b5ff]/50 bg-[#b8b5ff]/15';
-  return <span className={`rounded-full border px-2.5 py-1 text-xs font-medium text-foreground ${className}`}>{label}</span>;
+  const label =
+    errors.length > 0
+      ? 'Needs attention'
+      : fallback
+        ? 'Backup path'
+        : warning
+          ? 'Degraded'
+          : 'Normal';
+  const className = warning
+    ? 'border-red-400/50 bg-red-400/12'
+    : fallback
+      ? 'border-amber-400/50 bg-amber-400/12'
+      : 'border-[#8d8af1]/50 bg-[#8d8af1]/12';
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border px-2.5 py-1 font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-foreground ${className}`}
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full bg-current opacity-70"
+        aria-hidden="true"
+      />
+      {label}
+    </span>
+  );
 }
 
 function ProviderRing({ provider }: { provider: ProviderUsage | null }) {
@@ -473,59 +668,133 @@ function ProviderRing({ provider }: { provider: ProviderUsage | null }) {
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference * (1 - percent / 100);
   return (
-    <div className="relative h-28 w-28 shrink-0">
-      <svg className="h-full w-full -rotate-90" viewBox="0 0 120 120" role="img" aria-label="provider usage progress">
-        <circle cx="60" cy="60" r={radius} fill="none" className="stroke-muted" strokeWidth="11" />
-        <circle cx="60" cy="60" r={radius} fill="none" className="stroke-[#b8b5ff]" strokeWidth="11" strokeLinecap="round" strokeDasharray={circumference} strokeDashoffset={dashOffset} />
+    <div className="relative h-32 w-32 shrink-0 sm:h-36 sm:w-36">
+      <svg
+        className="h-full w-full -rotate-90"
+        viewBox="0 0 120 120"
+        role="img"
+        aria-label="provider usage progress"
+      >
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-muted"
+          strokeWidth="8"
+        />
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-[#8d8af1]"
+          strokeWidth="8"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+        />
       </svg>
-      <div className="absolute inset-0 flex items-center justify-center text-xl font-semibold tracking-tight">{formatPercent(percent)}</div>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-xl font-semibold tracking-tight sm:text-2xl">
+          {formatPercent(percent)}
+        </span>
+        <span className="font-mono text-[8px] uppercase tracking-[0.14em] text-muted-foreground">
+          used
+        </span>
+      </div>
     </div>
   );
 }
 
-function Hero({ status, local, activity, provider }: { status?: StoredProxyHealth | null; local: LocalUsage; activity: Activity; provider: ProviderUsage | null }) {
+function Hero({
+  status,
+  local,
+  activity,
+  provider,
+}: {
+  status?: StoredProxyHealth | null;
+  local: LocalUsage;
+  activity: Activity;
+  provider: ProviderUsage | null;
+}) {
   const payload = status?.payload;
   const errors = safeErrors(payload);
   const mode = payload?.mode ?? local.latestMode;
   const room = dailyRoom(provider);
   const average = activity.week / Math.max(1, activity.weekDayCount);
-  const checkedAt = provider?.lastRawAt ?? status?.updatedAt ?? local.latestCheckedAt;
+  const checkedAt =
+    provider?.lastRawAt ?? status?.updatedAt ?? local.latestCheckedAt;
 
   return (
-    <section className="rounded-2xl border bg-background/90 p-3 shadow-sm">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+    <section className="overflow-hidden rounded-[1.5rem] border border-border/70 bg-background/78">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/60 px-4 py-3">
         <div className="flex items-center gap-2">
           <StatusPill mode={mode ?? null} errors={errors} />
-          {providerAttention(provider) ? <span className="rounded-full border border-red-400/50 bg-red-400/15 px-2 py-0.5 text-xs text-foreground">attention</span> : null}
+          {providerAttention(provider) ? (
+            <span className="rounded-full border border-red-400/50 bg-red-400/15 px-2 py-0.5 text-xs text-foreground">
+              attention
+            </span>
+          ) : null}
         </div>
-        <div className="text-xs text-muted-foreground">checked <span className="font-medium text-foreground">{formatRelativeTime(checkedAt)}</span></div>
+        <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+          checked{' '}
+          <span className="font-semibold text-foreground">
+            {formatRelativeTime(checkedAt)}
+          </span>
+        </div>
       </div>
 
-      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.85fr)]">
-        <div className="flex min-h-36 items-center gap-4 rounded-xl border bg-muted/30 p-3">
+      <div className="grid lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+        <div className="relative flex min-h-52 items-center gap-4 overflow-hidden border-b border-border/60 bg-[radial-gradient(circle_at_18%_25%,rgba(141,138,241,0.16),transparent_52%)] p-4 lg:border-b-0 lg:border-r sm:p-6">
           <ProviderRing provider={provider} />
           <div className="min-w-0 flex-1">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Cycle</div>
-            <div className="mt-1 text-2xl font-semibold tracking-tight sm:text-3xl">{providerSummary(provider)}</div>
-            <div className="mt-1 text-xs text-muted-foreground">resets {formatDate(provider?.resetAt)}</div>
+            <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Current cycle
+            </div>
+            <div className="mt-2 text-xl font-semibold tracking-[-0.025em] sm:text-3xl">
+              {providerSummary(provider)}
+            </div>
+            <div className="mt-1.5 text-xs text-muted-foreground">
+              Next reset · {formatDate(provider?.resetAt)}
+            </div>
           </div>
         </div>
 
-        <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
-          <div className="rounded-xl border bg-muted/30 px-3 py-3">
-            <div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">24h</div>
-            <div className="mt-1 text-2xl font-semibold tracking-tight">{formatBytes(activity.day)}</div>
-            <div className="mt-0.5 text-xs text-muted-foreground">latest hour {formatBytes(activity.lastDelta)}</div>
+        <div className="grid sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+          <div className="border-b border-border/60 px-4 py-4 sm:border-b-0 sm:border-r lg:border-b lg:border-r-0 xl:border-b-0 xl:border-r">
+            <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+              24h traffic
+            </div>
+            <div className="mt-2 text-xl font-semibold tracking-tight">
+              {formatBytes(activity.day)}
+            </div>
+            <div className="mt-1 text-xs leading-5 text-muted-foreground">
+              Latest hour {formatBytes(activity.lastDelta)}
+            </div>
           </div>
-          <div className="rounded-xl border bg-muted/30 px-3 py-3">
-            <div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Room / day</div>
-            <div className="mt-1 text-2xl font-semibold tracking-tight">{formatBytes(room)}</div>
-            <div className="mt-0.5 text-xs text-muted-foreground">{activity.weekLabel.toLowerCase()} avg {formatBytes(average)} · {paceLabel(room, average)}</div>
+          <div className="border-b border-border/60 px-4 py-4 sm:border-b-0 sm:border-r lg:border-b lg:border-r-0 xl:border-b-0 xl:border-r">
+            <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+              Daily allowance
+            </div>
+            <div className="mt-2 text-xl font-semibold tracking-tight">
+              {formatBytes(room)}
+            </div>
+            <div className="mt-1 text-xs leading-5 text-muted-foreground">
+              {activity.weekLabel.toLowerCase()} avg {formatBytes(average)} ·{' '}
+              {paceLabel(room, average)}
+            </div>
           </div>
-          <div className="rounded-xl border bg-muted/30 px-3 py-3">
-            <div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Latency</div>
-            <div className="mt-1 text-2xl font-semibold tracking-tight">{formatMs(local.totalLatency)}</div>
-            <div className="mt-0.5 text-xs text-muted-foreground">24h {formatMs(local.totalLatency24h)}</div>
+          <div className="px-4 py-4">
+            <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+              Round trip
+            </div>
+            <div className="mt-2 text-xl font-semibold tracking-tight">
+              {formatMs(local.totalLatency)}
+            </div>
+            <div className="mt-1 text-xs leading-5 text-muted-foreground">
+              24h average {formatMs(local.totalLatency24h)}
+            </div>
           </div>
         </div>
       </div>
@@ -535,43 +804,112 @@ function Hero({ status, local, activity, provider }: { status?: StoredProxyHealt
 
 function BandwidthCard({ activity }: { activity: Activity }) {
   const [range, setRange] = useState<RangeKey>('30d');
-  const options: Array<{ key: RangeKey; label: string; buckets: Bucket[]; value: number; labelEvery: number; minBarPercent: number }> = [
-    { key: '24h', label: '24 hours', buckets: activity.dayBuckets, value: activity.day, labelEvery: 4, minBarPercent: 18 },
-    { key: '7d', label: activity.weekLabel, buckets: activity.weekBuckets, value: activity.week, labelEvery: 1, minBarPercent: 14 },
-    { key: '30d', label: '30 days', buckets: activity.monthBuckets, value: activity.month, labelEvery: 5, minBarPercent: 18 },
+  const options: Array<{
+    key: RangeKey;
+    label: string;
+    buckets: Bucket[];
+    value: number;
+    labelEvery: number;
+    minBarPercent: number;
+  }> = [
+    {
+      key: '24h',
+      label: '24 hours',
+      buckets: activity.dayBuckets,
+      value: activity.day,
+      labelEvery: 4,
+      minBarPercent: 18,
+    },
+    {
+      key: '7d',
+      label: activity.weekLabel,
+      buckets: activity.weekBuckets,
+      value: activity.week,
+      labelEvery: 1,
+      minBarPercent: 14,
+    },
+    {
+      key: '30d',
+      label: '30 days',
+      buckets: activity.monthBuckets,
+      value: activity.month,
+      labelEvery: 5,
+      minBarPercent: 18,
+    },
   ];
-  const selected = options.find((option) => option.key === range) ?? options[2];
+  const selected = options.find(option => option.key === range) ?? options[2];
 
   return (
-    <Card className="xl:col-span-4" title="Bandwidth" value={formatBytes(selected.value)}>
-      <div className="mb-3 flex rounded-full border bg-muted/30 p-1 text-xs font-medium">
-        {options.map((option) => (
+    <Card
+      className="xl:col-span-7"
+      title="Bandwidth"
+      value={formatBytes(selected.value)}
+    >
+      <div className="mb-4 grid grid-cols-3 overflow-hidden rounded-lg border border-border/60 bg-background/35 text-xs font-medium">
+        {options.map(option => (
           <button
             key={option.key}
             type="button"
             onClick={() => setRange(option.key)}
-            className={`flex-1 rounded-full px-3 py-1.5 transition-colors ${range === option.key ? 'bg-[#b8b5ff]/25 text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+            className={`min-h-11 border-r border-border/55 px-3 py-2 transition-colors last:border-r-0 ${range === option.key ? 'bg-[#8d8af1]/18 text-foreground' : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'}`}
           >
             {option.label}
           </button>
         ))}
       </div>
-      <Bars buckets={selected.buckets} height="h-44" labelEvery={selected.labelEvery} minBarPercent={selected.minBarPercent} />
+      <Bars
+        buckets={selected.buckets}
+        height="h-52 xl:h-96"
+        labelEvery={selected.labelEvery}
+        minBarPercent={selected.minBarPercent}
+      />
     </Card>
   );
 }
 
 function LatencyCard({ local }: { local: LocalUsage }) {
   return (
-    <Card className="xl:col-span-4" title="Latency">
-      <div className="grid gap-2 lg:grid-cols-[0.85fr_1.15fr]">
-        <div className="grid grid-cols-3 gap-2 rounded-lg border bg-muted/30 p-2">
-          <div className="rounded-lg border bg-background/50 px-3 py-2"><div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Primary</div><div className="mt-0.5 text-lg font-semibold tracking-tight">{formatMs(local.primary)}</div><div className="mt-0.5 text-[11px] text-muted-foreground">24h {formatMs(local.primary24h)}</div></div>
-          <div className="rounded-lg border bg-background/50 px-3 py-2"><div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Egress</div><div className="mt-0.5 text-lg font-semibold tracking-tight">{formatMs(local.relay)}</div><div className="mt-0.5 text-[11px] text-muted-foreground">relay</div></div>
-          <div className="rounded-lg border bg-background/50 px-3 py-2"><div className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground">Total</div><div className="mt-0.5 text-lg font-semibold tracking-tight">{formatMs(local.totalLatency)}</div><div className="mt-0.5 text-[11px] text-muted-foreground">24h {formatMs(local.totalLatency24h)}</div></div>
+    <Card className="xl:col-span-5" title="Latency">
+      <div className="grid gap-4">
+        <div className="grid grid-cols-1 overflow-hidden rounded-xl border border-border/60 bg-background/35 sm:grid-cols-3 xl:grid-cols-1">
+          <div className="border-b border-border/55 px-3 py-3 sm:border-b-0 sm:border-r xl:border-b xl:border-r-0">
+            <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+              Primary
+            </div>
+            <div className="mt-1 text-lg font-semibold tracking-tight">
+              {formatMs(local.primary)}
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              24h {formatMs(local.primary24h)}
+            </div>
+          </div>
+          <div className="border-b border-border/55 px-3 py-3 sm:border-b-0 sm:border-r xl:border-b xl:border-r-0">
+            <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+              Egress
+            </div>
+            <div className="mt-1 text-lg font-semibold tracking-tight">
+              {formatMs(local.relay)}
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              Relay leg
+            </div>
+          </div>
+          <div className="px-3 py-3">
+            <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+              Total
+            </div>
+            <div className="mt-1 text-lg font-semibold tracking-tight">
+              {formatMs(local.totalLatency)}
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              24h {formatMs(local.totalLatency24h)}
+            </div>
+          </div>
         </div>
         <div>
-          <div className="mb-2 text-xs font-medium text-muted-foreground">Primary + Egress · 24h</div>
+          <div className="mb-2 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
+            Primary + egress · 24h
+          </div>
           <MetricBars buckets={local.latencyBuckets} />
         </div>
       </div>
@@ -579,14 +917,31 @@ function LatencyCard({ local }: { local: LocalUsage }) {
   );
 }
 
-export function UsageDashboard({ samples, status }: { samples: ProxyHealthSample[]; status?: StoredProxyHealth | null; limitBytes?: number }) {
+export function UsageDashboard({
+  samples,
+  status,
+}: {
+  samples: ProxyHealthSample[];
+  status?: StoredProxyHealth | null;
+  limitBytes?: number;
+}) {
   const provider = providerUsage(status?.payload);
   const local = useMemo(() => buildLocalUsage(samples), [samples]);
-  const activity = useMemo(() => buildActivity(local, provider), [local, provider]);
+  const activity = useMemo(
+    () => buildActivity(local, provider),
+    [local, provider]
+  );
 
   return (
-    <div className="grid gap-3 xl:grid-cols-4">
-      <div className="xl:col-span-4"><Hero status={status} local={local} activity={activity} provider={provider} /></div>
+    <div className="grid gap-3 xl:grid-cols-12">
+      <div className="xl:col-span-12">
+        <Hero
+          status={status}
+          local={local}
+          activity={activity}
+          provider={provider}
+        />
+      </div>
       <BandwidthCard activity={activity} />
       <LatencyCard local={local} />
     </div>

--- a/components/proxy/usage-page.tsx
+++ b/components/proxy/usage-page.tsx
@@ -5,7 +5,11 @@ import { UsageDashboardContainer } from './usage-dashboard-container';
 
 function SignalSkeleton() {
   return (
-    <div className="grid animate-pulse gap-3 motion-reduce:animate-none" aria-label="Loading cached signal" role="status">
+    <div
+      className="grid animate-pulse gap-3 motion-reduce:animate-none"
+      aria-label="Loading dashboard"
+      role="status"
+    >
       <div className="h-44 rounded-2xl border border-border/70 bg-background/55" />
       <div className="grid gap-3 md:grid-cols-3">
         <div className="h-32 rounded-xl border border-border/70 bg-background/45" />
@@ -19,23 +23,18 @@ function SignalSkeleton() {
 export function UsagePage() {
   return (
     <ViewportPageShell
-      className="bg-[#dfdbd2] text-[#1b1b1f] dark:bg-[#15171b] dark:text-[#f1ede5]"
+      className="bg-[#dedbd3] text-[#1b1b1f] dark:bg-[#121419] dark:text-[#f1ede5]"
       contentClassName="min-h-0"
     >
       <ProxyLiveRefresh />
-      <div className="mx-auto w-full max-w-7xl px-4 py-4 pb-10 sm:px-6 lg:px-8">
-        <div className="mb-3 flex items-end justify-between gap-4">
-          <div>
-            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-black/58 dark:text-white/62">
-              Signal
-            </p>
-            <h1 className="mt-0.5 text-xl font-bold tracking-tight">Network pulse</h1>
-          </div>
+      <main className="mx-auto w-full max-w-7xl px-3 py-3 pb-10 sm:px-5 sm:py-5 lg:px-7">
+        <h1 className="sr-only">Signal</h1>
+        <div className="rounded-[1.75rem] border border-black/12 bg-[#ebe8e1]/76 p-2 shadow-[0_24px_70px_rgba(44,38,31,0.08)] dark:border-white/10 dark:bg-[#1a1c22]/78 dark:shadow-[0_28px_80px_rgba(0,0,0,0.25)] sm:p-3">
+          <Suspense fallback={<SignalSkeleton />}>
+            <UsageDashboardContainer />
+          </Suspense>
         </div>
-        <Suspense fallback={<SignalSkeleton />}>
-          <UsageDashboardContainer />
-        </Suspense>
-      </div>
+      </main>
     </ViewportPageShell>
   );
 }

--- a/components/site-atlas.tsx
+++ b/components/site-atlas.tsx
@@ -11,6 +11,7 @@ import {
 import * as Dialog from '@radix-ui/react-dialog';
 import {
   Activity,
+  BookOpenText,
   Brain,
   Clock3,
   Compass,
@@ -18,6 +19,7 @@ import {
   FlaskConical,
   Home,
   Images,
+  LibraryBig,
   NotebookPen,
   Moon,
   Palette,
@@ -61,6 +63,12 @@ function ItemIcon({ id }: { id: string }) {
       return <Shapes className={className} aria-hidden="true" />;
     case 'glossless':
       return <Sparkles className={className} aria-hidden="true" />;
+    case 'scrapbook-repository':
+      return <LibraryBig className={className} aria-hidden="true" />;
+    case 'fieldwork-repository':
+    case 'linux-fieldwork-repository':
+    case 'smolrunner-repository':
+      return <BookOpenText className={className} aria-hidden="true" />;
     case 'github':
       return <GitHubIcon className={className} aria-hidden="true" />;
     case 'twitter':
@@ -89,7 +97,7 @@ function AtlasLink({
       aria-current={active ? 'page' : undefined}
       data-site-atlas-link={item.id}
       data-active={active ? 'true' : undefined}
-      className={`group flex min-h-12 min-w-0 items-center gap-3 rounded-xl border px-3 py-2 text-left transition-[background-color,border-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+      className={`group flex min-h-[4.5rem] min-w-0 items-start gap-3 rounded-[1rem] border px-3 py-3 text-left transition-[background-color,border-color,transform] hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none ${
         active
           ? 'border-foreground/30 bg-foreground/[0.075]'
           : 'border-border/70 bg-background/55 hover:border-foreground/25 hover:bg-muted/70'
@@ -98,8 +106,13 @@ function AtlasLink({
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-card text-foreground">
         <ItemIcon id={item.id} />
       </span>
-      <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-        {item.label}
+      <span className="min-w-0 flex-1">
+        <span className="block text-[1.05rem] font-semibold leading-tight text-foreground">
+          {item.label}
+        </span>
+        <span className="mt-1 block text-xs leading-[1.35rem] text-muted-foreground">
+          {item.description}
+        </span>
       </span>
       {item.badge ? (
         <span className="shrink-0 rounded-full border border-border/70 px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
@@ -131,13 +144,20 @@ function AppearanceAction() {
         setTheme(isDark ? 'light' : 'dark');
       }}
       data-site-atlas-appearance
-      className="flex min-h-12 w-full items-center gap-3 rounded-xl border border-border/70 bg-background/55 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className="flex min-h-[4.5rem] w-full items-start gap-3 rounded-[1rem] border border-border/70 bg-background/55 px-3 py-3 text-left transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-card">
         <Sun className="h-4 w-4 dark:hidden" aria-hidden="true" />
         <Moon className="hidden h-4 w-4 dark:block" aria-hidden="true" />
       </span>
-      <span className="truncate text-sm font-semibold">Appearance</span>
+      <span className="min-w-0">
+        <span className="block text-[1.05rem] font-semibold leading-tight">
+          Appearance
+        </span>
+        <span className="mt-1 block text-xs leading-[1.35rem] text-muted-foreground">
+          Turn the paper and ink between day and night.
+        </span>
+      </span>
     </button>
   );
 }
@@ -159,12 +179,19 @@ function DiscordAction() {
       type="button"
       onClick={() => void copyDiscord()}
       data-site-atlas-discord
-      className="flex min-h-12 w-full items-center gap-3 rounded-xl border border-border/70 bg-background/55 px-3 py-2 text-left transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      className="flex min-h-[4.5rem] w-full items-start gap-3 rounded-[1rem] border border-border/70 bg-background/55 px-3 py-3 text-left transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-card">
         <DiscordIcon className="h-4 w-4" aria-hidden="true" />
       </span>
-      <span className="truncate text-sm font-semibold">Discord</span>
+      <span className="min-w-0">
+        <span className="block text-[1.05rem] font-semibold leading-tight">
+          Discord
+        </span>
+        <span className="mt-1 block text-xs leading-[1.35rem] text-muted-foreground">
+          Copy the handle for a quieter conversation.
+        </span>
+      </span>
     </button>
   );
 }
@@ -173,7 +200,7 @@ export function SiteAtlas({
   variant = 'label',
   className = '',
 }: {
-  variant?: 'label' | 'icon';
+  variant?: 'label' | 'icon' | 'rail';
   className?: string;
 }) {
   const pathname = usePathname() || '/';
@@ -183,13 +210,17 @@ export function SiteAtlas({
       <Dialog.Trigger asChild>
         <button
           type="button"
-          className={`${triggerBase} ${variant === 'icon' ? 'w-11 px-0' : ''} ${className}`}
+          className={`${
+            variant === 'rail'
+              ? 'inline-flex h-12 min-w-[44px] shrink-0 items-center justify-center gap-1.5 border-l border-border/60 bg-transparent px-3 text-xs font-semibold text-foreground transition-colors hover:bg-muted/75 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring motion-reduce:transition-none'
+              : triggerBase
+          } ${variant === 'icon' ? 'w-11 px-0' : ''} ${className}`}
           aria-label="Open site atlas"
           title="Open site atlas"
           data-site-atlas-trigger
         >
           <Compass className="h-4 w-4" aria-hidden="true" />
-          {variant === 'label' ? (
+          {variant !== 'icon' ? (
             <span className="hidden min-[420px]:inline">Atlas</span>
           ) : null}
         </button>
@@ -201,16 +232,19 @@ export function SiteAtlas({
           data-site-atlas-overlay
         />
         <Dialog.Content
-          className="fixed inset-0 z-[80] flex min-w-0 flex-col overflow-hidden bg-background text-foreground shadow-2xl outline-none [contain:layout_paint] data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none sm:inset-4 sm:mx-auto sm:max-w-4xl sm:rounded-[1.5rem] sm:border sm:border-border/70"
+          className="fixed inset-0 z-[80] flex min-w-0 flex-col overflow-hidden bg-background text-foreground shadow-2xl outline-none [contain:layout_paint] [font-family:ui-serif,Georgia,Cambria,'Times_New_Roman',serif] data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:animate-none sm:inset-4 sm:mx-auto sm:max-w-6xl sm:rounded-[1.5rem] sm:border sm:border-border/70 lg:inset-y-6"
           data-site-atlas
         >
-          <header className="flex shrink-0 items-center gap-3 border-b border-border/70 bg-card/90 px-4 py-[max(1rem,env(safe-area-inset-top))] sm:px-6 sm:py-4">
-            <Dialog.Title className="min-w-0 flex-1 text-2xl font-semibold tracking-tight sm:text-3xl">
-              Site Atlas
-            </Dialog.Title>
-            <Dialog.Description className="sr-only">
-              Site navigation
-            </Dialog.Description>
+          <header className="flex shrink-0 items-start gap-4 border-b border-border/70 bg-card/90 px-4 py-[max(1rem,env(safe-area-inset-top))] sm:px-6 sm:py-5">
+            <div className="min-w-0 flex-1">
+              <Dialog.Title className="text-3xl font-semibold tracking-[-0.03em] sm:text-4xl">
+                Site Atlas
+              </Dialog.Title>
+              <Dialog.Description className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+                Rooms, instruments, repositories, and a few paths leading
+                outward.
+              </Dialog.Description>
+            </div>
             <Dialog.Close asChild>
               <button
                 type="button"
@@ -227,7 +261,7 @@ export function SiteAtlas({
             className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pb-6"
             data-site-atlas-scroll
           >
-            <div className="grid gap-5 lg:grid-cols-2 lg:gap-6">
+            <div className="grid gap-6 lg:grid-cols-2 lg:gap-7">
               {siteNavigationGroups.map(group => (
                 <section
                   key={group.id}
@@ -236,10 +270,13 @@ export function SiteAtlas({
                 >
                   <h2
                     id={`site-atlas-${group.id}`}
-                    className="mb-2 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+                    className="mb-1 text-xl font-semibold tracking-[-0.02em] text-foreground"
                   >
                     {group.label}
                   </h2>
+                  <p className="mb-3 text-xs leading-5 text-muted-foreground">
+                    {group.description}
+                  </p>
                   <div className="grid gap-2 sm:grid-cols-2">
                     {group.items.map(item => (
                       <AtlasLink

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -2,11 +2,18 @@
 
 import { SiteAtlas } from '@/components/site-atlas';
 import { ThemeToggle } from '@/components/theme-toggle';
-import { isNavigationItemActive, primaryNavigationItems } from '@/lib/site-navigation';
+import {
+  isNavigationItemActive,
+  primaryNavigationItems,
+} from '@/lib/site-navigation';
 import { Clock3 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
+
+const subscribeToHydration = () => () => {};
+const getHydratedSnapshot = () => true;
+const getServerSnapshot = () => false;
 
 function TimeLink({ active }: { active: boolean }) {
   const [time, setTime] = useState('--:--');
@@ -17,7 +24,7 @@ function TimeLink({ active }: { active: boolean }) {
         new Intl.DateTimeFormat(undefined, {
           hour: '2-digit',
           minute: '2-digit',
-        }).format(new Date()),
+        }).format(new Date())
       );
     };
 
@@ -32,10 +39,10 @@ function TimeLink({ active }: { active: boolean }) {
       prefetch
       aria-current={active ? 'page' : undefined}
       data-site-time
-      className={`group inline-flex h-11 shrink-0 items-center gap-1.5 rounded-full border px-2.5 text-xs font-semibold shadow-[0_3px_10px_rgba(20,20,24,0.08)] transition-[background-color,box-shadow] hover:bg-muted hover:shadow-[0_6px_14px_rgba(20,20,24,0.12)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transition-none dark:shadow-[0_4px_12px_rgba(0,0,0,0.28)] ${
+      className={`group inline-flex h-12 shrink-0 items-center gap-1.5 border-r border-border/60 px-3 text-xs font-semibold transition-colors hover:bg-muted/75 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring motion-reduce:transition-none ${
         active
-          ? 'border-foreground/30 bg-foreground/[0.075] text-foreground'
-          : 'border-border/70 bg-card text-foreground'
+          ? 'bg-foreground/[0.075] text-foreground'
+          : 'bg-transparent text-muted-foreground hover:text-foreground'
       }`}
       title="Open time"
       aria-label={`Open the time converter. Local time ${time}`}
@@ -48,36 +55,38 @@ function TimeLink({ active }: { active: boolean }) {
 
 export function SiteNavBar() {
   const pathname = usePathname() || '/';
-  const directItems = primaryNavigationItems.filter((item) => item.id !== 'home');
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    setReady(true);
-  }, []);
+  const directItems = primaryNavigationItems.filter(item => item.id !== 'home');
+  const ready = useSyncExternalStore(
+    subscribeToHydration,
+    getHydratedSnapshot,
+    getServerSnapshot
+  );
 
   return (
     <nav
       aria-label="Site navigation"
-      className="sticky top-0 z-50 h-12 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_1px_0_rgba(255,255,255,0.22),0_8px_24px_rgba(20,20,24,0.08)] dark:shadow-[0_1px_0_rgba(255,255,255,0.04),0_10px_28px_rgba(0,0,0,0.28)]"
+      className="sticky top-0 z-50 h-12 min-w-0 border-b border-border/70 bg-background text-foreground shadow-[0_8px_24px_rgba(20,20,24,0.06)] dark:shadow-[0_10px_28px_rgba(0,0,0,0.22)]"
       data-site-nav
       data-site-nav-ready={ready ? 'true' : undefined}
     >
-      <div className="mx-auto h-full max-w-7xl px-2 sm:px-4 lg:px-6">
-        <div className="flex h-full min-w-0 items-center gap-1 sm:gap-1.5">
+      <div className="mx-auto h-full max-w-7xl border-x border-border/50">
+        <div className="flex h-full min-w-0 items-center">
           <Link
             href="/"
             prefetch
             aria-current={pathname === '/' ? 'page' : undefined}
             data-site-home
-            className="inline-flex h-11 min-w-0 max-w-[8.5rem] shrink items-center truncate rounded-md px-1.5 text-sm font-bold tracking-tight focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:max-w-none sm:text-base"
+            className="inline-flex h-12 min-w-0 max-w-[8.5rem] shrink items-center truncate border-r border-border/60 px-3 text-sm font-bold tracking-tight transition-colors hover:bg-muted/55 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:max-w-none sm:px-4 sm:text-base"
           >
             teamleaderleo
           </Link>
 
-          <TimeLink active={pathname === '/time' || pathname.startsWith('/time/')} />
+          <TimeLink
+            active={pathname === '/time' || pathname.startsWith('/time/')}
+          />
 
-          <div className="ml-2 hidden min-w-0 flex-1 items-center justify-center gap-1 xl:flex">
-            {directItems.map((item) => {
+          <div className="hidden h-full min-w-0 flex-1 items-stretch justify-center xl:flex">
+            {directItems.map(item => {
               const active = isNavigationItemActive(pathname, item);
               return (
                 <Link
@@ -86,10 +95,10 @@ export function SiteNavBar() {
                   prefetch
                   aria-current={active ? 'page' : undefined}
                   data-site-primary-link={item.id}
-                  className={`inline-flex h-11 items-center rounded-full px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
+                  className={`relative inline-flex h-12 flex-1 items-center justify-center border-r border-border/45 px-4 text-sm font-medium transition-colors first:border-l focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
                     active
-                      ? 'bg-foreground text-background'
-                      : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      ? 'bg-foreground/[0.07] text-foreground after:absolute after:inset-x-3 after:bottom-0 after:h-0.5 after:bg-foreground'
+                      : 'text-muted-foreground hover:bg-muted/65 hover:text-foreground'
                   }`}
                 >
                   {item.label}
@@ -98,9 +107,9 @@ export function SiteNavBar() {
             })}
           </div>
 
-          <div className="ml-auto flex shrink-0 items-center gap-1">
-            <ThemeToggle />
-            <SiteAtlas />
+          <div className="ml-auto flex h-full shrink-0 items-stretch">
+            <ThemeToggle variant="rail" />
+            <SiteAtlas variant="rail" />
           </div>
         </div>
       </div>

--- a/components/snow-globe/snow-globe.tsx
+++ b/components/snow-globe/snow-globe.tsx
@@ -6,10 +6,18 @@ import { useReducedMotion } from 'framer-motion';
 import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 
-const SNOW_COUNT = 180;
-const GLOBE_CENTRE_Y = 0.25;
-const GLOBE_RADIUS = 2.3;
-const SNOW_FLOOR = -0.96;
+const SNOW_COUNT = 210;
+const GLOBE_CENTRE_Y = 0.34;
+const GLOBE_RADIUS = 2.34;
+const SNOW_FLOOR = -0.92;
+const CAMERA_DISTANCE = 7.25;
+const CAMERA_REFERENCE_ASPECT = 0.72;
+
+const cabinGable = new THREE.Shape();
+cabinGable.moveTo(-0.76, 0);
+cabinGable.lineTo(0.76, 0);
+cabinGable.lineTo(0, 0.72);
+cabinGable.closePath();
 
 function seededRandom(seed: number) {
   let value = seed >>> 0;
@@ -32,14 +40,37 @@ function createSnowParticles() {
     const angle = random() * Math.PI * 2;
     const distance = Math.sqrt(random()) * 1.95;
     positions[offset] = Math.cos(angle) * distance;
-    positions[offset + 1] = SNOW_FLOOR + random() * 3.15;
+    positions[offset + 1] = SNOW_FLOOR + random() * 3.2;
     positions[offset + 2] = Math.sin(angle) * distance;
-    velocities[offset] = (random() - 0.5) * 0.08;
-    velocities[offset + 1] = -random() * 0.08;
-    velocities[offset + 2] = (random() - 0.5) * 0.08;
+    velocities[offset] = (random() - 0.5) * 0.07;
+    velocities[offset + 1] = -random() * 0.07;
+    velocities[offset + 2] = (random() - 0.5) * 0.07;
   }
 
   return { positions, velocities };
+}
+
+function ResponsiveCamera() {
+  const camera = useThree(state => state.camera);
+  const width = useThree(state => state.size.width);
+  const height = useThree(state => state.size.height);
+  const invalidate = useThree(state => state.invalidate);
+
+  useEffect(() => {
+    const aspect = width / Math.max(height, 1);
+    const distance = Math.min(
+      11.2,
+      Math.max(
+        CAMERA_DISTANCE,
+        CAMERA_DISTANCE * (CAMERA_REFERENCE_ASPECT / aspect)
+      )
+    );
+    camera.position.set(0, 0.35, distance);
+    camera.updateProjectionMatrix();
+    invalidate();
+  }, [camera, height, invalidate, width]);
+
+  return null;
 }
 
 function Snowfall({
@@ -75,12 +106,12 @@ function Snowfall({
     for (let index = 0; index < SNOW_COUNT; index += 1) {
       const offset = index * 3;
       const angle = random() * Math.PI * 2;
-      const force = 1.6 + random() * 2.3;
+      const force = 1.8 + random() * 2.5;
       particleState.velocities[offset] += Math.cos(angle) * force;
-      particleState.velocities[offset + 1] = 2.4 + random() * 3.2;
+      particleState.velocities[offset + 1] = 2.8 + random() * 3.4;
       particleState.velocities[offset + 2] += Math.sin(angle) * force;
-      if (particleState.positions[offset + 1] < -0.72) {
-        particleState.positions[offset + 1] = -0.72 + random() * 0.35;
+      if (particleState.positions[offset + 1] < -0.65) {
+        particleState.positions[offset + 1] = -0.65 + random() * 0.42;
       }
     }
 
@@ -98,8 +129,8 @@ function Snowfall({
 
     for (let index = 0; index < SNOW_COUNT; index += 1) {
       const offset = index * 3;
-      velocities[offset + 1] -= 1.55 * delta;
-      const drag = Math.pow(0.988, delta * 60);
+      velocities[offset + 1] -= 1.62 * delta;
+      const drag = Math.pow(0.987, delta * 60);
       velocities[offset] *= drag;
       velocities[offset + 1] *= Math.pow(0.996, delta * 60);
       velocities[offset + 2] *= drag;
@@ -110,16 +141,16 @@ function Snowfall({
 
       if (positions[offset + 1] < SNOW_FLOOR) {
         positions[offset + 1] = SNOW_FLOOR;
-        velocities[offset] *= 0.76;
-        velocities[offset + 1] *= -0.16;
-        velocities[offset + 2] *= 0.76;
+        velocities[offset] *= 0.74;
+        velocities[offset + 1] *= -0.14;
+        velocities[offset + 2] *= 0.74;
       }
 
       const dx = positions[offset];
       const dy = positions[offset + 1] - GLOBE_CENTRE_Y;
       const dz = positions[offset + 2];
       const distance = Math.hypot(dx, dy, dz);
-      const limit = GLOBE_RADIUS - 0.07;
+      const limit = GLOBE_RADIUS - 0.08;
 
       if (distance > limit) {
         const scale = limit / Math.max(distance, 0.001);
@@ -134,9 +165,9 @@ function Snowfall({
           velocities[offset + 1] * ny +
           velocities[offset + 2] * nz;
         if (outward > 0) {
-          velocities[offset] -= nx * outward * 1.35;
-          velocities[offset + 1] -= ny * outward * 1.35;
-          velocities[offset + 2] -= nz * outward * 1.35;
+          velocities[offset] -= nx * outward * 1.36;
+          velocities[offset + 1] -= ny * outward * 1.36;
+          velocities[offset + 2] -= nz * outward * 1.36;
         }
       }
     }
@@ -150,64 +181,181 @@ function Snowfall({
       <bufferGeometry ref={geometry} />
       <pointsMaterial
         color="#fffdf5"
-        size={0.055}
+        size={0.052}
         sizeAttenuation
         transparent
-        opacity={0.9}
+        opacity={0.92}
         depthWrite={false}
       />
     </points>
   );
 }
 
-function Pine({ position, scale = 1 }: { position: [number, number, number]; scale?: number }) {
+function SnowPine({
+  position,
+  scale = 1,
+  rotation = 0,
+}: {
+  position: [number, number, number];
+  scale?: number;
+  rotation?: number;
+}) {
   return (
-    <group position={position} scale={scale}>
-      <mesh position={[0, -0.15, 0]}>
-        <cylinderGeometry args={[0.09, 0.12, 0.7, 8]} />
-        <meshStandardMaterial color="#594233" roughness={0.92} />
+    <group position={position} scale={scale} rotation={[0, rotation, 0]}>
+      <mesh position={[0, -0.18, 0]}>
+        <cylinderGeometry args={[0.075, 0.11, 0.72, 7]} />
+        <meshStandardMaterial color="#554035" roughness={0.96} />
       </mesh>
-      <mesh position={[0, 0.18, 0]}>
-        <coneGeometry args={[0.54, 1.05, 10]} />
-        <meshStandardMaterial color="#31594e" roughness={0.9} />
+      <mesh position={[0, 0.08, 0]}>
+        <coneGeometry args={[0.55, 0.78, 9]} />
+        <meshStandardMaterial color="#284d49" roughness={0.93} />
       </mesh>
-      <mesh position={[0, 0.58, 0]}>
-        <coneGeometry args={[0.42, 0.86, 10]} />
-        <meshStandardMaterial color="#3b685b" roughness={0.9} />
+      <mesh position={[0, 0.45, 0]}>
+        <coneGeometry args={[0.43, 0.75, 9]} />
+        <meshStandardMaterial color="#35605a" roughness={0.93} />
+      </mesh>
+      <mesh position={[0, 0.78, 0]}>
+        <coneGeometry args={[0.3, 0.62, 9]} />
+        <meshStandardMaterial color="#47726a" roughness={0.93} />
+      </mesh>
+      <mesh position={[0, 0.33, 0]}>
+        <coneGeometry args={[0.46, 0.16, 9]} />
+        <meshStandardMaterial color="#e5e6e2" roughness={1} />
+      </mesh>
+      <mesh position={[0, 0.68, 0]}>
+        <coneGeometry args={[0.34, 0.14, 9]} />
+        <meshStandardMaterial color="#f0f0eb" roughness={1} />
       </mesh>
     </group>
   );
 }
 
-function Cabin() {
+function Window({ position }: { position: [number, number, number] }) {
   return (
-    <group position={[-0.42, -0.5, 0.04]} rotation={[0, -0.12, 0]}>
+    <group position={position}>
       <mesh>
-        <boxGeometry args={[1.18, 0.78, 0.96]} />
-        <meshStandardMaterial color="#80574b" roughness={0.86} />
-      </mesh>
-      <mesh position={[0, 0.63, 0]} rotation={[0, Math.PI / 4, 0]}>
-        <coneGeometry args={[0.86, 0.72, 4]} />
-        <meshStandardMaterial color="#d7d1c5" roughness={0.96} />
-      </mesh>
-      <mesh position={[0.27, 0.86, -0.18]}>
-        <boxGeometry args={[0.18, 0.55, 0.2]} />
-        <meshStandardMaterial color="#65504a" roughness={0.9} />
-      </mesh>
-      <mesh position={[0, -0.15, 0.5]}>
-        <boxGeometry args={[0.27, 0.48, 0.035]} />
-        <meshStandardMaterial color="#4d3a34" roughness={0.92} />
-      </mesh>
-      <mesh position={[-0.36, 0.08, 0.5]}>
-        <boxGeometry args={[0.25, 0.23, 0.04]} />
+        <boxGeometry args={[0.34, 0.31, 0.045]} />
         <meshStandardMaterial
-          color="#ffd981"
-          emissive="#eaa83d"
-          emissiveIntensity={1.8}
+          color="#ffd77d"
+          emissive="#e99d32"
+          emissiveIntensity={1.5}
           toneMapped={false}
         />
       </mesh>
-      <pointLight position={[-0.36, 0.08, 0.72]} color="#ffc96b" intensity={3.2} distance={2.7} />
+      <mesh position={[0, 0, 0.026]}>
+        <boxGeometry args={[0.025, 0.33, 0.026]} />
+        <meshStandardMaterial color="#4d3b38" roughness={0.9} />
+      </mesh>
+      <mesh position={[0, 0, 0.027]}>
+        <boxGeometry args={[0.36, 0.025, 0.026]} />
+        <meshStandardMaterial color="#4d3b38" roughness={0.9} />
+      </mesh>
+    </group>
+  );
+}
+
+function ReadingCabin() {
+  return (
+    <group position={[-0.32, -0.32, 0.12]} rotation={[0, -0.08, 0]}>
+      <mesh position={[0, -0.64, 0]}>
+        <boxGeometry args={[1.72, 0.18, 1.34]} />
+        <meshStandardMaterial color="#6f5b52" roughness={0.94} />
+      </mesh>
+      <mesh position={[0, -0.17, 0]}>
+        <boxGeometry args={[1.52, 0.82, 1.16]} />
+        <meshStandardMaterial color="#976d5b" roughness={0.9} />
+      </mesh>
+      <mesh position={[0, 0.24, 0.586]}>
+        <shapeGeometry args={[cabinGable]} />
+        <meshStandardMaterial
+          color="#a67862"
+          roughness={0.92}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+
+      <mesh position={[-0.4, 0.46, 0]} rotation={[0, 0, 0.59]}>
+        <boxGeometry args={[1.08, 0.13, 1.5]} />
+        <meshStandardMaterial color="#51445b" roughness={0.82} />
+      </mesh>
+      <mesh position={[0.4, 0.46, 0]} rotation={[0, 0, -0.59]}>
+        <boxGeometry args={[1.08, 0.13, 1.5]} />
+        <meshStandardMaterial color="#51445b" roughness={0.82} />
+      </mesh>
+      <mesh position={[-0.41, 0.535, 0]} rotation={[0, 0, 0.59]}>
+        <boxGeometry args={[0.98, 0.055, 1.43]} />
+        <meshStandardMaterial color="#e7e4df" roughness={1} />
+      </mesh>
+      <mesh position={[0.41, 0.535, 0]} rotation={[0, 0, -0.59]}>
+        <boxGeometry args={[0.98, 0.055, 1.43]} />
+        <meshStandardMaterial color="#f0eee9" roughness={1} />
+      </mesh>
+
+      <mesh position={[0.31, 0.8, -0.17]}>
+        <boxGeometry args={[0.2, 0.58, 0.24]} />
+        <meshStandardMaterial color="#55464a" roughness={0.88} />
+      </mesh>
+      <mesh position={[0.31, 1.1, -0.17]}>
+        <boxGeometry args={[0.26, 0.08, 0.3]} />
+        <meshStandardMaterial color="#40363b" roughness={0.85} />
+      </mesh>
+
+      <mesh position={[0.32, -0.29, 0.598]}>
+        <boxGeometry args={[0.34, 0.58, 0.06]} />
+        <meshStandardMaterial color="#493b38" roughness={0.94} />
+      </mesh>
+      <mesh position={[0.21, -0.27, 0.635]}>
+        <sphereGeometry args={[0.025, 10, 8]} />
+        <meshStandardMaterial
+          color="#d7b46b"
+          metalness={0.35}
+          roughness={0.45}
+        />
+      </mesh>
+      <Window position={[-0.35, -0.12, 0.61]} />
+      <mesh position={[0.31, -0.62, 0.74]}>
+        <boxGeometry args={[0.58, 0.1, 0.34]} />
+        <meshStandardMaterial color="#776158" roughness={0.95} />
+      </mesh>
+      <pointLight
+        position={[-0.18, 0, 0.92]}
+        color="#ffc66b"
+        intensity={3.4}
+        distance={3.1}
+      />
+    </group>
+  );
+}
+
+function WinterGround() {
+  const stones = [
+    [-0.02, -0.8, 1.12],
+    [0.18, -0.79, 1.38],
+    [0.05, -0.78, 1.62],
+  ] as const;
+
+  return (
+    <group>
+      <mesh position={[0, -1.03, 0]} scale={[1, 0.24, 1]}>
+        <sphereGeometry args={[2.08, 36, 18]} />
+        <meshStandardMaterial color="#ebeae5" roughness={1} />
+      </mesh>
+      <mesh position={[0.82, -0.77, 0.92]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.5, 32]} />
+        <meshPhysicalMaterial
+          color="#8bb2c3"
+          roughness={0.18}
+          metalness={0.08}
+          clearcoat={0.9}
+          clearcoatRoughness={0.12}
+        />
+      </mesh>
+      {stones.map((position, index) => (
+        <mesh key={index} position={position} scale={[1, 0.35, 1]}>
+          <sphereGeometry args={[0.13, 12, 8]} />
+          <meshStandardMaterial color="#b7aaa0" roughness={0.96} />
+        </mesh>
+      ))}
     </group>
   );
 }
@@ -229,56 +377,91 @@ function GlobeScene({
   useFrame(({ clock }, delta) => {
     const group = world.current;
     if (!group || reducedMotion) return;
-    group.rotation.y += delta * 0.16;
+    const time = clock.elapsedTime;
+    group.rotation.y = -0.26 + Math.sin(time * 0.22) * 0.3;
     if (wobble.current > 0.002) {
-      const phase = clock.elapsedTime * 24;
-      group.rotation.z = Math.sin(phase) * 0.075 * wobble.current;
-      group.position.x = Math.cos(phase * 0.83) * 0.11 * wobble.current;
-      wobble.current *= Math.pow(0.035, delta);
+      const phase = time * 28;
+      group.rotation.z = Math.sin(phase) * 0.095 * wobble.current;
+      group.position.x = Math.cos(phase * 0.81) * 0.14 * wobble.current;
+      group.position.y = Math.sin(phase * 1.13) * 0.035 * wobble.current;
+      wobble.current *= Math.pow(0.03, delta);
     } else {
-      group.rotation.z *= 0.88;
-      group.position.x *= 0.88;
+      group.rotation.z *= 0.86;
+      group.position.x *= 0.86;
+      group.position.y *= 0.86;
     }
   });
 
   return (
     <>
-      <ambientLight intensity={1.35} />
-      <directionalLight position={[4, 6, 5]} intensity={2.6} color="#fff7df" />
-      <directionalLight position={[-4, 2, -3]} intensity={1.15} color="#9fbaff" />
+      <ambientLight intensity={1.2} />
+      <hemisphereLight args={['#dce8ff', '#392f41', 1.25]} />
+      <directionalLight position={[4, 6, 5]} intensity={2.4} color="#fff6dc" />
+      <directionalLight
+        position={[-4, 2, -3]}
+        intensity={1.25}
+        color="#8faee8"
+      />
 
-      <group ref={world} rotation={[0.03, -0.35, 0]}>
-        <mesh position={[0, -1.12, 0]} receiveShadow>
-          <cylinderGeometry args={[2.08, 2.18, 0.34, 48]} />
-          <meshStandardMaterial color="#e8e5dc" roughness={0.98} />
-        </mesh>
-        <Cabin />
-        <Pine position={[0.9, -0.47, -0.18]} scale={1.18} />
-        <Pine position={[1.42, -0.66, 0.24]} scale={0.72} />
-        <Pine position={[-1.38, -0.68, -0.42]} scale={0.64} />
+      <group ref={world} rotation={[0.025, -0.26, 0]}>
+        <WinterGround />
+        <ReadingCabin />
+        <SnowPine position={[1.2, -0.46, -0.28]} scale={1.05} rotation={0.3} />
+        <SnowPine position={[1.62, -0.66, 0.18]} scale={0.62} rotation={-0.4} />
+        <SnowPine position={[-1.5, -0.65, -0.44]} scale={0.58} rotation={0.7} />
         <Snowfall shakeSignal={shakeSignal} reducedMotion={reducedMotion} />
       </group>
 
       <mesh position={[0, GLOBE_CENTRE_Y, 0]} renderOrder={3}>
-        <sphereGeometry args={[2.42, 48, 32]} />
+        <sphereGeometry args={[2.43, 52, 36]} />
         <meshPhysicalMaterial
-          color="#bfd8ff"
+          color="#c7dcff"
           transparent
-          opacity={0.16}
-          roughness={0.08}
-          metalness={0.04}
+          opacity={0.13}
+          roughness={0.05}
+          metalness={0.02}
           clearcoat={1}
-          clearcoatRoughness={0.08}
+          clearcoatRoughness={0.04}
           depthWrite={false}
         />
       </mesh>
-      <mesh position={[0, -2.07, 0]}>
-        <cylinderGeometry args={[1.95, 2.28, 0.72, 56]} />
-        <meshStandardMaterial color="#3f333e" roughness={0.68} metalness={0.12} />
+      <mesh
+        position={[-0.78, 1.1, 2.1]}
+        rotation={[0.18, -0.32, -0.48]}
+        renderOrder={4}
+      >
+        <capsuleGeometry args={[0.045, 1.2, 6, 12]} />
+        <meshBasicMaterial
+          color="#ffffff"
+          transparent
+          opacity={0.28}
+          depthWrite={false}
+        />
       </mesh>
-      <mesh position={[0, -1.73, 0]} rotation={[Math.PI / 2, 0, 0]}>
-        <torusGeometry args={[1.98, 0.075, 12, 64]} />
-        <meshStandardMaterial color="#8b7184" roughness={0.5} metalness={0.2} />
+
+      <mesh position={[0, -2.02, 0]}>
+        <cylinderGeometry args={[1.94, 2.24, 0.68, 56]} />
+        <meshStandardMaterial
+          color="#302c39"
+          roughness={0.7}
+          metalness={0.16}
+        />
+      </mesh>
+      <mesh position={[0, -2.37, 0]}>
+        <cylinderGeometry args={[2.24, 2.1, 0.12, 56]} />
+        <meshStandardMaterial
+          color="#171821"
+          roughness={0.75}
+          metalness={0.1}
+        />
+      </mesh>
+      <mesh position={[0, -1.71, 0]} rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[1.98, 0.065, 12, 64]} />
+        <meshStandardMaterial
+          color="#9b7d75"
+          roughness={0.45}
+          metalness={0.32}
+        />
       </mesh>
     </>
   );
@@ -289,42 +472,44 @@ export function SnowGlobe() {
   const [shakeSignal, setShakeSignal] = useState(0);
 
   return (
-    <section className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[minmax(0,1fr)_15rem] lg:items-center">
+    <section className="min-h-0 flex-1">
       <div
-        className="relative min-h-[27rem] overflow-hidden rounded-[2rem] border border-border/70 bg-[radial-gradient(circle_at_50%_32%,#dbe7ff_0%,#afbfd9_30%,#667087_68%,#272a35_100%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.28),0_24px_70px_rgba(20,24,38,0.18)] dark:bg-[radial-gradient(circle_at_50%_30%,#354563_0%,#1f2738_38%,#10131c_76%,#090a0f_100%)] sm:min-h-[36rem]"
+        className="relative h-[calc(100dvh-4.75rem)] min-h-[32rem] max-h-[48rem] overflow-hidden rounded-[2rem] border border-border/70 bg-[radial-gradient(circle_at_50%_30%,#dbe7ff_0%,#9baecb_36%,#536078_70%,#242734_100%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.32),0_28px_80px_rgba(20,24,38,0.2)] dark:bg-[radial-gradient(circle_at_50%_28%,#3c5273_0%,#202a3d_40%,#11151f_76%,#08090e_100%)] sm:h-[38rem] lg:h-[min(46rem,calc(100dvh-8.5rem))]"
         data-snow-globe-stage
-        role="img"
-        aria-label="A dimensional snow globe with a warm cabin, pine trees, and simulated snow"
       >
-        <Canvas
-          camera={{ position: [0, 0.62, 7.2], fov: 43 }}
-          dpr={[1, 1.5]}
-          frameloop={reducedMotion ? 'demand' : 'always'}
-          gl={{
-            alpha: true,
-            antialias: false,
-            powerPreference: 'high-performance',
-          }}
-          data-snow-globe-canvas
+        <div
+          className="absolute inset-0"
+          role="img"
+          aria-label="A dimensional snow globe with a warm A-frame reading cabin, snowy pines, a frozen pond, and simulated snow"
+          data-snow-globe-scene
         >
-          <GlobeScene shakeSignal={shakeSignal} reducedMotion={reducedMotion} />
-        </Canvas>
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-1/3 bg-[linear-gradient(120deg,rgba(255,255,255,0.22),transparent_38%)]" aria-hidden="true" />
-      </div>
-
-      <div className="space-y-3">
-        <div className="rounded-2xl border border-border/70 bg-card p-4">
-          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-            Auto orbit
-          </p>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            The scene turns on its own. Rattle it when the snow settles.
-          </p>
+          <Canvas
+            camera={{ position: [0, 0.35, CAMERA_DISTANCE], fov: 42 }}
+            dpr={[1, 1.5]}
+            frameloop={reducedMotion ? 'demand' : 'always'}
+            gl={{
+              alpha: true,
+              antialias: false,
+              powerPreference: 'high-performance',
+            }}
+            data-snow-globe-canvas
+          >
+            <ResponsiveCamera />
+            <GlobeScene
+              shakeSignal={shakeSignal}
+              reducedMotion={reducedMotion}
+            />
+          </Canvas>
         </div>
+
+        <div
+          className="pointer-events-none absolute inset-0 bg-[linear-gradient(122deg,rgba(255,255,255,0.2),transparent_28%,transparent_72%,rgba(8,10,18,0.18))]"
+          aria-hidden="true"
+        />
         <button
           type="button"
           onClick={() => setShakeSignal(current => current + 1)}
-          className="inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border border-border/70 bg-foreground px-4 py-2 text-sm font-semibold text-background transition-transform active:scale-[0.97] motion-reduce:transition-none"
+          className="absolute bottom-4 left-1/2 inline-flex min-h-11 w-[calc(100%-2rem)] max-w-xs -translate-x-1/2 items-center justify-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-semibold text-[#181a22] shadow-[0_12px_32px_rgba(0,0,0,0.24)] transition-transform active:translate-y-px active:scale-[0.98] motion-reduce:transition-none sm:bottom-6 sm:w-auto"
           aria-label="Rattle the globe"
         >
           <RotateCcw className="h-4 w-4" aria-hidden="true" />

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -7,7 +7,11 @@ type ThemeTransitionDocument = Document & {
   startViewTransition?: (update: () => void) => { finished: Promise<unknown> };
 };
 
-export function ThemeToggle() {
+export function ThemeToggle({
+  variant = 'pill',
+}: {
+  variant?: 'pill' | 'rail';
+}) {
   const { setTheme } = useTheme();
 
   const toggle = () => {
@@ -39,7 +43,11 @@ export function ThemeToggle() {
     <button
       data-theme-toggle
       onClick={toggle}
-      className="group relative inline-flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/70 bg-card text-foreground shadow-[0_3px_10px_rgba(20,20,24,0.09)] transition-[background-color,color,transform,box-shadow] duration-300 hover:-translate-y-px hover:bg-muted hover:shadow-[0_6px_15px_rgba(20,20,24,0.13)] active:translate-y-0 active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:shadow-[0_4px_12px_rgba(0,0,0,0.3)] motion-reduce:transition-none"
+      className={
+        variant === 'rail'
+          ? 'group relative inline-flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden border-l border-border/60 bg-transparent text-foreground transition-colors duration-200 hover:bg-muted/75 active:bg-muted focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring motion-reduce:transition-none'
+          : 'group relative inline-flex h-11 w-11 shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/70 bg-card text-foreground shadow-[0_3px_10px_rgba(20,20,24,0.09)] transition-[background-color,color,transform,box-shadow] duration-300 hover:-translate-y-px hover:bg-muted hover:shadow-[0_6px_15px_rgba(20,20,24,0.13)] active:translate-y-0 active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:shadow-[0_4px_12px_rgba(0,0,0,0.3)] motion-reduce:transition-none'
+      }
       aria-label="Toggle light and dark mode"
       type="button"
     >

--- a/lib/site-navigation.test.ts
+++ b/lib/site-navigation.test.ts
@@ -20,6 +20,8 @@ describe('site navigation registry', () => {
         '/gallery',
         '/atelier',
         '/snow-globe',
+        'https://github.com/teamleaderleo/fieldwork',
+        'https://github.com/teamleaderleo/linux-fieldwork',
       ])
     );
     expect(hrefs).not.toContain('/blog');

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -2,6 +2,7 @@ export type SiteNavigationGroupId =
   | 'places'
   | 'tools'
   | 'experiments'
+  | 'repositories'
   | 'connections';
 
 export type SiteSurface =
@@ -153,6 +154,52 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         group: 'experiments',
         surface: 'experimental',
         badge: 'Lab',
+      },
+    ],
+  },
+  {
+    id: 'repositories',
+    label: 'Repositories',
+    description: 'Codebases that feed the notes and experiments here.',
+    items: [
+      {
+        id: 'scrapbook-repository',
+        href: 'https://github.com/teamleaderleo/scrapbook',
+        label: 'Scrapbook',
+        description:
+          'This site, its public rooms, and the experiments between them.',
+        group: 'repositories',
+        surface: 'external',
+        external: true,
+      },
+      {
+        id: 'fieldwork-repository',
+        href: 'https://github.com/teamleaderleo/fieldwork',
+        label: 'Fieldwork',
+        description: 'Close readings and contributions in working codebases.',
+        group: 'repositories',
+        surface: 'external',
+        external: true,
+      },
+      {
+        id: 'linux-fieldwork-repository',
+        href: 'https://github.com/teamleaderleo/linux-fieldwork',
+        label: 'Linux fieldwork',
+        description:
+          'Kernel-oriented investigations, patches, and study trails.',
+        group: 'repositories',
+        surface: 'external',
+        external: true,
+      },
+      {
+        id: 'smolrunner-repository',
+        href: 'https://github.com/teamleaderleo/smolrunner',
+        label: 'Smolrunner',
+        description:
+          'A careful host-work runner built around inspectable plans.',
+        group: 'repositories',
+        surface: 'external',
+        external: true,
       },
     ],
   },

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -172,6 +172,11 @@ test('keeps the scorecard planted and lets the visitor pet Scraplet', async ({
 
   await expect(scoreboard).toBeVisible({ timeout: 15_000 });
   await expect(pet).toHaveAttribute('data-pets', '0');
+  await expect(pet.locator('[data-paper-creature-tail]')).toHaveCount(1);
+  await expect(pet.locator('[data-paper-creature-tail-fold]')).toHaveCount(1);
+  await expect(
+    pet.locator('[data-paper-creature-back-plates] path')
+  ).toHaveCount(2);
 
   const scoreboardBefore = await scoreboard.boundingBox();
   expect(scoreboardBefore).not.toBeNull();

--- a/tests/e2e/material-system.spec.ts
+++ b/tests/e2e/material-system.spec.ts
@@ -196,6 +196,19 @@ test('captures the live paper counter choreography', async ({
     .last()
     .locator('[aria-hidden="true"]');
   await expect(lastDigitFaces).toHaveCount(3, { timeout: 3_000 });
+  await expect
+    .poll(
+      () =>
+        counter
+          .locator('[data-paper-digit-step]')
+          .evaluateAll(digits =>
+            digits.some(
+              digit => Number(digit.getAttribute('data-paper-digit-step')) >= 1
+            )
+          ),
+      { timeout: 3_000 }
+    )
+    .toBe(true);
   await scoreboard.screenshot({
     path: path.join(frameDirectory, '01-lift.png'),
     animations: 'allow',

--- a/tests/e2e/signal-space-appearance.spec.ts
+++ b/tests/e2e/signal-space-appearance.spec.ts
@@ -1,15 +1,16 @@
 import { expect, test } from '@playwright/test';
 
-test('Signal is a public read-only surface with a useful first paint', async ({
+test('Signal renders the dashboard without promotional framing', async ({
   page,
 }) => {
   const response = await page.goto('/proxy-dashboard');
   expect(response?.ok()).toBe(true);
 
-  await expect(
-    page.getByRole('heading', { name: 'Network pulse', level: 1 })
-  ).toBeVisible();
-  await expect(page.getByText('Signal', { exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Bandwidth' })).toBeVisible();
+  await expect(page.locator('body')).not.toContainText('Network pulse');
+  await expect(page.locator('body')).not.toContainText(
+    'One small path, reduced to the few numbers worth noticing.'
+  );
   await expect(page.locator('body')).not.toContainText(
     'Proxy dashboard access token'
   );

--- a/tests/e2e/site-navigation.spec.ts
+++ b/tests/e2e/site-navigation.spec.ts
@@ -22,7 +22,7 @@ async function expectNoHorizontalOverflow(
   expect(metrics.bodyWidth).toBeLessThanOrEqual(metrics.viewport + 1);
 }
 
-test('site atlas exposes visible places, tools, experiments, and connections', async ({
+test('site atlas exposes rooms, repositories, experiments, and connections', async ({
   page,
 }, testInfo) => {
   await page.setViewportSize({ width: 1440, height: 900 });
@@ -35,6 +35,9 @@ test('site atlas exposes visible places, tools, experiments, and connections', a
   await expect(atlas.getByRole('heading', { name: 'Tools' })).toBeVisible();
   await expect(
     atlas.getByRole('heading', { name: 'Experiments' })
+  ).toBeVisible();
+  await expect(
+    atlas.getByRole('heading', { name: 'Repositories' })
   ).toBeVisible();
   await expect(
     atlas.getByRole('heading', { name: 'Connections' })
@@ -56,6 +59,19 @@ test('site atlas exposes visible places, tools, experiments, and connections', a
   await expect(github).toHaveAttribute('rel', /noopener/);
   await expect(atlas.locator('[data-site-atlas-discord]')).toBeVisible();
   await expect(atlas.locator('[data-site-atlas-appearance]')).toBeVisible();
+
+  for (const [id, href] of [
+    ['scrapbook-repository', 'https://github.com/teamleaderleo/scrapbook'],
+    ['fieldwork-repository', 'https://github.com/teamleaderleo/fieldwork'],
+    [
+      'linux-fieldwork-repository',
+      'https://github.com/teamleaderleo/linux-fieldwork',
+    ],
+  ] as const) {
+    await expect(
+      atlas.locator(`[data-site-atlas-link="${id}"]`)
+    ).toHaveAttribute('href', href);
+  }
 
   await page.screenshot({
     path: testInfo.outputPath(

--- a/tests/e2e/snow-globe.spec.ts
+++ b/tests/e2e/snow-globe.spec.ts
@@ -11,18 +11,31 @@ test('opens the snow globe from the site atlas', async ({ page }) => {
   await link.click();
 
   await expect(page).toHaveURL(/\/snow-globe$/);
-  await expect(page.getByRole('heading', { name: 'Snow globe', level: 1 })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Snow globe', level: 1 })
+  ).toBeVisible();
   await expect(page.locator('[data-snow-globe-stage]')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Rattle the globe' })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Rattle the globe' })
+  ).toBeVisible();
 });
 
-test('renders an automatic dimensional scene with a deliberate rattle control', async ({ page }) => {
+test('renders an automatic dimensional scene with a deliberate rattle control', async ({
+  page,
+}) => {
   const response = await page.goto('/snow-globe');
   expect(response?.ok()).toBe(true);
 
   const stage = page.locator('[data-snow-globe-stage]');
   await expect(stage.locator('canvas')).toBeVisible();
-  await expect(stage).toHaveAttribute('aria-label', /dimensional snow globe/i);
+  await expect(stage.locator('[data-snow-globe-scene]')).toHaveAttribute(
+    'aria-label',
+    /A-frame reading cabin.*frozen pond/i
+  );
+  await expect(stage).not.toContainText('Winter reading room');
+  await expect(stage).not.toContainText(
+    'The cabin slowly turns through the glass.'
+  );
+  await expect(stage).not.toContainText('Auto turning');
   await page.getByRole('button', { name: 'Rattle the globe' }).click();
-  await expect(page.getByText('Auto orbit', { exact: true })).toBeVisible();
 });


### PR DESCRIPTION
## What changed

- makes the activity counter transition through granular paper leaves and clarifies Scraplet geometry
- turns the top navigation into a continuous opaque rail and expands Site Atlas with repository links
- rebuilds the snow globe as a responsive 3D reading-cabin scene with a single functional control
- restructures Signal as a compact factual bandwidth and latency dashboard with no promotional framing

## Why

The personal site had several visually unrelated controls, awkward spacing, and explanatory copy around utilities that should be self-evident. This pass gives the affected surfaces clearer material roles while preserving mobile reflow, reduced motion, public navigation, and operational boundaries.

## Validation

- local CI: 6/6 stages passed
- Vitest: 38 files, 311 tests
- Playwright Chromium: 110 tests
- production build: 28 routes
- scoped lint and typecheck passed
- desktop and mobile visual inspection completed for Home, Atlas, Snow Globe, and Signal

## Remaining review

This is a draft checkpoint before the next copy-austerity and Space restructuring slices.