### PR TITLE
Add a private Space practice composer

### DIFF
--- a/app/space/read/[slug]/loading.tsx
+++ b/app/space/read/[slug]/loading.tsx
@@ -68,6 +68,20 @@ export default function ReadingSheetLoading() {
               <ReadingLines short />
             </section>
           </div>
+
+          <section className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] px-4 py-6 sm:px-9 sm:py-9">
+            <Skeleton className="h-2.5 w-24" />
+            <Skeleton className="mt-3 h-7 w-44" />
+            <Skeleton className="mt-3 h-3 w-4/5" />
+            <div className="mt-5 overflow-hidden rounded-[1.35rem] border border-[hsl(var(--material-paper-edge)/0.7)] p-4">
+              <Skeleton className="h-5 w-3/4" />
+              <Skeleton className="mt-4 h-36 w-full rounded-xl" />
+              <div className="mt-4 flex items-center justify-between gap-3 border-t border-[hsl(var(--material-paper-edge)/0.55)] pt-3">
+                <Skeleton className="h-11 w-48 rounded-xl" />
+                <Skeleton className="h-11 w-24 rounded-xl" />
+              </div>
+            </div>
+          </section>
         </article>
       </div>
     </main>

--- a/app/space/read/[slug]/page.tsx
+++ b/app/space/read/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { ArrowLeft, ArrowUpRight } from 'lucide-react';
 import { CodeDisplay } from '@/components/space/code-display';
 import { MarkdownContent } from '@/components/space/markdown-content';
+import { ReadingPracticeDock } from '@/components/space/reading-practice-dock';
 import { PageCurl, StitchedRule } from '@/components/cozy-flourishes';
 import { resolveSpaceLane } from '@/lib/space-lanes';
 import { displaySpaceTags } from '@/lib/space-tags';
@@ -191,6 +192,12 @@ export default async function ReadingSheetPage({
               </section>
             ))}
           </div>
+
+          <ReadingPracticeDock
+            slug={item.slug}
+            title={item.title}
+            sourceUrl={item.url}
+          />
 
           <PageCurl className="h-10 w-10 opacity-70 [&>span]:h-10 [&>span]:w-10" />
           <span className="material-paper-edge" aria-hidden="true" />

--- a/components/space/reading-practice-dock.test.ts
+++ b/components/space/reading-practice-dock.test.ts
@@ -1,0 +1,23 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { ReadingPracticeDock } from './reading-practice-dock';
+
+describe('ReadingPracticeDock', () => {
+  it('renders a private question-first practice surface without fake chat', () => {
+    const html = renderToStaticMarkup(
+      createElement(ReadingPracticeDock, {
+        slug: 'atomic-cache-publication',
+        title: 'Atomic cache publication',
+        sourceUrl: 'https://example.com/source',
+      })
+    );
+
+    expect(html).toContain('Continue the thread');
+    expect(html).toContain('Nothing is sent or scored.');
+    expect(html).toContain('Question notes');
+    expect(html).toContain('Copy prompt');
+    expect(html).toContain('Saved on this device');
+    expect(html).not.toContain('Assistant');
+  });
+});

