### PR TITLE
Align Space loading states with current layout

### DIFF
--- a/app/space/read/[slug]/loading.tsx
+++ b/app/space/read/[slug]/loading.tsx
@@ -1,23 +1,74 @@
 import { Skeleton } from '@/components/ui/skeleton';
 
+function ReadingLines({ short = false }: { short?: boolean }) {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-3 w-full" />
+      <Skeleton className="h-3 w-11/12" />
+      <Skeleton className={`h-3 ${short ? 'w-3/5' : 'w-4/5'}`} />
+    </div>
+  );
+}
+
 export default function ReadingSheetLoading() {
   return (
-    <main className="min-h-screen bg-background px-3 py-3 sm:px-6 sm:py-6">
+    <main
+      className="min-h-screen bg-background px-3 py-3 text-foreground sm:px-6 sm:py-6"
+      aria-label="Loading reading sheet"
+      aria-busy="true"
+      role="status"
+      data-reading-sheet-loading
+    >
       <div className="mx-auto grid w-full max-w-6xl gap-4 lg:grid-cols-[13rem_minmax(0,46rem)] lg:justify-center lg:gap-8">
-        <Skeleton className="h-11 w-36 rounded-full" />
-        <div
-          className="material-paper min-h-[70vh] rounded-2xl border p-6 sm:p-9"
-          aria-label="Loading reading sheet"
-          role="status"
-        >
-          <Skeleton className="h-3 w-28" />
-          <Skeleton className="mt-5 h-10 w-4/5" />
-          <div className="mt-10 space-y-3">
-            <Skeleton className="h-3 w-full" />
-            <Skeleton className="h-3 w-11/12" />
-            <Skeleton className="h-3 w-4/5" />
+        <aside className="lg:sticky lg:top-6 lg:h-fit">
+          <Skeleton className="h-11 w-36 rounded-full" />
+          <div className="mt-3 flex gap-2 overflow-hidden pb-1 lg:block lg:space-y-1">
+            {Array.from({ length: 3 }, (_, index) => (
+              <Skeleton
+                key={index}
+                className={`h-11 shrink-0 rounded-lg lg:w-full ${
+                  index === 0 ? 'w-36' : index === 1 ? 'w-28' : 'w-32'
+                }`}
+              />
+            ))}
           </div>
-        </div>
+        </aside>
+
+        <article className="material-paper relative min-w-0 overflow-hidden rounded-2xl border shadow-[0_20px_55px_rgba(38,33,27,0.12)] dark:shadow-[0_20px_55px_rgba(0,0,0,0.34)]">
+          <header className="px-5 pb-5 pt-6 sm:px-9 sm:pb-7 sm:pt-9">
+            <Skeleton className="h-2.5 w-32" />
+            <Skeleton className="mt-5 h-9 w-4/5 sm:h-12" />
+            <div className="mt-5 flex gap-1.5">
+              <Skeleton className="h-6 w-16 rounded-full" />
+              <Skeleton className="h-6 w-24 rounded-full" />
+              <Skeleton className="h-6 w-20 rounded-full" />
+            </div>
+            <Skeleton className="mt-5 h-11 w-40 rounded-lg" />
+          </header>
+
+          <div className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)]">
+            <section className="px-5 py-7 sm:px-9 sm:py-9">
+              <div className="mb-5 flex items-baseline justify-between gap-4">
+                <Skeleton className="h-7 w-40" />
+                <Skeleton className="h-2.5 w-5" />
+              </div>
+              <ReadingLines />
+              <div className="mt-6 rounded-xl border border-[hsl(var(--material-paper-edge)/0.6)] bg-black/[0.025] p-4 dark:bg-white/[0.025]">
+                <Skeleton className="h-3 w-2/3" />
+                <Skeleton className="mt-3 h-3 w-5/6" />
+                <Skeleton className="mt-3 h-3 w-1/2" />
+              </div>
+            </section>
+
+            <section className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] px-5 py-7 sm:px-9 sm:py-9">
+              <div className="mb-5 flex items-baseline justify-between gap-4">
+                <Skeleton className="h-7 w-32" />
+                <Skeleton className="h-2.5 w-5" />
+              </div>
+              <ReadingLines short />
+            </section>
+          </div>
+        </article>
       </div>
     </main>
   );

