### PR TITLE
Refine homepage composition and navigation

### DIFF
--- a/components/home/activity-grid.tsx
+++ b/components/home/activity-grid.tsx
@@ -169,7 +169,7 @@ export function ActivityGrid({
   return (
     <section
       ref={sectionRef}
-      className="min-w-0 overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_12px_28px_rgba(35,31,26,0.08)] dark:shadow-[0_14px_32px_rgba(0,0,0,0.25)] sm:p-4 [@media(max-height:780px)]:p-3"
+      className="flex min-w-0 flex-col overflow-hidden rounded-[1.25rem] border border-border/70 bg-card p-3.5 text-card-foreground shadow-[0_12px_28px_rgba(35,31,26,0.08)] dark:shadow-[0_14px_32px_rgba(0,0,0,0.25)] sm:p-4 [@media(max-height:780px)]:p-3"
       data-home-activity-grid
       data-fine-pointer={finePointer ? 'true' : 'false'}
     >
@@ -191,7 +191,7 @@ export function ActivityGrid({
         </div>
       </div>
 
-      <div className="mx-auto mt-3 grid w-full max-w-[15rem] grid-cols-[1.65rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 sm:max-w-[17rem] sm:gap-x-2.5 [@media(max-height:780px)]:mt-2">
+      <div className="mx-auto my-auto grid w-full max-w-[13.5rem] grid-cols-[1.65rem_minmax(0,1fr)] gap-x-2 gap-y-1.5 py-3 sm:max-w-[14rem] sm:gap-x-2.5 sm:py-4 [@media(max-height:780px)]:py-2">
         <span aria-hidden="true" />
         <div
           className="grid grid-cols-4 gap-1.5 px-px font-mono text-[8px] font-semibold uppercase tracking-[0.1em] text-muted-foreground sm:gap-2"

--- a/components/paper-creature.tsx
+++ b/components/paper-creature.tsx
@@ -108,11 +108,43 @@ export function PaperCreature({
           data-paper-creature-tail-fold
         />
 
+        <g data-paper-creature-back-plates>
+          <path
+            d="M22.5 18 27.5 11.5 32 18Z"
+            className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#ded8e3] dark:stroke-[#eeeaf2]"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M29.5 18 35.5 7.5 41 18Z"
+            className="fill-[#eee7f1] stroke-[#4d4852] dark:fill-[#c9c2d0] dark:stroke-[#eeeaf2]"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M37.5 18 43 10.5 48 18Z"
+            className="fill-[#e4dce9] stroke-[#4d4852] dark:fill-[#918a9b] dark:stroke-[#eeeaf2]"
+            strokeWidth="1.8"
+            strokeLinejoin="round"
+          />
+        </g>
+        <g
+          className="fill-none stroke-[#6b6470]/70 dark:stroke-[#c9c2d0]/70"
+          strokeWidth="0.85"
+          strokeLinecap="round"
+          data-paper-creature-back-folds
+        >
+          <path d="m27.5 11.5.5 6.5" />
+          <path d="m35.5 7.5 1 10.5" />
+          <path d="m43 10.5.5 7.5" />
+        </g>
+
         <path
           d="M22 17h25c9 0 15 6 15 14v2H20v-6c0-4 1-7 2-10Z"
           className="fill-[#cec4d6] stroke-[#4d4852] dark:fill-[#918a9b] dark:stroke-[#eeeaf2]"
           strokeWidth="2"
           strokeLinejoin="round"
+          data-paper-creature-torso
         />
         <path
           d="M42 8h14c6 0 10 4 10 10v10H43l-5-7 4-13Z"
@@ -120,21 +152,6 @@ export function PaperCreature({
           strokeWidth="2"
           strokeLinejoin="round"
         />
-        <g data-paper-creature-back-plates>
-          <path
-            d="m24 17 4.5-7 4.5 7Z"
-            className="fill-[#f7f2e9] stroke-[#4d4852] dark:fill-[#ded8e3] dark:stroke-[#eeeaf2]"
-            strokeWidth="1.8"
-            strokeLinejoin="round"
-          />
-          <path
-            d="m32 17 4.5-9.5 4.5 9.5Z"
-            className="fill-[#eee7f1] stroke-[#4d4852] dark:fill-[#c9c2d0] dark:stroke-[#eeeaf2]"
-            strokeWidth="1.8"
-            strokeLinejoin="round"
-          />
-        </g>
-
         {!sleeping ? (
           <path
             d="M28 32v8h8v-8M49 32v8h8v-8"

--- a/components/site-atlas.tsx
+++ b/components/site-atlas.tsx
@@ -97,7 +97,7 @@ function AtlasLink({
       aria-current={active ? 'page' : undefined}
       data-site-atlas-link={item.id}
       data-active={active ? 'true' : undefined}
-      className={`group flex min-h-[4.5rem] min-w-0 items-start gap-3 rounded-[1rem] border px-3 py-3 text-left transition-[background-color,border-color,transform] hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none ${
+      className={`group flex min-h-16 min-w-0 items-start gap-2.5 rounded-[0.9rem] border px-3 py-2.5 text-left transition-[background-color,border-color,transform] hover:-translate-y-px focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none ${
         active
           ? 'border-foreground/30 bg-foreground/[0.075]'
           : 'border-border/70 bg-background/55 hover:border-foreground/25 hover:bg-muted/70'
@@ -107,10 +107,10 @@ function AtlasLink({
         <ItemIcon id={item.id} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block text-[1.05rem] font-semibold leading-tight text-foreground">
+        <span className="block text-base font-semibold leading-tight text-foreground">
           {item.label}
         </span>
-        <span className="mt-1 block text-xs leading-[1.35rem] text-muted-foreground">
+        <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
           {item.description}
         </span>
       </span>
@@ -144,18 +144,18 @@ function AppearanceAction() {
         setTheme(isDark ? 'light' : 'dark');
       }}
       data-site-atlas-appearance
-      className="flex min-h-[4.5rem] w-full items-start gap-3 rounded-[1rem] border border-border/70 bg-background/55 px-3 py-3 text-left transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
+      className="flex min-h-16 w-full items-start gap-2.5 rounded-[0.9rem] border border-border/70 bg-background/55 px-3 py-2.5 text-left transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-card">
         <Sun className="h-4 w-4 dark:hidden" aria-hidden="true" />
         <Moon className="hidden h-4 w-4 dark:block" aria-hidden="true" />
       </span>
       <span className="min-w-0">
-        <span className="block text-[1.05rem] font-semibold leading-tight">
+        <span className="block text-base font-semibold leading-tight">
           Appearance
         </span>
-        <span className="mt-1 block text-xs leading-[1.35rem] text-muted-foreground">
-          Turn the paper and ink between day and night.
+        <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
+          Switch light or dark theme.
         </span>
       </span>
     </button>
@@ -179,17 +179,17 @@ function DiscordAction() {
       type="button"
       onClick={() => void copyDiscord()}
       data-site-atlas-discord
-      className="flex min-h-[4.5rem] w-full items-start gap-3 rounded-[1rem] border border-border/70 bg-background/55 px-3 py-3 text-left transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
+      className="flex min-h-16 w-full items-start gap-2.5 rounded-[0.9rem] border border-border/70 bg-background/55 px-3 py-2.5 text-left transition-[background-color,transform] hover:-translate-y-px hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 motion-reduce:transform-none"
     >
       <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-card">
         <DiscordIcon className="h-4 w-4" aria-hidden="true" />
       </span>
       <span className="min-w-0">
-        <span className="block text-[1.05rem] font-semibold leading-tight">
+        <span className="block text-base font-semibold leading-tight">
           Discord
         </span>
-        <span className="mt-1 block text-xs leading-[1.35rem] text-muted-foreground">
-          Copy the handle for a quieter conversation.
+        <span className="mt-0.5 block text-xs leading-5 text-muted-foreground">
+          Copy teamleaderleo.
         </span>
       </span>
     </button>
@@ -237,12 +237,11 @@ export function SiteAtlas({
         >
           <header className="flex shrink-0 items-start gap-4 border-b border-border/70 bg-card/90 px-4 py-[max(1rem,env(safe-area-inset-top))] sm:px-6 sm:py-5">
             <div className="min-w-0 flex-1">
-              <Dialog.Title className="text-3xl font-semibold tracking-[-0.03em] sm:text-4xl">
-                Site Atlas
+              <Dialog.Title className="text-3xl font-semibold tracking-[-0.03em]">
+                Atlas
               </Dialog.Title>
-              <Dialog.Description className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
-                Rooms, instruments, repositories, and a few paths leading
-                outward.
+              <Dialog.Description className="mt-1 max-w-2xl text-sm leading-5 text-muted-foreground">
+                Routes, repositories, and external profiles.
               </Dialog.Description>
             </div>
             <Dialog.Close asChild>
@@ -261,7 +260,7 @@ export function SiteAtlas({
             className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 pb-[max(1rem,env(safe-area-inset-bottom))] pt-4 sm:px-6 sm:pb-6"
             data-site-atlas-scroll
           >
-            <div className="grid gap-6 lg:grid-cols-2 lg:gap-7">
+            <div className="grid gap-5 lg:grid-cols-2 lg:gap-6">
               {siteNavigationGroups.map(group => (
                 <section
                   key={group.id}
@@ -270,11 +269,11 @@ export function SiteAtlas({
                 >
                   <h2
                     id={`site-atlas-${group.id}`}
-                    className="mb-1 text-xl font-semibold tracking-[-0.02em] text-foreground"
+                    className="mb-0.5 text-lg font-semibold tracking-[-0.02em] text-foreground"
                   >
                     {group.label}
                   </h2>
-                  <p className="mb-3 text-xs leading-5 text-muted-foreground">
+                  <p className="mb-2.5 text-xs leading-5 text-muted-foreground">
                     {group.description}
                   </p>
                   <div className="grid gap-2 sm:grid-cols-2">

--- a/components/site-nav-interactive.tsx
+++ b/components/site-nav-interactive.tsx
@@ -76,7 +76,7 @@ export function SiteNavBar() {
             prefetch
             aria-current={pathname === '/' ? 'page' : undefined}
             data-site-home
-            className="inline-flex h-12 min-w-0 max-w-[8.5rem] shrink items-center truncate border-r border-border/60 px-3 text-sm font-bold tracking-tight transition-colors hover:bg-muted/55 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:max-w-none sm:px-4 sm:text-base"
+            className="inline-flex h-12 min-w-0 flex-1 items-center truncate border-r border-border/60 px-3 text-sm font-bold tracking-tight transition-colors hover:bg-muted/55 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:max-w-none sm:flex-none sm:px-4 sm:text-base"
           >
             teamleaderleo
           </Link>
@@ -85,7 +85,7 @@ export function SiteNavBar() {
             active={pathname === '/time' || pathname.startsWith('/time/')}
           />
 
-          <div className="hidden h-full min-w-0 flex-1 items-stretch justify-center xl:flex">
+          <div className="hidden h-full min-w-0 flex-1 items-stretch justify-center sm:flex">
             {directItems.map(item => {
               const active = isNavigationItemActive(pathname, item);
               return (
@@ -95,7 +95,7 @@ export function SiteNavBar() {
                   prefetch
                   aria-current={active ? 'page' : undefined}
                   data-site-primary-link={item.id}
-                  className={`relative inline-flex h-12 flex-1 items-center justify-center border-r border-border/45 px-4 text-sm font-medium transition-colors first:border-l focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring ${
+                  className={`relative inline-flex h-12 min-w-0 flex-1 items-center justify-center border-r border-border/45 px-2 text-xs font-medium transition-colors first:border-l focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring lg:px-4 lg:text-sm ${
                     active
                       ? 'bg-foreground/[0.07] text-foreground after:absolute after:inset-x-3 after:bottom-0 after:h-0.5 after:bg-foreground'
                       : 'text-muted-foreground hover:bg-muted/65 hover:text-foreground'

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -42,13 +42,13 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
   {
     id: 'places',
     label: 'Places',
-    description: 'The main rooms of the scrapbook.',
+    description: 'Public routes.',
     items: [
       {
         id: 'home',
         href: '/',
         label: 'Home',
-        description: 'Recent activity and public work.',
+        description: 'Activity and repositories.',
         group: 'places',
         surface: 'public',
         primary: true,
@@ -58,7 +58,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'space',
         href: '/space',
         label: 'Space',
-        description: 'A public learning garden of notes, questions, and code.',
+        description: 'Public notes, questions, and code.',
         group: 'places',
         surface: 'public',
         primary: true,
@@ -69,7 +69,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'gallery',
         href: '/gallery',
         label: 'Gallery',
-        description: 'Visual objects and the agent guestbook.',
+        description: 'Artwork and the agent guestbook.',
         group: 'places',
         surface: 'public',
         primary: true,
@@ -80,7 +80,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'journal',
         href: '/journal',
         label: 'Journal',
-        description: 'Public field notes and agent work records.',
+        description: 'Field notes and agent records.',
         group: 'places',
         surface: 'public',
         primary: true,
@@ -91,7 +91,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'atelier',
         href: '/atelier',
         label: 'Atelier',
-        description: 'Interface sketches and experiments.',
+        description: 'Interface experiments.',
         group: 'places',
         surface: 'experimental',
         homeShelf: true,
@@ -102,7 +102,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
   {
     id: 'tools',
     label: 'Tools',
-    description: 'Focused utilities and operational views.',
+    description: 'Utilities and status.',
     items: [
       {
         id: 'time',
@@ -126,13 +126,13 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
   {
     id: 'experiments',
     label: 'Experiments',
-    description: 'Interactive prototypes.',
+    description: 'Prototypes.',
     items: [
       {
         id: 'snow-globe',
         href: '/snow-globe',
         label: 'Snow globe',
-        description: 'A motion-driven pocket snow globe.',
+        description: 'Interactive 3D scene.',
         group: 'experiments',
         surface: 'experimental',
         homeShelf: true,
@@ -141,7 +141,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'activity-lab',
         href: '/activity-lab',
         label: 'Activity geometry',
-        description: 'Activity-field comparisons.',
+        description: 'Calendar layout studies.',
         group: 'experiments',
         surface: 'experimental',
         badge: 'Lab',
@@ -150,7 +150,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'sigil-lab',
         href: '/sigil-lab',
         label: 'Sigil lab',
-        description: 'Generative identity studies.',
+        description: 'Generated identity studies.',
         group: 'experiments',
         surface: 'experimental',
         badge: 'Lab',
@@ -160,14 +160,13 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
   {
     id: 'repositories',
     label: 'Repositories',
-    description: 'Codebases that feed the notes and experiments here.',
+    description: 'Source repositories.',
     items: [
       {
         id: 'scrapbook-repository',
         href: 'https://github.com/teamleaderleo/scrapbook',
         label: 'Scrapbook',
-        description:
-          'This site, its public rooms, and the experiments between them.',
+        description: 'Source for this site.',
         group: 'repositories',
         surface: 'external',
         external: true,
@@ -176,7 +175,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'fieldwork-repository',
         href: 'https://github.com/teamleaderleo/fieldwork',
         label: 'Fieldwork',
-        description: 'Close readings and contributions in working codebases.',
+        description: 'Codebase investigations and contributions.',
         group: 'repositories',
         surface: 'external',
         external: true,
@@ -185,8 +184,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'linux-fieldwork-repository',
         href: 'https://github.com/teamleaderleo/linux-fieldwork',
         label: 'Linux fieldwork',
-        description:
-          'Kernel-oriented investigations, patches, and study trails.',
+        description: 'Linux and kernel studies.',
         group: 'repositories',
         surface: 'external',
         external: true,
@@ -195,8 +193,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         id: 'smolrunner-repository',
         href: 'https://github.com/teamleaderleo/smolrunner',
         label: 'Smolrunner',
-        description:
-          'A careful host-work runner built around inspectable plans.',
+        description: 'Host-work runner.',
         group: 'repositories',
         surface: 'external',
         external: true,
@@ -206,7 +203,7 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
   {
     id: 'connections',
     label: 'Connections',
-    description: 'External projects and public profiles.',
+    description: 'Profiles and external work.',
     items: [
       {
         id: 'glossless',

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -111,7 +111,7 @@ for (const viewport of desktopViewports) {
       footprint.recentSection.y
     );
     expect(footprint.activityCell.width).toBeGreaterThanOrEqual(36);
-    expect(footprint.activityCell.width).toBeLessThanOrEqual(72);
+    expect(footprint.activityCell.width).toBeLessThanOrEqual(44);
     expect(footprint.activityCell.height).toBeGreaterThanOrEqual(34);
     expect(footprint.activityCell.height).toBeLessThanOrEqual(72);
     expect(
@@ -179,7 +179,22 @@ test('keeps the scorecard planted and lets the visitor pet Scraplet', async ({
   await expect(pet.locator('[data-paper-creature-tail-fold]')).toHaveCount(1);
   await expect(
     pet.locator('[data-paper-creature-back-plates] path')
-  ).toHaveCount(2);
+  ).toHaveCount(3);
+  await expect(
+    pet.locator('[data-paper-creature-back-folds] path')
+  ).toHaveCount(3);
+  expect(
+    await pet.evaluate(element => {
+      const plates = element.querySelector('[data-paper-creature-back-plates]');
+      const torso = element.querySelector('[data-paper-creature-torso]');
+      return Boolean(
+        plates &&
+          torso &&
+          plates.compareDocumentPosition(torso) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+      );
+    })
+  ).toBe(true);
 
   const scoreboardBefore = await scoreboard.boundingBox();
   expect(scoreboardBefore).not.toBeNull();

--- a/tests/e2e/restored-home-time-contracts.spec.ts
+++ b/tests/e2e/restored-home-time-contracts.spec.ts
@@ -146,6 +146,48 @@ test('homepage has no one-pixel nav overflow and Atlas does not shift the layout
   expect(after.bodyPaddingRight).toBe(after.removedScrollbarSize);
 });
 
+test('navigation fills a phone rail and exposes room links when they fit', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+  await waitForHydratedHomepage(page);
+
+  const phone = await page.evaluate(() => {
+    const selectors = [
+      '[data-site-home]',
+      '[data-site-time]',
+      '[data-theme-toggle]',
+      '[data-site-atlas-trigger]',
+    ];
+    return selectors.map(selector => {
+      const element = document.querySelector<HTMLElement>(selector);
+      if (!element) throw new Error(`Missing ${selector}`);
+      const rect = element.getBoundingClientRect();
+      return { left: rect.left, right: rect.right, width: rect.width };
+    });
+  });
+
+  expect(phone[0]!.left).toBeLessThanOrEqual(1);
+  for (let index = 1; index < phone.length; index += 1) {
+    expect(Math.abs(phone[index]!.left - phone[index - 1]!.right)).toBeLessThan(
+      1
+    );
+  }
+  expect(phone.at(-1)!.right).toBeGreaterThanOrEqual(389);
+
+  await page.setViewportSize({ width: 740, height: 844 });
+  const roomLinks = page.locator('[data-site-primary-link]');
+  await expect(roomLinks).toHaveCount(3);
+  for (const link of await roomLinks.all()) {
+    await expect(link).toBeVisible();
+    const box = await link.boundingBox();
+    expect(box).toBeTruthy();
+    expect(box!.height).toBe(48);
+    expect(box!.width).toBeGreaterThanOrEqual(72);
+  }
+});
+
 test('timezone search recognises common city names', async ({ page }) => {
   await page.goto('/time');
   await page.locator('[data-timezone-trigger]').click();


### PR DESCRIPTION
## What changed\n\n- Make the activity calendar a compact field of true square cells.\n- Fill the responsive navigation rail intentionally on phone and tablet.\n- Tighten the Atlas and use literal route descriptions.\n- Rebuild Scraplet's back folds so they sit behind the torso.\n- Add responsive geometry and SVG-layering coverage.\n\n## Why\n\nThe homepage retained geometry from the earlier rectangular calendar, an inert navigation gap on small screens, overly spacious Atlas cards, and back plates painted over Scraplet's body.\n\n## Impact\n\nThe homepage is denser and better balanced from 390px through desktop widths. Navigation keeps full-size touch targets, the calendar has no horizontal overflow, and no client state or runtime dependency was added.\n\n## Validation\n\n- Local CI: 7 of 7 stages passed.\n- Lint: 0 errors; 34 existing warnings.\n- Typecheck passed.\n- Unit tests: 41 files and 322 tests passed.\n- Production build passed.\n- Playwright Chromium: 115 passed; 4 existing live-data tests skipped.\n- Focused browser verification passed at phone, tablet, and desktop widths.\n- Visual screenshots reviewed in light and dark modes.\n- Diff whitespace check passed.