--- a/components/space/reading-practice-dock.tsx
+++ b/components/space/reading-practice-dock.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useCallback, useState, useSyncExternalStore } from 'react';
+import {
+  buildSpacePracticePrompt,
+  SPACE_PRACTICE_MODES,
+  spacePracticeStorageKey,
+  type SpacePracticeMode,
+} from '@/lib/space-practice';
+
+const DRAFT_EVENT = 'space-practice-draft';
+const memoryDrafts = new Map<string, string>();
+
+function useLocalPracticeDraft(key: string) {
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      const onChange = (event: Event) => {
+        if (event instanceof StorageEvent && event.key !== key) return;
+        if (event instanceof CustomEvent && event.detail !== key) return;
+        listener();
+      };
+
+      window.addEventListener('storage', onChange);
+      window.addEventListener(DRAFT_EVENT, onChange);
+      return () => {
+        window.removeEventListener('storage', onChange);
+        window.removeEventListener(DRAFT_EVENT, onChange);
+      };
+    },
+    [key]
+  );
+  const getSnapshot = useCallback(() => {
+    try {
+      return window.localStorage.getItem(key) ?? memoryDrafts.get(key) ?? '';
+    } catch {
+      return memoryDrafts.get(key) ?? '';
+    }
+  }, [key]);
+  const draft = useSyncExternalStore(subscribe, getSnapshot, () => '');
+  const setDraft = useCallback(
+    (value: string) => {
+      if (value) memoryDrafts.set(key, value);
+      else memoryDrafts.delete(key);
+
+      try {
+        if (value) window.localStorage.setItem(key, value);
+        else window.localStorage.removeItem(key);
+      } catch {
+        // The in-memory draft remains usable when storage is unavailable.
+      }
+      window.dispatchEvent(new CustomEvent(DRAFT_EVENT, { detail: key }));
+    },
+    [key]
+  );
+
+  return [draft, setDraft] as const;
+}
+
+export function ReadingPracticeDock({
+  slug,
+  title,
+  sourceUrl,
+}: {
+  slug: string;
+  title: string;
+  sourceUrl?: string | null;
+}) {
+  const [mode, setMode] = useState<SpacePracticeMode>('question');
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
+    'idle'
+  );
+  const storageKey = spacePracticeStorageKey(slug, mode);
+  const [draft, setDraft] = useLocalPracticeDraft(storageKey);
+  const modeDefinition =
+    SPACE_PRACTICE_MODES.find(item => item.id === mode) ??
+    SPACE_PRACTICE_MODES[0];
+
+  const chooseMode = (nextMode: SpacePracticeMode) => {
+    setMode(nextMode);
+    setCopyState('idle');
+  };
+
+  const copyPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(
+        buildSpacePracticePrompt({
+          mode,
+          title,
+          sourceUrl,
+          draft,
+        })
+      );
+      setCopyState('copied');
+    } catch {
+      setCopyState('failed');
+    }
+  };
+
+  return (
+    <section
+      aria-labelledby="practice-bench-title"
+      className="border-t border-dashed border-[hsl(var(--material-paper-edge)/0.65)] px-4 py-6 sm:px-9 sm:py-9"
+      data-reading-practice
+    >
+      <header className="mx-auto max-w-[68ch]">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-[hsl(var(--material-paper-ink)/0.5)]">
+          Practice bench
+        </p>
+        <h2
+          id="practice-bench-title"
+          className="mt-2 text-xl font-semibold tracking-[-0.025em] sm:text-2xl"
+        >
+          Continue the thread
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-[hsl(var(--material-paper-ink)/0.64)]">
+          A private scratchpad for this reading. Nothing is sent or scored.
+        </p>
+      </header>
+
+      <div className="mx-auto mt-5 max-w-[68ch] overflow-hidden rounded-[1.35rem] border border-[hsl(var(--material-paper-edge)/0.7)] bg-[hsl(var(--material-paper-face)/0.48)] shadow-[0_10px_30px_rgba(39,34,28,0.08)] dark:shadow-[0_12px_32px_rgba(0,0,0,0.22)]">
+        <div className="px-4 pb-2 pt-4 sm:px-5 sm:pt-5">
+          <div className="flex items-center gap-2">
+            <span className="grid h-7 w-7 place-items-center rounded-full bg-[hsl(var(--material-paper-ink)/0.08)] font-mono text-[9px] font-semibold uppercase tracking-[0.08em]">
+              You
+            </span>
+            <p className="text-sm font-medium leading-6">
+              {modeDefinition.prompt}
+            </p>
+          </div>
+        </div>
+
+        <textarea
+          value={draft}
+          onChange={event => {
+            setDraft(event.target.value);
+            setCopyState('idle');
+          }}
+          aria-label={`${modeDefinition.label} notes`}
+          placeholder="Write a thought, a rough answer, or the next question…"
+          rows={5}
+          className="block min-h-36 w-full resize-y bg-transparent px-4 py-3 text-[15px] leading-7 text-[hsl(var(--material-paper-ink))] outline-none placeholder:text-[hsl(var(--material-paper-ink)/0.38)] focus-visible:bg-white/20 dark:focus-visible:bg-black/10 sm:px-5"
+        />
+
+        <footer className="flex flex-col gap-3 border-t border-[hsl(var(--material-paper-edge)/0.55)] bg-[hsl(var(--material-paper-ink)/0.025)] px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <div
+            className="grid grid-cols-3 gap-1 rounded-xl bg-[hsl(var(--material-paper-ink)/0.045)] p-1"
+            role="group"
+            aria-label="Practice mode"
+          >
+            {SPACE_PRACTICE_MODES.map(item => {
+              const active = item.id === mode;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => chooseMode(item.id)}
+                  className={`h-11 rounded-lg px-3 text-xs font-medium transition-[background-color,color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--material-paper-ink)/0.35)] ${
+                    active
+                      ? 'bg-[hsl(var(--material-paper-face))] text-[hsl(var(--material-paper-ink))] shadow-sm'
+                      : 'text-[hsl(var(--material-paper-ink)/0.58)] hover:text-[hsl(var(--material-paper-ink))]'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
+            {draft ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setDraft('');
+                  setCopyState('idle');
+                }}
+                className="h-11 rounded-lg px-3 text-xs font-medium text-[hsl(var(--material-paper-ink)/0.58)] hover:bg-[hsl(var(--material-paper-ink)/0.05)] hover:text-[hsl(var(--material-paper-ink))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--material-paper-ink)/0.35)]"
+              >
+                Clear
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void copyPrompt()}
+              className="h-11 rounded-xl border border-[hsl(var(--material-paper-edge)/0.8)] bg-[hsl(var(--material-paper-ink))] px-4 text-xs font-semibold text-[hsl(var(--material-paper-face))] transition-[transform,box-shadow] hover:-translate-y-px hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--material-paper-ink)/0.35)]"
+            >
+              {copyState === 'copied' ? 'Copied' : 'Copy prompt'}
+            </button>
+          </div>
+        </footer>
+      </div>
+
+      <p
+        className="mx-auto mt-2 max-w-[68ch] px-1 font-mono text-[9px] uppercase tracking-[0.1em] text-[hsl(var(--material-paper-ink)/0.42)]"
+        aria-live="polite"
+      >
+        {copyState === 'failed'
+          ? 'Clipboard unavailable · select the text manually'
+          : 'Saved on this device · one draft per mode'}
+      </p>
+    </section>
+  );
+}

--- a/lib/space-practice.test.ts
+++ b/lib/space-practice.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSpacePracticePrompt,
+  spacePracticeStorageKey,
+} from './space-practice';
+
+describe('Space practice prompts', () => {
+  it('keeps local drafts isolated by study and practice mode', () => {
+    expect(spacePracticeStorageKey('cache-identity', 'question')).toBe(
+      'space:practice:cache-identity:question'
+    );
+    expect(spacePracticeStorageKey('cache-identity', 'trace')).not.toBe(
+      spacePracticeStorageKey('cache-identity', 'question')
+    );
+  });
+
+  it('builds a portable prompt with provenance and optional notes', () => {
+    expect(
+      buildSpacePracticePrompt({
+        mode: 'trace',
+        title: 'Atomic cache publication',
+        sourceUrl: 'https://example.com/source',
+        draft: '  Start at the temporary file.  ',
+      })
+    ).toBe(
+      [
+        'Trace one concrete input through the system, step by step.',
+        '',
+        'Study: Atomic cache publication',
+        'Source: https://example.com/source',
+        '',
+        'My notes:',
+        'Start at the temporary file.',
+      ].join('\n')
+    );
+  });
+
+  it('does not invent an empty notes block', () => {
+    expect(
+      buildSpacePracticePrompt({
+        mode: 'question',
+        title: 'A bounded question',
+        sourceUrl: null,
+        draft: '   ',
+      })
+    ).not.toContain('My notes:');
+  });
+});

--- a/lib/space-practice.ts
+++ b/lib/space-practice.ts
@@ -1,0 +1,48 @@
+export const SPACE_PRACTICE_MODES = [
+  {
+    id: 'question',
+    label: 'Question',
+    prompt: 'What is still unclear, or what would change the explanation?',
+  },
+  {
+    id: 'explain',
+    label: 'Explain',
+    prompt: 'Explain the central mechanism in your own words.',
+  },
+  {
+    id: 'trace',
+    label: 'Trace',
+    prompt: 'Trace one concrete input through the system, step by step.',
+  },
+] as const;
+
+export type SpacePracticeMode = (typeof SPACE_PRACTICE_MODES)[number]['id'];
+
+export function spacePracticeStorageKey(slug: string, mode: SpacePracticeMode) {
+  return `space:practice:${slug}:${mode}`;
+}
+
+export function buildSpacePracticePrompt({
+  mode,
+  title,
+  sourceUrl,
+  draft,
+}: {
+  mode: SpacePracticeMode;
+  title: string;
+  sourceUrl?: string | null;
+  draft: string;
+}) {
+  const definition = SPACE_PRACTICE_MODES.find(item => item.id === mode);
+  const lines: string[] = [
+    definition?.prompt ?? SPACE_PRACTICE_MODES[0].prompt,
+  ];
+
+  lines.push('', `Study: ${title}`);
+  if (sourceUrl) lines.push(`Source: ${sourceUrl}`);
+
+  const trimmedDraft = draft.trim();
+  if (trimmedDraft) lines.push('', 'My notes:', trimmedDraft);
+
+  return lines.join('\n');
+}

--- a/tests/e2e/space-reading-sheet.spec.ts
+++ b/tests/e2e/space-reading-sheet.spec.ts
@@ -47,6 +47,21 @@ for (const study of [
     await expect(
       page.getByRole('link', { name: 'Back to fieldwork' })
     ).toHaveAttribute('href', '/space?lane=fieldwork');
+    const practice = page.locator('[data-reading-practice]');
+    await expect(
+      practice.getByRole('heading', { name: 'Continue the thread' })
+    ).toBeVisible();
+    await expect(
+      practice.getByRole('group', { name: 'Practice mode' }).getByRole('button')
+    ).toHaveCount(3);
+    await expect(practice.getByLabel('Question notes')).toBeVisible();
+    const practiceModeHeights = await practice
+      .getByRole('group', { name: 'Practice mode' })
+      .getByRole('button')
+      .evaluateAll(buttons =>
+        buttons.map(button => button.getBoundingClientRect().height)
+      );
+    expect(practiceModeHeights.every(height => height >= 44)).toBe(true);
 
     const backLink = page.getByRole('link', { name: 'Back to fieldwork' });
     const backHeight = await backLink.evaluate(


### PR DESCRIPTION
## What changed\n\n- Add a calm practice composer to every public Space reading sheet.\n- Support Question, Explain, and Trace modes with one private draft per mode.\n- Persist drafts only in the current browser, with an in-memory fallback when storage is unavailable.\n- Copy a portable prompt containing the exercise, study title, pinned source, and optional notes.\n- Match the composer in the reading-sheet loading geometry.\n- Add prompt, server-render, touch-target, and live reading-sheet contracts.\n\n## Why\n\nSpace needs an inviting bridge from passive reading into questions and teach-back. Current ChatGPT and Claude project/artifact surfaces work well because conversation stays calm and secondary to a durable work object. This applies that relationship without pretending an assistant is present or publishing private notes.\n\n## Impact\n\nReaders can respond to a lesson immediately on phone or desktop, switch between complementary learning actions, return to browser-local drafts, or carry a source-backed prompt into another tool. Nothing is sent, scored, or written to the Space database.\n\n## Validation\n\n- Local CI passed all 7 stages in 76.5 seconds.\n- Lint: 0 errors; 34 existing warnings.\n- Typecheck passed.\n- Unit tests: 43 files and 326 tests passed.\n- Production build passed.\n- Playwright Chromium: 117 passed; 4 existing live-data tests skipped.\n- Live direct reading-sheet layouts passed at phone light, phone dark, and desktop light.\n- Manual browser flow verified mode isolation, reload persistence, clipboard provenance, 44px targets, and no overflow in phone light and desktop dark.\n- One separate live archive-list navigation check encountered the known external Supabase fetch failure; the changed direct reading surface passed all three live runs.\n- Diff whitespace check passed.