--- a/components/space/space-shell-skeleton.tsx
+++ b/components/space/space-shell-skeleton.tsx
@@ -1,49 +1,56 @@
-function Line({ className = '' }: { className?: string }) {
+import { Skeleton } from '@/components/ui/skeleton';
+import { SPACE_LANES } from '@/lib/space-lanes';
+
+function SidebarRow({ width }: { width: string }) {
   return (
-    <span
-      className={`skeleton-surface block rounded ${className}`}
-      aria-hidden="true"
-      data-skeleton
-    />
+    <div className="flex h-8 items-center rounded-lg px-3">
+      <Skeleton className={`h-3.5 ${width}`} />
+    </div>
   );
 }
 
-function SidebarRows({ count }: { count: number }) {
+function LaneCard({ label, index }: { label: string; index: number }) {
   return (
-    <div className="space-y-2">
-      {Array.from({ length: count }, (_, index) => (
-        <div
-          key={index}
-          className="flex h-9 items-center gap-2 rounded-md px-3"
-        >
-          <Line className="h-4 w-4 shrink-0 rounded-sm" />
-          <Line
-            className={`h-4 ${index % 3 === 0 ? 'w-28' : index % 3 === 1 ? 'w-20' : 'w-24'}`}
-          />
-        </div>
-      ))}
+    <div
+      className="min-h-28 snap-start rounded-xl border border-border/65 bg-background/60 p-3"
+      data-space-loading-lane
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-semibold tracking-tight">{label}</span>
+        <Skeleton className="h-2.5 w-5 rounded-full" />
+      </div>
+      <div className="mt-3 space-y-2">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className={`h-3 ${index % 2 === 0 ? 'w-4/5' : 'w-2/3'}`} />
+      </div>
     </div>
   );
 }
 
 function ItemRow({ index }: { index: number }) {
   return (
-    <li className="rounded border border-border bg-white p-3 dark:border-sidebar-border dark:bg-sidebar">
-      <div className="flex items-start justify-between gap-3">
+    <li
+      className="material-paper relative overflow-hidden rounded-xl border px-4 py-3.5 pl-5"
+      data-space-loading-row
+    >
+      <span
+        aria-hidden="true"
+        className="absolute left-0 top-4 h-11 w-1.5 rounded-r-full bg-[#9baa88]/55"
+      />
+      <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <Line
-              className={`h-5 ${index % 2 === 0 ? 'w-44' : 'w-56'} max-w-full`}
+            <Skeleton
+              className={`h-5 ${index % 2 === 0 ? 'w-44' : 'w-56'} max-w-[72%]`}
             />
-            <Line className="h-7 w-12" />
-            <Line className="h-7 w-14" />
+            <Skeleton className="h-5 w-11 rounded-full" />
           </div>
-          <Line className="mt-2 h-3 w-64 max-w-full" />
+          <div className="mt-2 flex gap-1.5">
+            <Skeleton className="h-4 w-16 rounded-full" />
+            <Skeleton className="h-4 w-20 rounded-full" />
+          </div>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Line className="h-3 w-14" />
-          <Line className="h-4 w-4" />
-        </div>
+        <Skeleton className="mt-1 h-4 w-14 shrink-0" />
       </div>
     </li>
   );
@@ -52,50 +59,98 @@ function ItemRow({ index }: { index: number }) {
 export function SpaceShellSkeleton() {
   return (
     <div
-      className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground"
+      className="flex h-[100dvh] min-h-[100dvh] w-full min-w-0 overflow-hidden bg-background text-foreground"
       role="status"
       aria-label="Loading Space"
+      aria-busy="true"
+      data-space-loading-shell
     >
-      <aside className="hidden h-full w-64 shrink-0 flex-col border-r bg-sidebar text-sidebar-foreground md:flex">
-        <div className="flex h-12 shrink-0 items-center justify-between border-b px-4">
-          <span className="text-lg font-bold leading-none">teamleaderleo</span>
-          <Line className="h-8 w-8 rounded-md" />
+      <aside className="hidden h-full w-64 shrink-0 flex-col border-r border-border/70 bg-sidebar text-sidebar-foreground md:flex">
+        <div className="flex h-14 shrink-0 items-center justify-between border-b border-border/70 px-4">
+          <div>
+            <span className="block text-base font-semibold leading-none tracking-[-0.025em]">
+              teamleaderleo
+            </span>
+            <span className="mt-1 block font-mono text-[8px] uppercase tracking-[0.18em] text-muted-foreground">
+              space
+            </span>
+          </div>
+          <Skeleton className="h-8 w-8 rounded-lg" />
         </div>
-        <div className="shrink-0 border-b p-3">
-          <div className="flex h-10 items-center gap-2 rounded-md bg-muted/60 px-3">
-            <Line className="h-4 w-4" />
-            <Line className="h-4 w-20" />
+
+        <div className="shrink-0 border-b border-dashed border-border/70 p-3">
+          <div className="material-paper flex h-10 items-center gap-2 rounded-lg border px-3">
+            <Skeleton className="h-4 w-4 shrink-0 rounded-sm" />
+            <Skeleton className="h-3.5 w-24" />
           </div>
         </div>
+
         <div className="min-h-0 flex-1 overflow-hidden py-3">
-          <p className="px-4 text-xs font-medium text-muted-foreground">View</p>
-          <SidebarRows count={2} />
-          <p className="mt-4 px-4 text-xs font-medium text-muted-foreground">
-            Shortcuts
-          </p>
-          <SidebarRows count={6} />
+          <Skeleton className="mx-4 mb-2 h-2.5 w-14" />
+          <div className="space-y-0.5 px-2">
+            <SidebarRow width="w-20" />
+            <SidebarRow width="w-28" />
+            <SidebarRow width="w-16" />
+            <SidebarRow width="w-24" />
+            <SidebarRow width="w-20" />
+          </div>
+          <Skeleton className="mx-4 mb-2 mt-5 h-2.5 w-12" />
+          <div className="space-y-0.5 px-2">
+            <SidebarRow width="w-28" />
+            <SidebarRow width="w-20" />
+            <SidebarRow width="w-24" />
+          </div>
         </div>
-        <div className="shrink-0 space-y-2 border-t p-3">
-          <Line className="h-4 w-36" />
-          <Line className="h-9 w-full" />
+
+        <div className="shrink-0 space-y-2 border-t border-dashed border-border/70 p-3">
+          <Skeleton className="h-8 w-full rounded-lg" />
+          <Skeleton className="h-8 w-full rounded-lg" />
         </div>
       </aside>
 
       <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        <header className="flex h-12 shrink-0 items-center justify-between border-b bg-background px-3 sm:px-4">
-          <div className="flex items-center gap-3">
-            <Line className="h-8 w-8 rounded-md md:hidden" />
-            <Line className="h-4 w-24" />
-          </div>
-          <Line className="h-8 w-20" />
+        <header className="flex h-12 shrink-0 items-center gap-2 border-b border-dashed border-border/75 bg-background/88 px-2 sm:px-4">
+          <Skeleton className="h-8 w-8 rounded-lg" />
+          <Skeleton className="h-8 w-20 rounded-lg" />
+          <Skeleton className="hidden h-8 w-20 rounded-lg sm:block" />
+          <Skeleton className="h-2.5 w-24" />
+          <span className="flex-1" />
+          <Skeleton className="h-8 w-8 rounded-lg" />
         </header>
 
-        <main className="min-h-0 flex-1 overflow-hidden px-3 py-3 sm:p-4">
-          <ul className="space-y-2">
-            {Array.from({ length: 7 }, (_, index) => (
-              <ItemRow key={index} index={index} />
-            ))}
-          </ul>
+        <main className="relative min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:p-5">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-20"
+            style={{
+              backgroundImage:
+                'linear-gradient(rgba(67,58,46,0.035) 1px, transparent 1px), linear-gradient(90deg, rgba(67,58,46,0.035) 1px, transparent 1px)',
+              backgroundSize: '24px 24px',
+            }}
+          />
+
+          <div className="relative mx-auto w-full max-w-5xl">
+            <section className="mb-4 px-1">
+              <h1 className="text-xl font-semibold tracking-[-0.025em] sm:text-2xl">
+                Space
+              </h1>
+            </section>
+
+            <div
+              className="-mx-3 mb-5 grid snap-x snap-mandatory grid-flow-col auto-cols-[min(76vw,15rem)] gap-2 overflow-hidden px-3 pb-2 sm:mx-0 sm:grid-flow-row sm:grid-cols-2 sm:px-0 lg:grid-cols-4"
+              data-space-loading-lanes
+            >
+              {SPACE_LANES.map((lane, index) => (
+                <LaneCard key={lane.id} label={lane.label} index={index} />
+              ))}
+            </div>
+
+            <ul className="grid gap-3">
+              {Array.from({ length: 5 }, (_, index) => (
+                <ItemRow key={index} index={index} />
+              ))}
+            </ul>
+          </div>
         </main>
       </div>
     </div>

--- a/tests/e2e/space-loading.spec.ts
+++ b/tests/e2e/space-loading.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+for (const viewport of [
+  { name: 'phone', width: 390, height: 844 },
+  { name: 'desktop', width: 1280, height: 800 },
+] as const) {
+  test(`Space loading shell preserves the desk geometry on ${viewport.name}`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    await page.goto('/space', { waitUntil: 'commit' });
+
+    const shell = page.locator('[data-space-loading-shell]');
+    await expect(shell).toBeVisible();
+    await page.waitForFunction(() => {
+      const element = document.querySelector('[data-space-loading-shell]');
+      return element && getComputedStyle(element).display === 'flex';
+    });
+    await expect(shell.locator('[data-space-loading-lane]')).toHaveCount(4);
+    await expect(shell.locator('[data-space-loading-row]')).toHaveCount(5);
+
+    const geometry = await shell.evaluate(element => ({
+      shellHeight: element.getBoundingClientRect().height,
+      documentWidth: document.documentElement.scrollWidth,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
+      skeletonCount: element.querySelectorAll('[data-skeleton]').length,
+    }));
+
+    expect(geometry.shellHeight).toBe(geometry.viewportHeight);
+    expect(geometry.documentWidth).toBeLessThanOrEqual(geometry.viewportWidth);
+    expect(geometry.skeletonCount).toBeGreaterThanOrEqual(20);
+  });
+}


### PR DESCRIPTION
## What changed\n\n- Rebuild the Space shell fallback around the current sidebar, header, four public lanes, and paper rows.\n- Rebuild the reading-sheet fallback around its responsive sidebar, metadata header, sections, and code block.\n- Give loading landmarks explicit busy semantics and stable test hooks.\n- Add phone and desktop contracts for viewport coverage, lane and row counts, shimmer surfaces, and horizontal containment.\n\n## Why\n\nThe old Space fallback still depicted a retired sidebar/list interface, while the reading fallback collapsed most of the final page into a few lines. Both produced a visible geometry jump. The shell also used a height utility that did not emit the intended viewport height in this Tailwind setup, so it collapsed to its contents while streaming.\n\n## Impact\n\nSlow Space navigations now show an honest preview of the page that will replace them. The fallback fills the dynamic viewport, preserves mobile and desktop composition, uses the existing low-motion shimmer treatment, and adds no client JavaScript.\n\n## Validation\n\n- Local CI passed all 7 stages in 76.3 seconds.\n- Lint: 0 errors; 34 existing warnings.\n- Typecheck passed.\n- Unit tests: 41 files and 322 tests passed.\n- Production build passed.\n- Playwright Chromium: 117 passed; 4 existing live-data tests skipped.\n- Focused loading-state contract: 2 of 2 passed.\n- Forced-streaming screenshots inspected at 390 by 844 and 1280 by 800.\n- Diff whitespace check passed.