### PR TITLE
Build a personalized Space learning trail

### DIFF
--- a/app/space/data.test.ts
+++ b/app/space/data.test.ts
@@ -103,4 +103,39 @@ describe('withSpaceTimeout', () => {
     expect(from).toHaveBeenCalledWith('items');
     expect(from).not.toHaveBeenCalledWith('reviews');
   });
+
+  it('starts the public archive request while identity is still loading', async () => {
+    let resolveIdentity: (value: {
+      data: { user: null };
+      error: null;
+    }) => void = () => undefined;
+    const identity = new Promise<{ data: { user: null }; error: null }>(
+      resolve => {
+        resolveIdentity = resolve;
+      }
+    );
+    const abortSignal = vi.fn().mockResolvedValue({ data: [], error: null });
+    const query = {
+      select: vi.fn(),
+      order: vi.fn(),
+      range: vi.fn(),
+      abortSignal,
+    };
+    query.select.mockReturnValue(query);
+    query.order.mockReturnValue(query);
+    query.range.mockReturnValue(query);
+    createClient.mockResolvedValue({
+      auth: { getUser: vi.fn().mockReturnValue(identity) },
+      from: vi.fn().mockReturnValue(query),
+    });
+
+    const pending = loadInitialSpaceData();
+    await vi.waitFor(() => expect(abortSignal).toHaveBeenCalledOnce());
+    resolveIdentity({ data: { user: null }, error: null });
+
+    await expect(pending).resolves.toMatchObject({
+      items: [],
+      isAdmin: false,
+    });
+  });
 });

--- a/app/space/data.ts
+++ b/app/space/data.ts
@@ -91,44 +91,48 @@ export async function loadInitialSpaceData(): Promise<InitialSpaceData> {
   }
 
   const supabase = await createClient();
-  let user: User | null = null;
-  try {
-    const authResult = await withSpaceTimeout(
-      supabase.auth.getUser(),
-      AUTH_TIMEOUT_MS,
-      'Space identity'
-    );
-    user = authResult.error ? null : authResult.data.user;
-  } catch (authError) {
-    console.warn('Space identity check did not complete:', authError);
-  }
-
-  const isAdmin = isAdminUser(user);
+  const userPromise: Promise<User | null> = withSpaceTimeout(
+    supabase.auth.getUser(),
+    AUTH_TIMEOUT_MS,
+    'Space identity'
+  )
+    .then(authResult => (authResult.error ? null : authResult.data.user))
+    .catch(authError => {
+      console.warn('Space identity check did not complete:', authError);
+      return null;
+    });
 
   const itemsAbortController = new AbortController();
   let itemsResult;
   try {
-    itemsResult = await withSpaceTimeout(
-      supabase
-        .from('items')
-        .select(SPACE_ITEM_SELECT)
-        .order('created_at', { ascending: false })
-        .range(0, SPACE_PAGE_SIZE - 1)
-        .abortSignal(itemsAbortController.signal),
-      INITIAL_LOAD_TIMEOUT_MS,
-      'Space archive',
-      () => itemsAbortController.abort()
-    );
+    [, itemsResult] = await Promise.all([
+      userPromise,
+      withSpaceTimeout(
+        supabase
+          .from('items')
+          .select(SPACE_ITEM_SELECT)
+          .order('created_at', { ascending: false })
+          .range(0, SPACE_PAGE_SIZE - 1)
+          .abortSignal(itemsAbortController.signal),
+        INITIAL_LOAD_TIMEOUT_MS,
+        'Space archive',
+        () => itemsAbortController.abort()
+      ),
+    ]);
   } catch (itemsError) {
     console.error('Space archive could not be loaded:', itemsError);
+    const user = await userPromise;
     return {
       ...unavailableSpaceData(
         'Space could not open the archive. Try again in a moment.'
       ),
       user,
-      isAdmin,
+      isAdmin: isAdminUser(user),
     };
   }
