### PR TITLE
Add active next moves to Space Trail

### DIFF
--- a/app/space/read/[slug]/page.tsx
+++ b/app/space/read/[slug]/page.tsx
@@ -7,12 +7,23 @@ import { MarkdownContent } from '@/components/space/markdown-content';
 import { ReadingPracticeDock } from '@/components/space/reading-practice-dock';
 import { PageCurl, StitchedRule } from '@/components/cozy-flourishes';
 import { resolveSpaceLane } from '@/lib/space-lanes';
+import {
+  buildSpaceNextMove,
+  parseSpaceNextMoveStage,
+  parseSpacePracticeMode,
+} from '@/lib/space-practice';
 import { displaySpaceTags } from '@/lib/space-tags';
 import { loadReadingSheet } from '../data';
 
 type ReadingSheetPageProps = {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ lane?: string; tags?: string; from?: string }>;
+  searchParams: Promise<{
+    lane?: string;
+    tags?: string;
+    from?: string;
+    practice?: string;
+    stage?: string;
+  }>;
 };
 
 function sectionId(label: string, index: number) {
@@ -86,6 +97,14 @@ export default async function ReadingSheetPage({
   const primary = versions[item.defaultIndex] ?? versions[0];
   const rest = versions.filter(version => version !== primary);
   const orderedVersions = primary ? [primary, ...rest] : [];
+  const requestedPracticeMode = parseSpacePracticeMode(query.practice);
+  const nextMoveStage = parseSpaceNextMoveStage(query.stage);
+  const suggestedMove = requestedPracticeMode
+    ? buildSpaceNextMove(item, {
+        familiar: nextMoveStage !== undefined,
+        learned: nextMoveStage === 'learned',
+      })
+    : undefined;
 
   return (
     <main className="min-h-screen bg-background px-3 py-3 text-foreground sm:px-6 sm:py-6">
@@ -197,9 +216,16 @@ export default async function ReadingSheetPage({
           </div>
 
           <ReadingPracticeDock
+            key={`${item.slug}:${requestedPracticeMode ?? 'question'}`}
             slug={item.slug}
             title={item.title}
             sourceUrl={item.url}
+            initialMode={requestedPracticeMode}
+            promptOverride={
+              suggestedMove?.mode === requestedPracticeMode
+                ? suggestedMove?.prompt
+                : undefined
+            }
           />
 
           <PageCurl className="h-10 w-10 opacity-70 [&>span]:h-10 [&>span]:w-10" />

--- a/components/space/reading-practice-dock.test.ts
+++ b/components/space/reading-practice-dock.test.ts
@@ -20,4 +20,19 @@ describe('ReadingPracticeDock', () => {
     expect(html).toContain('Saved on this device');
     expect(html).not.toContain('Assistant');
   });
+
+  it('opens on a contextual next move when Trail supplies one', () => {
+    const html = renderToStaticMarkup(
+      createElement(ReadingPracticeDock, {
+        slug: 'atomic-cache-publication',
+        title: 'Atomic cache publication',
+        initialMode: 'trace',
+        promptOverride: 'Predict the first observable write.',
+      })
+    );
+
+    expect(html).toContain('Predict the first observable write.');
+    expect(html).toContain('Trace notes');
+    expect(html).toContain('aria-pressed="true"');
+  });
 });

--- a/components/space/reading-practice-dock.tsx
+++ b/components/space/reading-practice-dock.tsx
@@ -60,12 +60,16 @@ export function ReadingPracticeDock({
   slug,
   title,
   sourceUrl,
+  initialMode = 'question',
+  promptOverride,
 }: {
   slug: string;
   title: string;
   sourceUrl?: string | null;
+  initialMode?: SpacePracticeMode;
+  promptOverride?: string;
 }) {
-  const [mode, setMode] = useState<SpacePracticeMode>('question');
+  const [mode, setMode] = useState<SpacePracticeMode>(initialMode);
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
     'idle'
   );
@@ -74,6 +78,10 @@ export function ReadingPracticeDock({
   const modeDefinition =
     SPACE_PRACTICE_MODES.find(item => item.id === mode) ??
     SPACE_PRACTICE_MODES[0];
+  const activePrompt =
+    mode === initialMode && promptOverride?.trim()
+      ? promptOverride
+      : modeDefinition.prompt;
 
   const chooseMode = (nextMode: SpacePracticeMode) => {
     setMode(nextMode);
@@ -88,6 +96,7 @@ export function ReadingPracticeDock({
           title,
           sourceUrl,
           draft,
+          prompt: activePrompt,
         })
       );
       setCopyState('copied');
@@ -123,9 +132,7 @@ export function ReadingPracticeDock({
             <span className="grid h-7 w-7 place-items-center rounded-full bg-[hsl(var(--material-paper-ink)/0.08)] font-mono text-[9px] font-semibold uppercase tracking-[0.08em]">
               You
             </span>
-            <p className="text-sm font-medium leading-6">
-              {modeDefinition.prompt}
-            </p>
+            <p className="text-sm font-medium leading-6">{activePrompt}</p>
           </div>
         </div>
 

--- a/components/space/space-trail.tsx
+++ b/components/space/space-trail.tsx
@@ -15,6 +15,7 @@ import {
 import { useItems } from '@/app/lib/contexts/item-context';
 import { SpaceHeader } from '@/components/space/space-header';
 import { displaySpaceTags } from '@/lib/space-tags';
+import { buildSpaceNextMove } from '@/lib/space-practice';
 import {
   EMPTY_SPACE_TRAIL_MEMORY,
   markSpaceTrailOpened,
@@ -95,6 +96,18 @@ function TrailCard({
   const { item, estimatedMinutes, excerpt, reasons } = recommendation;
   const tags = displaySpaceTags(item.tags).slice(0, 5);
   const isStoppingPoint = (index + 1) % 12 === 0;
+  const nextMove = buildSpaceNextMove(item, {
+    familiar: reaction !== undefined,
+    learned: reaction === 'learned',
+  });
+  const nextMoveStage =
+    reaction === 'learned' ? 'learned' : reaction ? 'familiar' : undefined;
+  const readingHref = new URLSearchParams({
+    lane: 'archive',
+    from: 'trail',
+    practice: nextMove.mode,
+  });
+  if (nextMoveStage) readingHref.set('stage', nextMoveStage);
 
   return (
     <section
@@ -121,7 +134,7 @@ function TrailCard({
           </h2>
 
           {excerpt ? (
-            <p className="mt-5 max-w-[62ch] text-[15px] leading-7 text-[hsl(var(--material-paper-ink)/0.7)] sm:text-base">
+            <p className="mt-5 line-clamp-6 max-w-[62ch] text-[15px] leading-7 text-[hsl(var(--material-paper-ink)/0.7)] sm:line-clamp-none sm:text-base">
               {excerpt}
             </p>
           ) : null}
@@ -139,7 +152,17 @@ function TrailCard({
             </div>
           ) : null}
 
-          <details className="group mt-6 rounded-xl border border-[hsl(var(--material-paper-edge)/0.62)] bg-[hsl(var(--material-paper-ink)/0.025)] px-3.5 py-3 text-xs text-[hsl(var(--material-paper-ink)/0.62)]">
+          <div className="mt-6 rounded-2xl border border-[hsl(var(--material-paper-edge)/0.68)] bg-[hsl(var(--material-paper-ink)/0.035)] px-4 py-3.5">
+            <div className="flex items-center justify-between gap-3 font-mono text-[9px] font-semibold uppercase tracking-[0.14em] text-[hsl(var(--material-paper-ink)/0.48)]">
+              <span>Next move · 2 min</span>
+              <span>{nextMove.label}</span>
+            </div>
+            <p className="mt-2 text-[13px] leading-5 text-[hsl(var(--material-paper-ink)/0.72)] sm:text-sm sm:leading-6">
+              {nextMove.prompt}
+            </p>
+          </div>
+
+          <details className="group mt-3 rounded-xl border border-[hsl(var(--material-paper-edge)/0.62)] bg-[hsl(var(--material-paper-ink)/0.025)] px-3.5 py-3 text-xs text-[hsl(var(--material-paper-ink)/0.62)]">
             <summary className="cursor-pointer list-none font-medium text-[hsl(var(--material-paper-ink)/0.72)] focus-visible:outline-none group-open:mb-2">
               Why this?
             </summary>
@@ -175,7 +198,7 @@ function TrailCard({
           </div>
 
           <Link
-            href={`/space/read/${encodeURIComponent(item.slug)}?lane=archive&from=trail`}
+            href={`/space/read/${encodeURIComponent(item.slug)}?${readingHref.toString()}`}
             prefetch
             onClick={onOpen}
             className="mt-3 inline-flex min-h-[48px] w-full items-center justify-center gap-2 rounded-xl bg-[hsl(var(--material-paper-ink))] px-4 text-sm font-semibold text-[hsl(var(--material-paper-face))] transition-[transform,box-shadow] hover:-translate-y-px hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--material-paper-ink)/0.4)] active:translate-y-0"

--- a/docs/space-study-workbench.md
+++ b/docs/space-study-workbench.md
@@ -136,6 +136,55 @@ screen. A reset control clears the profile. Before any server-side learner
 model, define the event lifecycle, retention, export/delete behavior, and a
 learning-oriented success measure.
 
+### Next moves and optional generation
+
+Every Trail card now offers one small active-learning move—trace, review,
+stress, explain, interrogate, or transfer—selected from the study's category,
+tags, code presence, and the learner's explicit state. This first layer is a
+deterministic triage function, not generated prose. It runs instantly, works
+offline after the archive loads, and can only ask the reader to inspect or
+reason about the attached study; it cannot invent a claim about the source.
+Opening the study carries the selected mode into its private practice bench.
+
+Keep ranking and content generation separate. Ranking is a small decision
+problem and can graduate from understandable rules to a contextual bandit once
+there are enough meaningful outcomes. It does not need a language model.
+Generation is an editorial supply problem and should happen asynchronously:
+
+1. select a published study and its pinned source;
+2. ask a small model for structured candidate moves such as predict, trace,
+   compare, alter, or review;
+3. require source quotes or exact code pointers for factual premises;
+4. reject malformed, duplicative, or unsupported candidates;
+5. save the survivors as private drafts;
+6. let the owner edit, publish, revise, or discard them.
+
+Do not generate a new card synchronously during a swipe, and do not auto-publish
+model output. A tiny local embedding or classifier model may later improve
+topic relations and triage. A browser LLM is a poor default for the phone path:
+WebGPU support remains uneven outside Chromium and the model download competes
+with the instant, low-friction experience. If richer drafts earn their keep, a
+small server-side model can run in a background import/publishing job; the UI
+should continue to consume ordinary reviewed data even when that model is
+unavailable.
+
+Current implementation options and constraints:
+
+- [Transformers.js WebGPU](https://huggingface.co/docs/transformers.js/guides/webgpu)
+  can run embeddings and classifiers entirely in the browser, but its own guide
+  warns that WebGPU is still experimental, especially outside Chromium.
+- [WebLLM](https://github.com/mlc-ai/web-llm) supports private in-browser LLM
+  inference and structured JSON through WebGPU; keep it as an opt-in desktop
+  experiment rather than a required phone bundle.
+- [Chrome's Prompt API](https://developer.chrome.com/docs/ai/prompt-api) can use
+  a browser-provided model, but its current availability and device requirements
+  make it unsuitable as Space's universal generation layer.
+- [Cloudflare Workers AI pricing](https://developers.cloudflare.com/workers-ai/platform/pricing/)
+  currently includes a daily free allocation and a 1B-class instruct model,
+  which is enough for a low-volume draft worker without placing model weights
+  on the phone. It would still require explicit retention, provenance, and
+  editorial-review rules before integration.
+
 ## Publishing boundary
 
 Current Space items are public unless tagged `visibility:private`. The public

--- a/lib/space-practice.test.ts
+++ b/lib/space-practice.test.ts
@@ -1,10 +1,63 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildSpaceNextMove,
   buildSpacePracticePrompt,
+  parseSpaceNextMoveStage,
+  parseSpacePracticeMode,
   spacePracticeStorageKey,
 } from './space-practice';
+import type { Item } from '@/app/lib/item-types';
+
+function study(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'study-id',
+    title: 'Atomic cache publication',
+    slug: 'atomic-cache-publication',
+    url: 'https://example.com/source',
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'Note',
+        content: 'A bounded explanation.',
+        contentHtml: '<p>A bounded explanation.</p>',
+        code: null,
+        codeHtml: '',
+      },
+    ],
+    tags: [],
+    category: 'article',
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
 
 describe('Space practice prompts', () => {
+  it('triages studies into source-bounded next moves', () => {
+    expect(
+      buildSpaceNextMove(
+        study({ category: 'trace', tags: ['topic:lifecycle'] })
+      )
+    ).toMatchObject({ mode: 'trace', label: 'Trace it' });
+    expect(buildSpaceNextMove(study({ category: 'design' }))).toMatchObject({
+      mode: 'question',
+      label: 'Stress it',
+    });
+    expect(buildSpaceNextMove(study(), { learned: true })).toMatchObject({
+      mode: 'explain',
+      label: 'Transfer it',
+    });
+  });
+
+  it('recognizes only supported practice modes', () => {
+    expect(parseSpacePracticeMode('trace')).toBe('trace');
+    expect(parseSpacePracticeMode('invented')).toBeUndefined();
+    expect(parseSpacePracticeMode(undefined)).toBeUndefined();
+    expect(parseSpaceNextMoveStage('familiar')).toBe('familiar');
+    expect(parseSpaceNextMoveStage('learned')).toBe('learned');
+    expect(parseSpaceNextMoveStage('fresh')).toBeUndefined();
+  });
+
   it('keeps local drafts isolated by study and practice mode', () => {
     expect(spacePracticeStorageKey('cache-identity', 'question')).toBe(
       'space:practice:cache-identity:question'
@@ -33,6 +86,18 @@ describe('Space practice prompts', () => {
         'Start at the temporary file.',
       ].join('\n')
     );
+  });
+
+  it('copies a contextual prompt when one is supplied', () => {
+    expect(
+      buildSpacePracticePrompt({
+        mode: 'trace',
+        title: 'Atomic cache publication',
+        sourceUrl: null,
+        draft: '',
+        prompt: 'Predict the first observable write.',
+      })
+    ).toContain('Predict the first observable write.');
   });
 
   it('does not invent an empty notes block', () => {

--- a/lib/space-practice.ts
+++ b/lib/space-practice.ts
@@ -1,3 +1,5 @@
+import type { Item } from '@/app/lib/item-types';
+
 export const SPACE_PRACTICE_MODES = [
   {
     id: 'question',
@@ -18,6 +20,146 @@ export const SPACE_PRACTICE_MODES = [
 
 export type SpacePracticeMode = (typeof SPACE_PRACTICE_MODES)[number]['id'];
 
+export type SpaceNextMove = {
+  mode: SpacePracticeMode;
+  label: string;
+  prompt: string;
+};
+
+export type SpaceNextMoveStage = 'familiar' | 'learned';
+
+const TRACE_SIGNALS = [
+  'trace',
+  'lifecycle',
+  'request',
+  'state machine',
+  'pipeline',
+  'cache',
+  'network',
+] as const;
+
+const REVIEW_SIGNALS = [
+  'review',
+  'diff',
+  'patch',
+  'debug',
+  'diagnose',
+  'failure',
+  'incident',
+] as const;
+
+const DESIGN_SIGNALS = [
+  'design',
+  'architecture',
+  'system',
+  'interface',
+  'frontend',
+] as const;
+
+function activeVersion(item: Item) {
+  return item.versions[item.defaultIndex] ?? item.versions[0];
+}
+
+function itemSignals(item: Item) {
+  return [item.category, item.title, ...item.tags].join(' ').toLowerCase();
+}
+
+function hasSignal(signals: string, candidates: readonly string[]) {
+  return candidates.some(candidate => signals.includes(candidate));
+}
+
+/**
+ * Creates a fast, source-bounded practice cue without calling a model.
+ * The cue asks the learner to inspect the study; it never invents a fact about it.
+ */
+export function buildSpaceNextMove(
+  item: Item,
+  context: { familiar?: boolean; learned?: boolean } = {}
+): SpaceNextMove {
+  if (context.learned) {
+    return {
+      mode: 'explain',
+      label: 'Transfer it',
+      prompt:
+        'Explain the mechanism and tradeoff from memory. Name one case where the idea transfers—and one where it does not.',
+    };
+  }
+
+  if (context.familiar) {
+    return {
+      mode: 'question',
+      label: 'Interrogate it',
+      prompt:
+        'Find one assumption the explanation depends on. What question or counterexample could change the conclusion?',
+    };
+  }
+
+  const category = item.category.toLowerCase();
+  const signals = itemSignals(item);
+  const version = activeVersion(item);
+  const hasCode = Boolean(
+    version?.code?.trim() || version?.content.includes('```')
+  );
+
+  if (
+    hasSignal(category, REVIEW_SIGNALS) ||
+    (!hasSignal(category, DESIGN_SIGNALS) && hasSignal(signals, REVIEW_SIGNALS))
+  ) {
+    return {
+      mode: 'question',
+      label: 'Review it',
+      prompt:
+        'Treat this like a real patch: name the invariant you would protect and the first failure case you would test.',
+    };
+  }
+
+  if (hasSignal(category, DESIGN_SIGNALS)) {
+    return {
+      mode: 'question',
+      label: 'Stress it',
+      prompt:
+        'Make one constraint ten times harsher. Predict which design decision breaks first and why.',
+    };
+  }
+
+  if (hasCode || hasSignal(signals, TRACE_SIGNALS)) {
+    return {
+      mode: 'trace',
+      label: 'Trace it',
+      prompt:
+        'Choose one concrete input. Predict the first state change and first visible output; then check the study.',
+    };
+  }
+
+  if (hasSignal(signals, DESIGN_SIGNALS)) {
+    return {
+      mode: 'question',
+      label: 'Stress it',
+      prompt:
+        'Make one constraint ten times harsher. Predict which design decision breaks first and why.',
+    };
+  }
+
+  return {
+    mode: 'explain',
+    label: 'Explain it',
+    prompt:
+      'Before opening, write three short lines: the mechanism you expect, its main tradeoff, and the question the study should answer.',
+  };
+}
+
+export function parseSpacePracticeMode(
+  value: string | null | undefined
+): SpacePracticeMode | undefined {
+  return SPACE_PRACTICE_MODES.find(mode => mode.id === value)?.id;
+}
+
+export function parseSpaceNextMoveStage(
+  value: string | null | undefined
+): SpaceNextMoveStage | undefined {
+  return value === 'familiar' || value === 'learned' ? value : undefined;
+}
+
 export function spacePracticeStorageKey(slug: string, mode: SpacePracticeMode) {
   return `space:practice:${slug}:${mode}`;
 }
@@ -27,15 +169,17 @@ export function buildSpacePracticePrompt({
   title,
   sourceUrl,
   draft,
+  prompt,
 }: {
   mode: SpacePracticeMode;
   title: string;
   sourceUrl?: string | null;
   draft: string;
+  prompt?: string;
 }) {
   const definition = SPACE_PRACTICE_MODES.find(item => item.id === mode);
   const lines: string[] = [
-    definition?.prompt ?? SPACE_PRACTICE_MODES[0].prompt,
+    prompt?.trim() || definition?.prompt || SPACE_PRACTICE_MODES[0].prompt,
   ];
 
   lines.push('', `Study: ${title}`);


### PR DESCRIPTION
## What changed

- add an instant, source-bounded “next move” to every Trail card
- triage studies into trace, review, stress, explain, interrogate, or transfer prompts using existing metadata and explicit feedback
- carry the selected prompt into the reading sheet’s private practice bench
- keep phone cards within the snap viewport by clamping only the feed teaser
- document the boundary between lightweight ranking and optional model-generated editorial drafts

## Why

The Trail should lead naturally from passive browsing into a small useful action without waiting for a network model or inventing material. A deterministic first layer keeps swipes instant and gives a future small/free model a safe role: proposing private, source-grounded drafts for review rather than generating live public cards.

## Verification

- `pnpm ci:local --skip-install` — 6/6 steps
  - lint: 0 errors (existing warnings only)
  - typecheck
  - 44 test files / 336 unit tests
  - production build
  - diff check
  - Chromium: 117 passed / 4 expected live-data skips
- focused practice/trail tests: 13/13
- manual Playwright at 390×844 in light and dark: full primary card fits, Open study remains visible, no horizontal overflow, no framework overlay or console errors
- verified Trail-selected Trace mode and contextual prompt arrive in the reading practice dock

## Risk and rollback

No schema, auth, privacy, or external model changes. The prompts are static local logic over already-public item metadata. Rollback is the single commit.