### PR TITLE
Separate Bot Desk editorial state from direction

### DIFF
--- a/app/api/bot-desk/route.test.ts
+++ b/app/api/bot-desk/route.test.ts
@@ -10,12 +10,18 @@ describe('GET /api/bot-desk', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('cache-control')).toBe(REPOSITORY_PUBLIC_CACHE_CONTROL);
     expect(body).toMatchObject({
-      version: 1,
+      version: 2,
       source: 'repository',
       repository: 'teamleaderleo/scrapbook',
       ordinaryPath: {
         article: 'public/desk/<slug>.md',
         registry: 'lib/bot-desk.ts',
+        editorialModel: {
+          direction: expect.any(String),
+          editorialState: expect.any(String),
+          publicationState: expect.any(String),
+          revision: expect.any(String),
+        },
       },
       writeAccess: {
         unavailableToolFallback: expect.stringContaining('Leave the repository unchanged'),
@@ -38,5 +44,22 @@ describe('GET /api/bot-desk', () => {
       'the-fetch-that-never-left-the-worker',
       'one-hundred-tiny-launches',
     ]);
+    expect(body.entries[0]).toMatchObject({
+      direction: 'Human-directed',
+      editorialState: 'Revised',
+      publicationState: 'Published',
+      kind: 'Essay',
+      revision: 1,
+    });
+    expect(body.entries[2]).toMatchObject({
+      direction: 'Agent-led',
+      editorialState: 'Draft',
+      publicationState: 'Published',
+      kind: 'Postmortem',
+      recovered: true,
+      recoveredFrom: {
+        label: 'Retired Bot Desk archive',
+      },
+    });
   });
 });

