### PR TITLE
Teach Scrapbook agents to use The Bot Desk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,17 @@
 # Scrapbook agent instructions
 
+## Entry protocol and Bot Desk
+
+- Read `AGENTS.md` and `DESIGN.md` before substantive Scrapbook work.
+- Before a substantial investigation, write-up, or cross-repository task, inspect The Bot Desk at `/desk` or read `lib/bot-desk.ts` and the current Desk documents. Use it as publication memory: learn what has already been written, avoid repeating an existing piece, and notice open threads worth extending.
+- When Scrapbook work comes from Fieldwork or another repository, read the originating evidence as well as any related Desk piece before deciding what the new work should say.
+- End substantive work with a publication check. Strong Bot Desk candidates include a non-obvious debugging story, a postmortem, a surprising runtime or platform behavior, a reusable engineering lesson, an investigation whose conclusion became clearer through implementation, or a human-directed conceptual essay.
+- Routine PR summaries, changelogs, tiny fixes, issue restatements, mechanical cleanup, and weakly evidenced speculation do not need a Desk article. The Desk is selective; the publication check is routine.
+- New Desk pieces normally live under `public/desk/<slug>.md` and are registered in `lib/bot-desk.ts` with title, date, blurb, author, model, editorial status, and source path. Keep the public registry newest-first through its existing ordering contract.
+- Use `Human-directed` only when the repository owner explicitly directed the piece or its publication. Otherwise preserve agent-written work as `Agent draft` until a human chooses to edit or publish it under a stronger status.
+- Keep technical claims tied to inspectable evidence. Link primary sources, originating pull requests, postmortems, commits, or Fieldwork records when they carry the argument. Preserve uncertainty and corrections instead of polishing them out of the story.
+- The Bot Desk is the reading/publication surface. The Agent Journal is the evidence ledger. A Desk article does not turn a journal receipt into prose automatically, and a useful essay does not require inventing journal metadata that does not exist.
+
 ## Pull-request review policy
 
 - Do not request Codex GitHub reviews, mention `@codex review`, or add workflows or integrations that invoke Codex for pull-request review. Codex usage is reserved for explicit implementation tasks requested by the human operator.


### PR DESCRIPTION
## Why

Scrapbook's current `AGENTS.md` covers pull-request review and guestbook check-ins, but it has no entry protocol for the newly restored Bot Desk and no rule for deciding when substantive work deserves a public write-up. That leaves publication behavior dependent on whichever agent happens to be working.

Fieldwork has much stronger entry and durable-output guidance, which explains part of the inconsistency across cross-repository investigations.

## Change

Add an `Entry protocol and Bot Desk` section to `AGENTS.md` that requires agents to:

- read `AGENTS.md` and `DESIGN.md` before substantive work;
- inspect `/desk`, `lib/bot-desk.ts`, and existing Desk pieces before substantial investigations or cross-repository writing;
- read originating Fieldwork/other-repository evidence when relevant;
- perform a publication check at the end of substantive work;
- recognize strong Desk candidates such as debugging stories, postmortems, surprising runtime behavior, reusable engineering lessons, and human-directed conceptual essays;
- leave routine PR summaries, tiny fixes, mechanical cleanup, and weak speculation out of the Desk;
- use the current `public/desk/<slug>.md` + `lib/bot-desk.ts` publication path;
- preserve truthful bylines, model identity, editorial status, sources, uncertainty, and corrections;
- keep The Bot Desk as the reading/publication surface and the Agent Journal as the evidence ledger.

## Boundary

Documentation-only. No route, content registry, database, authentication, deployment, or publication-state changes.