+
+  const user = await userPromise;
+  const isAdmin = isAdminUser(user);
 
   if (itemsResult.error) {
     console.error('Space archive could not be loaded:', itemsResult.error);

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -30,7 +30,7 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
         initialHasMore={hasMore}
         initialError={error}
       >
-        <div className="flex h-dvh min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
+        <div className="flex h-[100dvh] min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
           <SearchCommand />
           <AppSidebar />
           <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">

--- a/app/space/read/[slug]/page.tsx
+++ b/app/space/read/[slug]/page.tsx
@@ -12,7 +12,7 @@ import { loadReadingSheet } from '../data';
 
 type ReadingSheetPageProps = {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ lane?: string; tags?: string }>;
+  searchParams: Promise<{ lane?: string; tags?: string; from?: string }>;
 };
 
 function sectionId(label: string, index: number) {
@@ -75,7 +75,10 @@ export default async function ReadingSheetPage({
   });
   const backQuery = new URLSearchParams({ lane });
   if (query.tags?.trim()) backQuery.set('tags', query.tags.trim());
-  const backHref = `/space?${backQuery.toString()}`;
+  const fromTrail = query.from === 'trail';
+  const backHref = fromTrail
+    ? '/space/trail'
+    : `/space?${backQuery.toString()}`;
   const versions = item.versions.map((version, index) => ({
     ...version,
     id: sectionId(version.label, index),
@@ -93,7 +96,7 @@ export default async function ReadingSheetPage({
             className="inline-flex min-h-[44px] items-center gap-2 rounded-full border border-border/70 bg-background/80 px-4 text-sm font-medium backdrop-blur transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-            Back to {lane}
+            Back to {fromTrail ? 'trail' : lane}
           </Link>
 
           {orderedVersions.length > 1 ? (

--- a/app/space/trail/page.tsx
+++ b/app/space/trail/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import { SpaceTrail } from '@/components/space/space-trail';
+
+export const metadata: Metadata = {
+  title: 'Trail · Space',
+  description: 'A phone-friendly trail through the public learning archive.',
+  alternates: { canonical: '/space/trail' },
+};
+
+export default function SpaceTrailPage() {
+  return <SpaceTrail />;
+}

--- a/components/space/app-sidebar.tsx
+++ b/components/space/app-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   LogOut,
   Plus,
   Search,
+  Waves,
 } from 'lucide-react';
 import { shortcuts } from '@/app/lib/sidebar-data';
 import { useItems } from '@/app/lib/contexts/item-context';
@@ -52,6 +53,7 @@ export function AppSidebar() {
     pathname === '/space/review' ||
     pathname?.startsWith('/space/add') ||
     pathname?.startsWith('/space/edit');
+  const isListView = pathname === '/space';
   const { user, isAdmin, signOut } = useItems();
   const [loading, setLoading] = useState(false);
   const currentParams = new URLSearchParams();
@@ -145,7 +147,7 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar className="flex h-dvh max-h-dvh max-w-[calc(100vw-0.75rem)] flex-col border-r border-border/70 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] md:h-svh md:max-h-svh md:pb-0 md:pt-0">
+    <Sidebar className="flex h-[100dvh] max-h-[100dvh] max-w-[calc(100vw-0.75rem)] flex-col border-r border-border/70 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] md:h-[100svh] md:max-h-[100svh] md:pb-0 md:pt-0">
       <SidebarHeader className="m-0 h-14 shrink-0 border-b border-border/70 bg-background/85 p-0 text-foreground backdrop-blur-sm">
         <div className="flex h-full items-center justify-between px-4">
           <Link
@@ -218,11 +220,28 @@ export function AppSidebar() {
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    className="mx-2 rounded-lg px-3"
+                    isActive={pathname === '/space/trail'}
+                    asChild
+                  >
+                    <Link
+                      href="/space/trail"
+                      onClick={closeMobile}
+                      className="flex items-center gap-2"
+                    >
+                      <Waves className="h-4 w-4 shrink-0" aria-hidden="true" />
+                      <span className="min-w-0 flex-1 truncate">Trail</span>
+                      <SpaceLinkHint />
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
                 {SPACE_LANES.map(lane => (
                   <SidebarMenuItem key={lane.id}>
                     <SidebarMenuButton
                       className="mx-2 rounded-lg px-3"
-                      isActive={!isReviewLike && currentLane === lane.id}
+                      isActive={isListView && currentLane === lane.id}
                       asChild
                     >
                       <Link

--- a/components/space/space-trail.tsx
+++ b/components/space/space-trail.tsx
@@ -1,0 +1,461 @@
+'use client';
+
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpRight,
+  Check,
+  RotateCcw,
+  SlidersHorizontal,
+  ThumbsDown,
+  ThumbsUp,
+} from 'lucide-react';
+import { useItems } from '@/app/lib/contexts/item-context';
+import { SpaceHeader } from '@/components/space/space-header';
+import { displaySpaceTags } from '@/lib/space-tags';
+import {
+  EMPTY_SPACE_TRAIL_MEMORY,
+  markSpaceTrailOpened,
+  parseSpaceTrailMemory,
+  rankSpaceTrail,
+  setSpaceTrailResume,
+  updateSpaceTrailReaction,
+  type SpaceTrailMemory,
+  type SpaceTrailReaction,
+  type SpaceTrailRecommendation,
+} from '@/lib/space-trail';
+
+const TRAIL_MEMORY_KEY = 'scrapbook:space-trail:v1';
+const LOAD_MORE_THRESHOLD = 8;
+
+function readMemory() {
+  try {
+    return parseSpaceTrailMemory(window.localStorage.getItem(TRAIL_MEMORY_KEY));
+  } catch {
+    return EMPTY_SPACE_TRAIL_MEMORY;
+  }
+}
+
+function writeMemory(memory: SpaceTrailMemory) {
+  try {
+    window.localStorage.setItem(TRAIL_MEMORY_KEY, JSON.stringify(memory));
+  } catch {
+    // The current session remains personalized when storage is unavailable.
+  }
+}
+
+function TrailReactionButton({
+  label,
+  reaction,
+  activeReaction,
+  onSelect,
+  icon,
+}: {
+  label: string;
+  reaction: SpaceTrailReaction;
+  activeReaction?: SpaceTrailReaction;
+  onSelect: (reaction: SpaceTrailReaction) => void;
+  icon: React.ReactNode;
+}) {
+  const active = activeReaction === reaction;
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={() => onSelect(reaction)}
+      className={`inline-flex min-h-[44px] items-center justify-center gap-2 rounded-xl border px-3 text-xs font-medium transition-[background-color,border-color,color,transform] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.98] ${
+        active
+          ? 'border-foreground/35 bg-foreground text-background'
+          : 'border-border/75 bg-background/65 text-muted-foreground hover:border-foreground/25 hover:text-foreground'
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function TrailCard({
+  recommendation,
+  index,
+  total,
+  reaction,
+  onReaction,
+  onOpen,
+}: {
+  recommendation: SpaceTrailRecommendation;
+  index: number;
+  total: number;
+  reaction?: SpaceTrailReaction;
+  onReaction: (reaction: SpaceTrailReaction) => void;
+  onOpen: () => void;
+}) {
+  const { item, estimatedMinutes, excerpt, reasons } = recommendation;
+  const tags = displaySpaceTags(item.tags).slice(0, 5);
+  const isStoppingPoint = (index + 1) % 12 === 0;
+
+  return (
+    <section
+      className="grid min-h-full snap-start snap-always place-items-center px-3 py-4 sm:px-6 sm:py-8"
+      data-trail-index={index}
+      data-trail-item={item.id}
+    >
+      <article
+        className="material-paper relative flex w-full max-w-2xl flex-col overflow-hidden rounded-[1.6rem] border shadow-[0_22px_70px_rgba(43,37,29,0.12)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.32)]"
+        style={{ contentVisibility: 'auto', containIntrinsicSize: '780px' }}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-dashed border-[hsl(var(--material-paper-edge)/0.62)] px-5 py-4 sm:px-7">
+          <p className="min-w-0 truncate font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[hsl(var(--material-paper-ink)/0.55)]">
+            {item.category} · {estimatedMinutes} min
+          </p>
+          <p className="shrink-0 font-mono text-[9px] tabular-nums text-[hsl(var(--material-paper-ink)/0.42)]">
+            {String(index + 1).padStart(2, '0')} / {total}
+          </p>
+        </div>
+
+        <div className="px-5 pb-5 pt-6 sm:px-7 sm:pb-7 sm:pt-8">
+          <h2 className="max-w-[23ch] text-balance text-[clamp(1.75rem,7vw,3.15rem)] font-semibold leading-[1.02] tracking-[-0.042em] text-[hsl(var(--material-paper-ink))]">
+            {item.title}
+          </h2>
+
+          {excerpt ? (
+            <p className="mt-5 max-w-[62ch] text-[15px] leading-7 text-[hsl(var(--material-paper-ink)/0.7)] sm:text-base">
+              {excerpt}
+            </p>
+          ) : null}
+
+          {tags.length > 0 ? (
+            <div className="mt-5 flex flex-wrap gap-1.5" aria-label="Topics">
+              {tags.map((tag, tagIndex) => (
+                <span
+                  key={`${tag}-${tagIndex}`}
+                  className="rounded-full border border-[hsl(var(--material-paper-edge)/0.68)] bg-[hsl(var(--material-paper-face)/0.55)] px-2.5 py-1 text-[10px] text-[hsl(var(--material-paper-ink)/0.62)]"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          <details className="group mt-6 rounded-xl border border-[hsl(var(--material-paper-edge)/0.62)] bg-[hsl(var(--material-paper-ink)/0.025)] px-3.5 py-3 text-xs text-[hsl(var(--material-paper-ink)/0.62)]">
+            <summary className="cursor-pointer list-none font-medium text-[hsl(var(--material-paper-ink)/0.72)] focus-visible:outline-none group-open:mb-2">
+              Why this?
+            </summary>
+            <ul className="space-y-1.5 leading-5">
+              {reasons.map(reason => (
+                <li key={reason}>· {reason}</li>
+              ))}
+            </ul>
+          </details>
+
+          <div className="mt-6 grid grid-cols-3 gap-2">
+            <TrailReactionButton
+              label="More"
+              reaction="more"
+              activeReaction={reaction}
+              onSelect={onReaction}
+              icon={<ThumbsUp className="h-3.5 w-3.5" aria-hidden="true" />}
+            />
+            <TrailReactionButton
+              label="Less"
+              reaction="less"
+              activeReaction={reaction}
+              onSelect={onReaction}
+              icon={<ThumbsDown className="h-3.5 w-3.5" aria-hidden="true" />}
+            />
+            <TrailReactionButton
+              label="Learned"
+              reaction="learned"
+              activeReaction={reaction}
+              onSelect={onReaction}
+              icon={<Check className="h-3.5 w-3.5" aria-hidden="true" />}
+            />
+          </div>
+
+          <Link
+            href={`/space/read/${encodeURIComponent(item.slug)}?lane=archive&from=trail`}
+            prefetch
+            onClick={onOpen}
+            className="mt-3 inline-flex min-h-[48px] w-full items-center justify-center gap-2 rounded-xl bg-[hsl(var(--material-paper-ink))] px-4 text-sm font-semibold text-[hsl(var(--material-paper-face))] transition-[transform,box-shadow] hover:-translate-y-px hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--material-paper-ink)/0.4)] active:translate-y-0"
+          >
+            Open study
+            <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+          </Link>
+
+          {isStoppingPoint ? (
+            <p className="mt-4 text-center font-mono text-[9px] uppercase tracking-[0.12em] text-[hsl(var(--material-paper-ink)/0.45)]">
+              A good place to stop · or keep swiping
+            </p>
+          ) : null}
+        </div>
+        <span className="material-paper-edge" aria-hidden="true" />
+      </article>
+    </section>
+  );
+}
+
+export function SpaceTrail() {
+  const { items, nowMs, hasMore, loadMore, loadingMore, error, reload } =
+    useItems();
+  const seed = `space-trail:${new Date(nowMs).toISOString().slice(0, 10)}`;
+  const scrollerRef = useRef<HTMLElement>(null);
+  const initializedRef = useRef(false);
+  const resumedRef = useRef(false);
+  const [memory, setMemory] = useState<SpaceTrailMemory>(
+    EMPTY_SPACE_TRAIL_MEMORY
+  );
+  const [recommendations, setRecommendations] = useState(() =>
+    rankSpaceTrail(items, EMPTY_SPACE_TRAIL_MEMORY, { seed, nowMs })
+  );
+  const [activeIndex, setActiveIndex] = useState(0);
+  const scrollToIndex = useCallback(
+    (index: number, behavior: ScrollBehavior = 'smooth') => {
+      const scroller = scrollerRef.current;
+      const target = scroller?.querySelector<HTMLElement>(
+        `[data-trail-index="${index}"]`
+      );
+      target?.scrollIntoView({ behavior, block: 'start' });
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+    const storedMemory = readMemory();
+    setMemory(storedMemory);
+    setRecommendations(rankSpaceTrail(items, storedMemory, { seed, nowMs }));
+  }, [items, nowMs, seed]);
+
+  useEffect(() => {
+    if (!initializedRef.current) return;
+    setRecommendations(current => {
+      const knownIds = new Set(current.map(entry => entry.item.id));
+      const additions = items.filter(item => !knownIds.has(item.id));
+      if (additions.length === 0) return current;
+      return [
+        ...current,
+        ...rankSpaceTrail(additions, memory, { seed, nowMs }),
+      ];
+    });
+  }, [items, memory, nowMs, seed]);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+    if (!scroller) return;
+    const sections =
+      scroller.querySelectorAll<HTMLElement>('[data-trail-index]');
+    const observer = new IntersectionObserver(
+      entries => {
+        const visible = entries
+          .filter(entry => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (!visible) return;
+        const index = Number(
+          (visible.target as HTMLElement).dataset.trailIndex ?? 0
+        );
+        setActiveIndex(index);
+        const itemId = (visible.target as HTMLElement).dataset.trailItem;
+        if (itemId) {
+          setMemory(current => {
+            if (!resumedRef.current && current.resumeId) return current;
+            const nextMemory = setSpaceTrailResume(current, itemId);
+            if (nextMemory !== current) writeMemory(nextMemory);
+            return nextMemory;
+          });
+        }
+      },
+      { root: scroller, threshold: [0.6, 0.8] }
+    );
+    sections.forEach(section => observer.observe(section));
+    return () => observer.disconnect();
+  }, [recommendations.length]);
+
+  useEffect(() => {
+    if (resumedRef.current || !memory.resumeId) return;
+    const index = recommendations.findIndex(
+      entry => entry.item.id === memory.resumeId
+    );
+    if (index < 0) return;
+    resumedRef.current = true;
+    requestAnimationFrame(() => scrollToIndex(index, 'auto'));
+  }, [memory.resumeId, recommendations, scrollToIndex]);
+
+  useEffect(() => {
+    if (
+      activeIndex < recommendations.length - LOAD_MORE_THRESHOLD ||
+      !hasMore ||
+      loadingMore
+    ) {
+      return;
+    }
+    void loadMore();
+  }, [activeIndex, hasMore, loadMore, loadingMore, recommendations.length]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName.toLowerCase();
+      if (
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+
+      if (event.key === 'ArrowDown' || event.key.toLowerCase() === 'j') {
+        event.preventDefault();
+        scrollToIndex(Math.min(activeIndex + 1, recommendations.length - 1));
+      }
+      if (event.key === 'ArrowUp' || event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        scrollToIndex(Math.max(activeIndex - 1, 0));
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [activeIndex, recommendations.length, scrollToIndex]);
+
+  const chooseReaction = (itemId: string, reaction: SpaceTrailReaction) => {
+    const nextReaction =
+      memory.reactions[itemId] === reaction ? null : reaction;
+    const nextMemory = updateSpaceTrailReaction(memory, itemId, nextReaction);
+    setMemory(nextMemory);
+    writeMemory(nextMemory);
+
+    setRecommendations(current => {
+      const prefix = current.slice(0, activeIndex + 1);
+      const fixedIds = new Set(prefix.map(entry => entry.item.id));
+      const remaining = items.filter(item => !fixedIds.has(item.id));
+      return [
+        ...prefix,
+        ...rankSpaceTrail(remaining, nextMemory, { seed, nowMs }),
+      ];
+    });
+  };
+
+  const markOpened = (itemId: string) => {
+    const nextMemory = markSpaceTrailOpened(memory, itemId);
+    setMemory(nextMemory);
+    writeMemory(nextMemory);
+  };
+
+  const resetPersonalization = () => {
+    const nextMemory = EMPTY_SPACE_TRAIL_MEMORY;
+    setMemory(nextMemory);
+    try {
+      window.localStorage.removeItem(TRAIL_MEMORY_KEY);
+    } catch {
+      // The in-memory reset still applies.
+    }
+    setRecommendations(rankSpaceTrail(items, nextMemory, { seed, nowMs }));
+    setActiveIndex(0);
+    scrollerRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const headerStatus = useMemo(() => {
+    const position = recommendations.length > 0 ? activeIndex + 1 : 0;
+    return `${position} / ${recommendations.length}${hasMore ? '+' : ''}${
+      loadingMore ? ' · loading' : ''
+    }`;
+  }, [activeIndex, hasMore, loadingMore, recommendations.length]);
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col bg-background">
+      <SpaceHeader
+        leftContent={headerStatus}
+        centerContent={
+          <Link
+            href="/space"
+            prefetch
+            className="inline-flex h-8 items-center gap-1.5 rounded-lg border border-transparent px-2 text-sm font-medium text-muted-foreground transition hover:border-border/60 hover:bg-muted/65 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <SlidersHorizontal className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden sm:inline">Archive</span>
+          </Link>
+        }
+        rightContent={
+          <button
+            type="button"
+            onClick={resetPersonalization}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-muted/65 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Reset Trail personalization"
+            title="Reset Trail personalization"
+          >
+            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+          </button>
+        }
+      />
+
+      <main
+        ref={scrollerRef}
+        className="relative h-0 min-h-0 flex-1 snap-y snap-mandatory overflow-y-auto overscroll-y-contain bg-[radial-gradient(circle_at_12%_8%,hsl(var(--muted)/0.6),transparent_32%),radial-gradient(circle_at_88%_78%,hsl(var(--muted)/0.48),transparent_28%)] [scrollbar-gutter:stable] [touch-action:pan-y]"
+        aria-label="Personalized learning trail"
+        data-space-trail
+      >
+        <h1 className="sr-only">Learning trail</h1>
+        {recommendations.map((recommendation, index) => (
+          <TrailCard
+            key={recommendation.item.id}
+            recommendation={recommendation}
+            index={index}
+            total={recommendations.length}
+            reaction={memory.reactions[recommendation.item.id]}
+            onReaction={reaction =>
+              chooseReaction(recommendation.item.id, reaction)
+            }
+            onOpen={() => markOpened(recommendation.item.id)}
+          />
+        ))}
+
+        {recommendations.length === 0 ? (
+          <div className="grid min-h-full place-items-center px-4 text-center">
+            <div className="max-w-sm">
+              <p className="text-lg font-semibold">No studies loaded</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {error ?? 'The public archive is empty.'}
+              </p>
+              {error ? (
+                <button
+                  type="button"
+                  onClick={() => void reload()}
+                  className="mt-4 min-h-[44px] rounded-xl border px-4 text-sm font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Try again
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </main>
+
+      <nav
+        aria-label="Trail controls"
+        className="pointer-events-none absolute bottom-[max(0.75rem,env(safe-area-inset-bottom))] right-3 z-20 hidden gap-1 sm:flex"
+      >
+        <button
+          type="button"
+          onClick={() => scrollToIndex(Math.max(activeIndex - 1, 0))}
+          className="pointer-events-auto grid h-10 w-10 place-items-center rounded-full border bg-background/85 text-muted-foreground shadow-sm backdrop-blur hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Previous study"
+        >
+          <ArrowUp className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            scrollToIndex(Math.min(activeIndex + 1, recommendations.length - 1))
+          }
+          className="pointer-events-auto grid h-10 w-10 place-items-center rounded-full border bg-background/85 text-muted-foreground shadow-sm backdrop-blur hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Next study"
+        >
+          <ArrowDown className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </nav>
+    </div>
+  );
+}

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -206,9 +206,18 @@ export function SpaceView() {
 
         <div className="relative mx-auto w-full max-w-5xl">
           <section className="mb-4 px-1">
-            <h1 className="text-xl font-semibold tracking-[-0.025em] sm:text-2xl">
-              Space
-            </h1>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h1 className="text-xl font-semibold tracking-[-0.025em] sm:text-2xl">
+                Space
+              </h1>
+              <Link
+                href="/space/trail"
+                prefetch
+                className="inline-flex min-h-[44px] items-center rounded-xl border border-border/70 bg-background/70 px-3 text-xs font-medium text-muted-foreground transition hover:border-foreground/25 hover:bg-card hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Open swipe trail
+              </Link>
+            </div>
           </section>
 
           <nav

--- a/docs/space-study-workbench.md
+++ b/docs/space-study-workbench.md
@@ -1,7 +1,7 @@
 # Space: study workbench direction
 
 Status: implementation-ready product brief  
-Updated: 2026-08-09
+Updated: 2026-08-10
 
 ## Decision
 
@@ -94,6 +94,47 @@ The feed must retain stable URLs, clear source provenance, “why am I seeing
 this?”, a visible stopping point, and a way to resume. It should optimize for
 interesting trails and comprehension—not raw session length, outrage, novelty,
 or an unread-count treadmill.
+
+### Trail ranking, first implementation
+
+`/space/trail` is the first bounded version of this idea. It ranks the published
+archive on the device and presents one study per vertical snap point. The
+ranking combines:
+
+- explicit **more**, **less**, and **learned** feedback;
+- similarity through existing category and topic/source/mode tags;
+- recency, Fieldwork provenance, and short-session fit;
+- a deterministic exploration term so unfamiliar material can enter the mix;
+- sequence penalties that avoid adjacent items with the same category or a
+  heavily overlapping feature set.
+
+The useful TikTok mechanics are feedback density, weighted signals, controlled
+exploration, and deliberate feed diversity—not its objective function. TikTok's
+public explanation says strong intentional behavior is weighted above weak
+context, and that the feed intentionally intersperses diverse material and
+supports explicit “not interested” feedback. A contextual bandit is the likely
+later model once there is enough meaningful outcome data: it can trade off
+known relevance and exploration instead of pretending a fixed score is
+omniscient. Sources: [TikTok's recommendation overview](https://newsroom.tiktok.com/how-tiktok-recommends-videos-for-you),
+[TikTok on sequence diversity](https://newsroom.tiktok.com/an-update-on-our-work-to-safeguard-and-diversify-recommendations),
+and the [Yahoo contextual-bandit paper](https://arxiv.org/abs/1003.0146).
+
+For Space, the reward must be different. Opening a study, producing an answer,
+returning successfully, or marking the material useful is stronger evidence
+than dwell time. The feed should eventually calibrate difficulty as well as
+interest, similar in spirit to Duolingo's published description of Birdbrain,
+which estimates learner ability and exercise difficulty before assembling a
+session. Passive cards should regularly lead into explain, trace, answer, or
+compare actions, following the ICAP prediction that constructive and
+interactive engagement are stronger than passive exposure. Sources:
+[Duolingo on Birdbrain](https://blog.duolingo.com/learning-how-to-help-you-learn-introducing-birdbrain/)
+and the [ICAP framework](https://doi.org/10.1080/00461520.2014.965823).
+
+The current memory is versioned, bounded, and stored only in the browser. It is
+not uploaded and does not infer a preference merely because a card stayed on
+screen. A reset control clears the profile. Before any server-side learner
+model, define the event lifecycle, retention, export/delete behavior, and a
+learning-oriented success measure.
 
 ## Publishing boundary
 

--- a/lib/space-trail.test.ts
+++ b/lib/space-trail.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import type { Item } from '@/app/lib/item-types';
+import {
+  EMPTY_SPACE_TRAIL_MEMORY,
+  estimateTrailMinutes,
+  markSpaceTrailOpened,
+  parseSpaceTrailMemory,
+  rankSpaceTrail,
+  setSpaceTrailResume,
+  trailItemExcerpt,
+  updateSpaceTrailReaction,
+} from './space-trail';
+
+const nowMs = Date.UTC(2026, 7, 10);
+
+function item(
+  id: string,
+  category: string,
+  tags: string[],
+  updatedAt = nowMs - 90 * 86_400_000
+): Item {
+  return {
+    id,
+    title: `Study ${id}`,
+    slug: `study-${id}`,
+    url: null,
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'Note',
+        content:
+          '# Heading\nA **useful** [linked](https://example.com) explanation.',
+        contentHtml: '',
+        code: null,
+        codeHtml: '',
+      },
+    ],
+    tags,
+    category,
+    createdAt: updatedAt,
+    updatedAt,
+  };
+}
+
+describe('Space trail ranking', () => {
+  it('uses positive feedback to raise related material', () => {
+    const source = item('source', 'article', ['topic:linux']);
+    const related = item('related', 'trace', ['topic:linux']);
+    const unrelated = item('unrelated', 'design', ['topic:css']);
+    const memory = updateSpaceTrailReaction(
+      EMPTY_SPACE_TRAIL_MEMORY,
+      source.id,
+      'more'
+    );
+
+    const result = rankSpaceTrail([source, unrelated, related], memory, {
+      seed: 'stable',
+      nowMs,
+    });
+
+    expect(
+      result.findIndex(entry => entry.item.id === related.id)
+    ).toBeLessThan(result.findIndex(entry => entry.item.id === unrelated.id));
+    expect(
+      result.find(entry => entry.item.id === related.id)?.reasons[0]
+    ).toContain('linux');
+  });
+
+  it('removes explicit less-like-this items without hiding learned material forever', () => {
+    const hidden = item('hidden', 'article', []);
+    const learned = item('learned', 'article', []);
+    let memory = updateSpaceTrailReaction(
+      EMPTY_SPACE_TRAIL_MEMORY,
+      hidden.id,
+      'less'
+    );
+    memory = updateSpaceTrailReaction(memory, learned.id, 'learned');
+
+    const result = rankSpaceTrail([hidden, learned], memory, {
+      seed: 'stable',
+      nowMs,
+    });
+
+    expect(result.map(entry => entry.item.id)).toEqual(['learned']);
+  });
+
+  it('penalizes repetitive sequences when alternatives exist', () => {
+    const items = [
+      item('a', 'article', ['topic:a']),
+      item('b', 'article', ['topic:b']),
+      item('c', 'trace', ['topic:c']),
+    ];
+
+    const result = rankSpaceTrail(items, EMPTY_SPACE_TRAIL_MEMORY, {
+      seed: 'diverse',
+      nowMs,
+    });
+
+    expect(result).toHaveLength(3);
+    expect(new Set(result.map(entry => entry.item.id))).toHaveLength(3);
+    expect(result[0].item.category).not.toBe(result[1].item.category);
+  });
+});
+
+describe('Space trail memory and presentation helpers', () => {
+  it('validates stored memory and bounds the opened history', () => {
+    const opened = Array.from({ length: 520 }, (_, index) => `item-${index}`);
+    const parsed = parseSpaceTrailMemory(
+      JSON.stringify({
+        version: 1,
+        reactions: { a: 'more', b: 'invalid' },
+        opened,
+      })
+    );
+
+    expect(parsed.reactions).toEqual({ a: 'more' });
+    expect(parsed.opened).toHaveLength(500);
+    expect(parseSpaceTrailMemory('{broken')).toEqual(EMPTY_SPACE_TRAIL_MEMORY);
+    expect(markSpaceTrailOpened(parsed, 'item-519').opened.at(-1)).toBe(
+      'item-519'
+    );
+    expect(setSpaceTrailResume(parsed, 'item-42').resumeId).toBe('item-42');
+  });
+
+  it('turns markdown into a compact excerpt and respects time tags', () => {
+    const study = item('a', 'article', ['time:7 min']);
+    expect(trailItemExcerpt(study)).toBe(
+      'Heading A useful linked explanation.'
+    );
+    expect(estimateTrailMinutes(study)).toBe(7);
+  });
+});

--- a/lib/space-trail.ts
+++ b/lib/space-trail.ts
@@ -1,0 +1,280 @@
+import type { Item } from '@/app/lib/item-types';
+
+export const SPACE_TRAIL_MEMORY_VERSION = 1 as const;
+
+export type SpaceTrailReaction = 'more' | 'less' | 'learned';
+
+export type SpaceTrailMemory = {
+  version: typeof SPACE_TRAIL_MEMORY_VERSION;
+  reactions: Record<string, SpaceTrailReaction>;
+  opened: string[];
+  resumeId?: string;
+};
+
+export type SpaceTrailRecommendation = {
+  item: Item;
+  excerpt: string;
+  estimatedMinutes: number;
+  reasons: string[];
+};
+
+export const EMPTY_SPACE_TRAIL_MEMORY: SpaceTrailMemory = {
+  version: SPACE_TRAIL_MEMORY_VERSION,
+  reactions: {},
+  opened: [],
+};
+
+const NON_INTEREST_TAG_PREFIXES = [
+  'device:',
+  'state:',
+  'time:',
+  'visibility:',
+] as const;
+
+const FIELDWORK_TAGS = new Set(['source:fieldwork', 'source:linux-fieldwork']);
+
+function hashUnit(value: string) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4_294_967_295;
+}
+
+function normalizedTags(item: Item) {
+  return item.tags.map(tag => tag.trim().toLowerCase()).filter(Boolean);
+}
+
+function interestFeatures(item: Item) {
+  const features = [`category:${item.category.trim().toLowerCase()}`];
+  for (const tag of normalizedTags(item)) {
+    if (NON_INTEREST_TAG_PREFIXES.some(prefix => tag.startsWith(prefix))) {
+      continue;
+    }
+    features.push(tag);
+  }
+  return [...new Set(features)];
+}
+
+function isFieldworkItem(item: Item) {
+  const url = item.url?.toLowerCase() ?? '';
+  return (
+    normalizedTags(item).some(tag => FIELDWORK_TAGS.has(tag)) ||
+    url.includes('github.com/teamleaderleo/fieldwork') ||
+    url.includes('github.com/teamleaderleo/linux-fieldwork')
+  );
+}
+
+function activeContent(item: Item) {
+  return (
+    item.versions[item.defaultIndex]?.content ?? item.versions[0]?.content ?? ''
+  );
+}
+
+export function trailItemExcerpt(item: Item, maxLength = 360) {
+  const text = activeContent(item)
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/^[#>*+-]+\s*/gm, '')
+    .replace(/[\*_~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (text.length <= maxLength) return text;
+  const clipped = text.slice(0, maxLength + 1);
+  const lastSpace = clipped.lastIndexOf(' ');
+  return `${clipped.slice(0, Math.max(lastSpace, maxLength - 40)).trim()}…`;
+}
+
+export function estimateTrailMinutes(item: Item) {
+  for (const tag of normalizedTags(item)) {
+    const match = tag.match(/^time:(\d+)\s*min/);
+    if (match) return Math.max(1, Number.parseInt(match[1], 10));
+  }
+
+  const wordCount = activeContent(item)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return Math.max(2, Math.min(30, Math.ceil(wordCount / 180)));
+}
+
+export function parseSpaceTrailMemory(value: string | null): SpaceTrailMemory {
+  if (!value) return EMPTY_SPACE_TRAIL_MEMORY;
+
+  try {
+    const candidate = JSON.parse(value) as Partial<SpaceTrailMemory>;
+    if (
+      candidate.version !== SPACE_TRAIL_MEMORY_VERSION ||
+      !candidate.reactions ||
+      typeof candidate.reactions !== 'object' ||
+      !Array.isArray(candidate.opened)
+    ) {
+      return EMPTY_SPACE_TRAIL_MEMORY;
+    }
+
+    const reactions = Object.fromEntries(
+      Object.entries(candidate.reactions).filter(
+        (entry): entry is [string, SpaceTrailReaction] =>
+          Boolean(entry[0]) &&
+          (entry[1] === 'more' || entry[1] === 'less' || entry[1] === 'learned')
+      )
+    );
+    const opened = candidate.opened
+      .filter((id): id is string => typeof id === 'string' && Boolean(id))
+      .slice(-500);
+
+    return {
+      version: SPACE_TRAIL_MEMORY_VERSION,
+      reactions,
+      opened: [...new Set(opened)],
+      resumeId:
+        typeof candidate.resumeId === 'string' && candidate.resumeId
+          ? candidate.resumeId
+          : undefined,
+    };
+  } catch {
+    return EMPTY_SPACE_TRAIL_MEMORY;
+  }
+}
+
+export function updateSpaceTrailReaction(
+  memory: SpaceTrailMemory,
+  itemId: string,
+  reaction: SpaceTrailReaction | null
+): SpaceTrailMemory {
+  const reactions = { ...memory.reactions };
+  if (reaction) reactions[itemId] = reaction;
+  else delete reactions[itemId];
+
+  return { ...memory, reactions };
+}
+
+export function markSpaceTrailOpened(
+  memory: SpaceTrailMemory,
+  itemId: string
+): SpaceTrailMemory {
+  return {
+    ...memory,
+    opened: [...memory.opened.filter(id => id !== itemId), itemId].slice(-500),
+    resumeId: itemId,
+  };
+}
+
+export function setSpaceTrailResume(
+  memory: SpaceTrailMemory,
+  itemId: string
+): SpaceTrailMemory {
+  if (memory.resumeId === itemId) return memory;
+  return { ...memory, resumeId: itemId };
+}
+
+export function rankSpaceTrail(
+  items: Item[],
+  memory: SpaceTrailMemory,
+  options: { seed: string; nowMs: number }
+): SpaceTrailRecommendation[] {
+  const itemById = new Map(items.map(item => [item.id, item]));
+  const affinity = new Map<string, number>();
+
+  for (const [itemId, reaction] of Object.entries(memory.reactions)) {
+    const item = itemById.get(itemId);
+    if (!item) continue;
+    const weight = reaction === 'more' ? 2.5 : reaction === 'less' ? -2 : 0;
+    if (weight === 0) continue;
+    for (const feature of interestFeatures(item)) {
+      affinity.set(feature, (affinity.get(feature) ?? 0) + weight);
+    }
+  }
+
+  const opened = new Set(memory.opened);
+  const candidates = items
+    .filter(item => memory.reactions[item.id] !== 'less')
+    .map(item => {
+      const features = interestFeatures(item);
+      const matchingFeatures = features
+        .map(feature => ({ feature, weight: affinity.get(feature) ?? 0 }))
+        .filter(match => match.weight > 0)
+        .sort((a, b) => b.weight - a.weight);
+      const affinityScore = matchingFeatures
+        .slice(0, 3)
+        .reduce((total, match) => total + match.weight, 0);
+      const ageDays = Math.max(
+        0,
+        (options.nowMs - item.updatedAt) / 86_400_000
+      );
+      const freshnessScore = Math.max(0, 2 - ageDays / 45);
+      const explorationScore = hashUnit(`${options.seed}:${item.id}`) * 2.2;
+      const estimatedMinutes = estimateTrailMinutes(item);
+      const fieldwork = isFieldworkItem(item);
+      const learned = memory.reactions[item.id] === 'learned';
+      const score =
+        affinityScore +
+        freshnessScore +
+        explorationScore +
+        (fieldwork ? 1.25 : 0) +
+        (estimatedMinutes <= 5 ? 0.5 : 0) +
+        (opened.has(item.id) ? -1.25 : 1.5) +
+        (learned ? -2.5 : 0);
+
+      const reasons: string[] = [];
+      if (matchingFeatures.length > 0) {
+        const feature = matchingFeatures[0].feature.replace(/^[^:]+:/, '');
+        reasons.push(`Matches ${feature}, which you asked to see more often`);
+      }
+      if (fieldwork) reasons.push('Connected to Fieldwork');
+      if (ageDays <= 30) reasons.push('Recently updated');
+      if (estimatedMinutes <= 5) reasons.push('Fits a short session');
+      if (reasons.length === 0 || explorationScore > 1.85) {
+        reasons.push('A deliberate detour to keep the trail varied');
+      }
+
+      return {
+        item,
+        features,
+        score,
+        recommendation: {
+          item,
+          excerpt: trailItemExcerpt(item),
+          estimatedMinutes,
+          reasons: reasons.slice(0, 3),
+        } satisfies SpaceTrailRecommendation,
+      };
+    });
+
+  const ranked: SpaceTrailRecommendation[] = [];
+  let previousFeatures = new Set<string>();
+  let previousCategory = '';
+
+  while (candidates.length > 0) {
+    let bestIndex = 0;
+    let bestScore = Number.NEGATIVE_INFINITY;
+
+    for (let index = 0; index < candidates.length; index += 1) {
+      const candidate = candidates[index];
+      const category = candidate.item.category.trim().toLowerCase();
+      const overlap = candidate.features.filter(feature =>
+        previousFeatures.has(feature)
+      ).length;
+      const sequencePenalty =
+        (category === previousCategory ? 2.75 : 0) +
+        Math.min(1.5, overlap * 0.5);
+      const sequenceScore = candidate.score - sequencePenalty;
+      if (sequenceScore > bestScore) {
+        bestScore = sequenceScore;
+        bestIndex = index;
+      }
+    }
+
+    const [selected] = candidates.splice(bestIndex, 1);
+    ranked.push(selected.recommendation);
+    previousFeatures = new Set(selected.features);
+    previousCategory = selected.item.category.trim().toLowerCase();
+  }
+
+  return ranked;
+}


### PR DESCRIPTION
## What changed

- add a phone-first vertical Trail through the published Space archive
- rank studies locally from explicit More, Less, and Learned feedback, topic similarity, recency, Fieldwork provenance, short-session fit, exploration, and sequence diversity
- keep the profile on-device with bounded versioned storage, reset, and exact resume after opening a reading sheet
- expose transparent Why this explanations and visible stopping points without autoplay, streaks, or dwell-time scoring
- start the public archive request in parallel with identity loading
- correct Space viewport units so the snap container has stable phone geometry
- document the ranking rationale and primary research sources

## Why

Space needs a low-friction mobile entry point that feels as easy to continue as a short-form feed while optimizing for useful learning rather than raw session length. This is a bounded first model over trusted published material; it does not generate new claims or upload behavioral telemetry.

## Validation

- local CI: 6/6 stages passed
- lint: 0 errors (34 existing warnings)
- typecheck passed
- unit tests: 44 files, 332 tests passed
- production build passed
- Chromium: 117 passed, 4 data-dependent reading-sheet cases skipped under the fake CI Supabase endpoint
- manual browser checks: 320px, 390px, desktop, light/dark, 44/48px controls, ten-card snap jump, local feedback persistence, and exact Trail to reading sheet to Trail resume
- git diff --check passed