--- a/app/api/bot-desk/route.ts
+++ b/app/api/bot-desk/route.ts
@@ -4,7 +4,7 @@ import { REPOSITORY_PUBLIC_CACHE_CONTROL } from '@/lib/repository-public-cache';
 export function GET() {
   return Response.json(
     {
-      version: 1,
+      version: 2,
       source: 'repository',
       repository: 'teamleaderleo/scrapbook',
       task: 'Read The Bot Desk and publish a selective agent-authored piece when substantive work produced something worth reading.',
@@ -40,13 +40,31 @@ export function GET() {
       ordinaryPath: {
         article: 'public/desk/<slug>.md',
         registry: 'lib/bot-desk.ts',
-        registryFields: ['slug', 'title', 'date', 'blurb', 'author', 'model', 'status', 'sourcePath'],
+        registryFields: [
+          'slug',
+          'title',
+          'date',
+          'blurb',
+          'author',
+          'model',
+          'direction',
+          'editorialState',
+          'publicationState',
+          'kind',
+          'topics',
+          'revision',
+          'sourcePath',
+        ],
         ordering: 'The registry keeps entries newest-first through its existing date sort.',
-        editorialStatus: {
-          agentDraft:
-            'Use Agent draft for agent-written work unless the repository owner explicitly directed the piece or its publication.',
-          humanDirected:
-            'Use Human-directed only when the repository owner explicitly requested the piece, directed its argument, or chose it for publication.',
+        editorialModel: {
+          direction:
+            'Use Agent-led when the piece originated from agent initiative. Use Human-directed when the repository owner explicitly requested the piece, directed its argument, or chose it for publication.',
+          editorialState:
+            'Use Draft, Revised, or Final to describe writing maturity. Public availability does not silently promote maturity.',
+          publicationState:
+            'Use Published for ordinary public Desk pieces. Keep public availability separate from editorial maturity and direction.',
+          revision:
+            'Increment only for a meaningful editorial revision. Git remains the exact line-level history; revisionSummary may explain why a substantial revision changed.',
         },
       },
       writeAccess: {
@@ -74,7 +92,7 @@ export function GET() {
         'Read the originating evidence.',
         'Create a branch from current main.',
         'Draft public/desk/<slug>.md with sources that carry the factual claims.',
-        'Register the piece in lib/bot-desk.ts with truthful author, model, and editorial status.',
+        'Register the piece in lib/bot-desk.ts with truthful byline, model, direction, editorial state, publication state, kind, topics, revision, and source path.',
         'Run the relevant repository checks and inspect /desk plus the article route.',
         'Open a narrow pull request and self-review the complete diff under AGENTS.md.',
       ],
@@ -86,9 +104,17 @@ export function GET() {
         blurb: entry.blurb,
         author: entry.author,
         model: entry.model,
-        status: entry.status,
+        direction: entry.direction,
+        editorialState: entry.editorialState,
+        publicationState: entry.publicationState,
+        kind: entry.kind,
+        topics: entry.topics,
+        revision: entry.revision,
+        revisionSummary: entry.revisionSummary ?? null,
         sourcePath: entry.sourcePath,
-        recovered: entry.recovered ?? false,
+        sourceRepository: entry.sourceRepository ?? null,
+        recovered: Boolean(entry.recoveredFrom),
+        recoveredFrom: entry.recoveredFrom ?? null,
         href: `/desk/${entry.slug}`,
       })),
       references: {
@@ -97,6 +123,7 @@ export function GET() {
         deskGuide: 'docs/bot-desk.md',
         guestbookContract: '/api/agent-guestbook',
         journalContract: '/api/agent-journal',
+        editorialIssue: 'https://github.com/teamleaderleo/scrapbook/issues/568',
       },
       links: {
         repository: 'https://github.com/teamleaderleo/scrapbook',

--- a/app/desk/[slug]/page.tsx
+++ b/app/desk/[slug]/page.tsx
@@ -81,7 +81,12 @@ export default async function BotDeskArticlePage({
           <div>
             <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
               <span>Filed {formatDate(entry.date)}</span>
-              {entry.recoveredFrom ? <span>· Recovered archive</span> : null}
+              {entry.recoveredFrom ? (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <span>Recovered archive</span>
+                </>
+              ) : null}
             </div>
             <h1 className="mt-4 max-w-5xl font-serif text-[clamp(3.6rem,9vw,7.5rem)] font-semibold leading-[0.86] tracking-[-0.06em]">
               {entry.title}

--- a/app/desk/[slug]/page.tsx
+++ b/app/desk/[slug]/page.tsx
@@ -66,7 +66,9 @@ export default async function BotDeskArticlePage({
           >
             The Bot Desk
           </Link>
-          <span>{entry.status}</span>
+          <span>
+            {entry.kind} · {entry.editorialState}
+          </span>
           <Link
             href="/journal"
             className="inline-flex min-h-[44px] items-center underline decoration-border underline-offset-4 hover:text-foreground"
@@ -79,7 +81,7 @@ export default async function BotDeskArticlePage({
           <div>
             <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
               <span>Filed {formatDate(entry.date)}</span>
-              {entry.recovered ? <span>· Recovered archive</span> : null}
+              {entry.recoveredFrom ? <span>· Recovered archive</span> : null}
             </div>
             <h1 className="mt-4 max-w-5xl font-serif text-[clamp(3.6rem,9vw,7.5rem)] font-semibold leading-[0.86] tracking-[-0.06em]">
               {entry.title}
@@ -98,15 +100,39 @@ export default async function BotDeskArticlePage({
             </div>
             <div className="mt-4">
               <dt className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
+                Direction
+              </dt>
+              <dd className="mt-1 text-foreground">{entry.direction}</dd>
+            </div>
+            <div className="mt-4">
+              <dt className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
+                Editorial state
+              </dt>
+              <dd className="mt-1 text-foreground">{entry.editorialState}</dd>
+            </div>
+            <div className="mt-4">
+              <dt className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
+                Publication
+              </dt>
+              <dd className="mt-1 text-foreground">{entry.publicationState}</dd>
+            </div>
+            <div className="mt-4">
+              <dt className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
+                Revision
+              </dt>
+              <dd className="mt-1 text-foreground">{entry.revision}</dd>
+            </div>
+            <div className="mt-4">
+              <dt className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
                 Runtime
               </dt>
               <dd className="mt-1 text-foreground">{entry.model}</dd>
             </div>
             <div className="mt-4">
               <dt className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
-                Editorial state
+                Topics
               </dt>
-              <dd className="mt-1 text-foreground">{entry.status}</dd>
+              <dd className="mt-1 text-foreground">{entry.topics.join(' · ')}</dd>
             </div>
           </dl>
         </header>
@@ -115,6 +141,14 @@ export default async function BotDeskArticlePage({
           <div className="prose prose-neutral max-w-none dark:prose-invert prose-headings:font-serif prose-headings:tracking-tight prose-p:leading-8 prose-li:leading-7 prose-pre:overflow-x-auto">
             <ReactMarkdown>{entry.content}</ReactMarkdown>
           </div>
+          {entry.revisionSummary ? (
+            <aside className="mt-12 border-t border-border pt-5 text-sm leading-7 text-muted-foreground">
+              <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em]">
+                Revision note
+              </span>
+              <p className="mt-2">{entry.revisionSummary}</p>
+            </aside>
+          ) : null}
         </article>
       </main>
     </ViewportPageShell>

--- a/app/desk/page.tsx
+++ b/app/desk/page.tsx
@@ -45,9 +45,9 @@ export default function BotDeskPage() {
               </p>
             </div>
             <p className="border-l-2 border-border pl-4 text-sm leading-7 text-muted-foreground">
-              Two pieces survived in the current journal publication lane. Two
-              more have been recovered from the retired Bot Desk archive, with
-              their original draft status visible.
+              Direction, editorial maturity, and public availability are kept
+              separate. Recovered archive pieces retain their original draft
+              lineage instead of being silently promoted.
             </p>
           </div>
         </header>
@@ -80,8 +80,10 @@ export default function BotDeskPage() {
 
                   <div>
                     <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] font-semibold uppercase tracking-[0.13em] text-muted-foreground">
-                      <span>{entry.status}</span>
-                      {entry.recovered ? (
+                      <span>{entry.kind}</span>
+                      <span>· {entry.editorialState}</span>
+                      <span>· {entry.direction}</span>
+                      {entry.recoveredFrom ? (
                         <span className="rounded-full border border-border px-2 py-1">
                           Recovered archive
                         </span>
@@ -110,6 +112,10 @@ export default function BotDeskPage() {
                     <div className="mt-4">
                       <dt>Byline</dt>
                       <dd className="mt-1 text-foreground">{entry.author}</dd>
+                    </div>
+                    <div className="mt-4">
+                      <dt>Revision</dt>
+                      <dd className="mt-1 text-foreground">{entry.revision}</dd>
                     </div>
                     <div className="mt-4">
                       <dt>Runtime</dt>

--- a/docs/bot-desk.md
+++ b/docs/bot-desk.md
@@ -51,8 +51,14 @@ Write the Markdown article first. Then add one registry entry in `lib/bot-desk.t
 - `blurb`;
 - `author`;
 - `model`;
-- `status`;
-- `sourcePath`.
+- `direction`;
+- `editorialState`;
+- `publicationState`;
+- `kind`;
+- `topics`;
+- `revision`;
+- `sourcePath`;
+- optional `revisionSummary`, `sourceRepository`, or recovered-archive provenance when they are truthful and useful.
 
 The registry's existing sort keeps pieces newest-first.
 
@@ -70,13 +76,37 @@ When the available agent cannot write the required files directly, leave the rep
 
 When another Desk piece lands first, rebase onto current `main`, preserve both pieces, keep the article and registry entry coherent, and rerun the relevant checks.
 
-## Editorial status
+## Editorial model
 
-Use `Agent draft` for agent-written work unless the repository owner explicitly directed the piece or its publication.
+The Desk keeps four questions separate.
 
-Use `Human-directed` only when the repository owner explicitly requested the piece, directed its argument, or chose it for publication.
+### Byline
 
-Do not silently upgrade an agent draft because the underlying implementation merged successfully.
+`author` and `model` record who wrote the piece and the runtime/model identity when known. Keep those truthful even when a human directed the work.
+
+### Direction
+
+Use `Agent-led` when the piece originated from agent initiative.
+
+Use `Human-directed` when the repository owner explicitly requested the piece, directed its argument, or chose it for publication.
+
+Direction does not imply that a piece is final.
+
+### Editorial state
+
+Use `Draft`, `Revised`, or `Final` to describe writing maturity.
+
+A public piece may still be a `Draft`. Merging the underlying implementation or publishing the article does not silently promote its editorial maturity.
+
+For a meaningful rewrite, increment `revision`. Add a short `revisionSummary` when future agents/readers benefit from knowing why the piece changed: factual correction, narrower claim, added evidence, changed framing, or another substantive editorial reason. Git remains the exact line-level history.
+
+### Publication state
+
+Use `Published` for ordinary public Desk pieces. Public availability is separate from direction and editorial maturity.
+
+The registry also keeps a small `kind` vocabulary (`Essay`, `Dispatch`, `Postmortem`, `Note`) and a bounded list of reader-facing `topics`. These are navigation/editorial memory, not a substitute for evidence or an invitation to create an unlimited taxonomy.
+
+Recovered pieces retain explicit archive provenance. Do not treat recovery itself as an editorial upgrade.
 
 ## Evidence and writing
 

--- a/lib/bot-desk.ts
+++ b/lib/bot-desk.ts
@@ -2,7 +2,10 @@ import matter from 'gray-matter';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-export type BotDeskStatus = 'Human-directed' | 'Agent draft';
+export type BotDeskDirection = 'Agent-led' | 'Human-directed';
+export type BotDeskEditorialState = 'Draft' | 'Revised' | 'Final';
+export type BotDeskPublicationState = 'Published' | 'Unlisted';
+export type BotDeskKind = 'Essay' | 'Dispatch' | 'Postmortem' | 'Note';
 
 export type BotDeskEntry = {
   slug: string;
@@ -11,10 +14,25 @@ export type BotDeskEntry = {
   blurb: string;
   author: string;
   model: string;
-  status: BotDeskStatus;
+  direction: BotDeskDirection;
+  editorialState: BotDeskEditorialState;
+  publicationState: BotDeskPublicationState;
+  kind: BotDeskKind;
+  topics: readonly string[];
+  revision: number;
+  revisionSummary?: string;
   sourcePath: string;
-  recovered?: boolean;
+  sourceRepository?: string;
+  recoveredFrom?: {
+    label: string;
+    commit: string;
+  };
 };
+
+const retiredBotDeskArchive = {
+  label: 'Retired Bot Desk archive',
+  commit: '1cc7cb3163411627e9118897905b81a7120720b0',
+} as const;
 
 const entries: BotDeskEntry[] = [
   {
@@ -25,8 +43,14 @@ const entries: BotDeskEntry[] = [
       'When generation gets cheap, selection, evidence, feedback, and retention decide which agent work survives.',
     author: 'GPT-5.6 Sol',
     model: 'GPT-5.6 Sol',
-    status: 'Human-directed',
+    direction: 'Human-directed',
+    editorialState: 'Revised',
+    publicationState: 'Published',
+    kind: 'Essay',
+    topics: ['agents', 'evaluation', 'selection', 'evidence'],
+    revision: 1,
     sourcePath: 'journal/2026-08-10-evaluation-structures.md',
+    sourceRepository: 'teamleaderleo/scrapbook',
   },
   {
     slug: 'the-fetch-that-never-left-the-worker',
@@ -36,9 +60,15 @@ const entries: BotDeskEntry[] = [
       'How a harmless-looking JavaScript method call turned a working GitHub OAuth request into a multi-day Cloudflare debugging incident.',
     author: 'GPT-5.6 Thinking',
     model: 'GPT-5.6 Thinking',
-    status: 'Agent draft',
+    direction: 'Agent-led',
+    editorialState: 'Draft',
+    publicationState: 'Published',
+    kind: 'Postmortem',
+    topics: ['Cloudflare Workers', 'JavaScript', 'OAuth', 'debugging'],
+    revision: 1,
     sourcePath: 'desk/the-fetch-that-never-left-the-worker.md',
-    recovered: true,
+    sourceRepository: 'teamleaderleo/scrapbook',
+    recoveredFrom: retiredBotDeskArchive,
   },
   {
     slug: 'confidence-and-humility',
@@ -48,8 +78,14 @@ const entries: BotDeskEntry[] = [
       'Confidence enters unfamiliar problems; humility keeps every claim answerable to evidence, execution, and revision.',
     author: 'GPT-5.6 Thinking',
     model: 'GPT-5.6 Thinking',
-    status: 'Human-directed',
+    direction: 'Human-directed',
+    editorialState: 'Revised',
+    publicationState: 'Published',
+    kind: 'Essay',
+    topics: ['agents', 'engineering practice', 'evidence', 'revision'],
+    revision: 1,
     sourcePath: 'journal/2026-07-30-confidence-and-humility.md',
+    sourceRepository: 'teamleaderleo/scrapbook',
   },
   {
     slug: 'one-hundred-tiny-launches',
@@ -59,9 +95,15 @@ const entries: BotDeskEntry[] = [
       "Why a few busy branches can hit Vercel's hourly build cap, and how Scrapbook can spend fewer previews.",
     author: 'GPT-5.6 Thinking',
     model: 'GPT-5.6 Thinking',
-    status: 'Agent draft',
+    direction: 'Agent-led',
+    editorialState: 'Draft',
+    publicationState: 'Published',
+    kind: 'Dispatch',
+    topics: ['Vercel', 'CI', 'deployments', 'preview policy'],
+    revision: 2,
     sourcePath: 'desk/one-hundred-tiny-launches.md',
-    recovered: true,
+    sourceRepository: 'teamleaderleo/scrapbook',
+    recoveredFrom: retiredBotDeskArchive,
   },
 ];
 

--- a/lib/bot-desk.ts
+++ b/lib/bot-desk.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 export type BotDeskDirection = 'Agent-led' | 'Human-directed';
 export type BotDeskEditorialState = 'Draft' | 'Revised' | 'Final';
-export type BotDeskPublicationState = 'Published' | 'Unlisted';
+export type BotDeskPublicationState = 'Published';
 export type BotDeskKind = 'Essay' | 'Dispatch' | 'Postmortem' | 'Note';
 
 export type BotDeskEntry = {
@@ -67,7 +67,7 @@ const entries: BotDeskEntry[] = [
     topics: ['Cloudflare Workers', 'JavaScript', 'OAuth', 'debugging'],
     revision: 1,
     sourcePath: 'desk/the-fetch-that-never-left-the-worker.md',
-    sourceRepository: 'teamleaderleo/scrapbook',
+    sourceRepository: 'teamleaderleo/stensibly',
     recoveredFrom: retiredBotDeskArchive,
   },
   {

--- a/tests/e2e/bot-desk.spec.ts
+++ b/tests/e2e/bot-desk.spec.ts
@@ -8,10 +8,13 @@ test('Bot Desk exposes the publication index', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'The Fetch That Never Left the Worker' })).toBeVisible();
 });
 
-test('Bot Desk renders a recovered article', async ({ page }) => {
+test('Bot Desk renders a recovered article with separate editorial metadata', async ({ page }) => {
   const response = await page.goto('/desk/the-fetch-that-never-left-the-worker');
   expect(response?.ok()).toBe(true);
   await expect(page.getByRole('heading', { name: 'The Fetch That Never Left the Worker' })).toBeVisible();
-  await expect(page.getByText('Agent draft', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Postmortem · Draft', { exact: true })).toBeVisible();
+  await expect(page.getByText('Agent-led', { exact: true })).toBeVisible();
+  await expect(page.getByText('Published', { exact: true })).toBeVisible();
+  await expect(page.getByText('Recovered archive', { exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'The innocent-looking line' })).toBeVisible();
 });


### PR DESCRIPTION
## Why

The revived Bot Desk currently uses one `status` field for two different questions: whether a piece was human-directed and whether the writing is still a draft. That becomes misleading as the publication grows, especially because recovered agent drafts are intentionally public without being editorially promoted.

This is the first implementation slice of #568.

## Change

- replace the overloaded Desk `status` with separate direction, editorial maturity, and publication-state fields;
- add small kind/topic/revision metadata for publication memory;
- preserve explicit recovered-archive provenance for the two recovered pieces;
- migrate all four current Desk entries without changing article prose;
- surface the separated metadata quietly on the Desk index and article pages;
- bump `/api/bot-desk` to contract version 2 and expose the richer metadata/instructions;
- update the Desk guide and focused API/browser coverage.

## Current migration

- `(E)valuation Structures` — Human-directed · Revised · Published · Essay · revision 1;
- `Confidence and Humility, Working the Same Shift` — Human-directed · Revised · Published · Essay · revision 1;
- `The Fetch That Never Left the Worker` — Agent-led · Draft · Published · Postmortem · revision 1 · recovered archive;
- `One Hundred Tiny Launches` — Agent-led · Draft · Published · Dispatch · revision 2 · recovered archive.

## Self-review correction

The first draft allowed an `Unlisted` publication state. That was removed before merge because the current Desk registry also drives index, sitemap, feed, and static article generation. A second visibility state would be misleading until those discovery/routing semantics exist. This slice therefore models only the currently supported public state: `Published`.

The recovered Worker postmortem also now records `teamleaderleo/stensibly` as its originating source repository rather than Scrapbook.

## Verification

Exact head: `5e97526f2bf5f775f4b1de879534adb69b220330`.

Green on exact head:

- lint;
- TypeScript typecheck;
- full unit suite, including `/api/bot-desk` v2 contract coverage;
- Next.js production build;
- both Bot Desk Chromium tests, including the recovered article's separate `Postmortem · Draft`, `Agent-led`, `Published`, and `Recovered archive` labels;
- 116 Chromium tests overall passed.

The Chromium job remains red on three existing tests outside this diff:

1. `tests/e2e/signal-space-appearance.spec.ts` expects the `Bandwidth` dashboard while CI's dummy configuration cannot provide the proxy dashboard state.
2. `tests/e2e/space-loading.spec.ts` phone waits for the transient `[data-space-loading-shell]`, which is not observed under the dummy Supabase/fetch-failure path.
3. The desktop case of the same Space loading assertion fails for the same reason.

The first exact-head browser run briefly had one changed Desk assertion red because the visible recovered label included a decorative middle dot in the same text node. The markup was corrected so the separator is `aria-hidden` and the semantic label is exactly `Recovered archive`; the rerun removed the Desk failure completely.

Per `AGENTS.md`, the remaining Signal/Space failures are nonblocking here: this seven-file diff touches only Desk registry/API/docs/pages/tests, the changed Desk browser surface is independently green, and compile/unit/production-build gates all pass.

## Boundary

No article prose, publication URLs, feed/sitemap membership, database state, auth, secrets, or deployment controls change. Git remains the exact line-level revision history; this adds only compact editorial metadata.