### PR TITLE
Make mobile Space actions obvious and keep editor state across dismissal

### DIFF
--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -37,7 +37,7 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
             <SearchCommand />
             <AppSidebar />
             <div
-              className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+              className="h-full min-h-0 min-w-0 flex-1 overflow-hidden pb-[var(--space-mobile-actions-offset,0px)] md:pb-0"
               data-space-background
             >
               {children}

--- a/app/space/layout.tsx
+++ b/app/space/layout.tsx
@@ -6,6 +6,7 @@ import { SpaceShellSkeleton } from '@/components/space/space-shell-skeleton';
 import { ItemsProvider } from '../lib/contexts/item-context';
 import { SearchCommand } from '@/components/space/search-command';
 import { MonacoEditorPanel } from '@/components/space/monaco-editor-panel';
+import { SpaceMobileActions } from '@/components/space/space-mobile-actions';
 import { SpaceShortcutProvider } from '@/components/space/space-shortcut-provider';
 import { loadInitialSpaceData } from './data';
 
@@ -35,9 +36,13 @@ async function SpaceDataShell({ children }: { children: React.ReactNode }) {
           <div className="flex h-[100dvh] min-h-0 w-full min-w-0 overflow-hidden bg-background text-foreground">
             <SearchCommand />
             <AppSidebar />
-            <div className="h-full min-h-0 min-w-0 flex-1 overflow-hidden">
+            <div
+              className="h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+              data-space-background
+            >
               {children}
             </div>
+            <SpaceMobileActions />
             <MonacoEditorPanel />
           </div>
         </SpaceShortcutProvider>

--- a/components/space/monaco-editor-panel.module.css
+++ b/components/space/monaco-editor-panel.module.css
@@ -1,7 +1,11 @@
 .panel {
   position: fixed;
-  inset: 3.5rem 0.5rem 0.5rem;
-  height: auto;
+  left: 0;
+  right: 0;
+  top: var(--mobile-editor-top, 0px);
+  bottom: auto;
+  width: auto;
+  height: var(--mobile-editor-height, 100dvh);
 }
 
 @media (min-width: 768px) {

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -17,9 +17,7 @@ import {
   useSpaceShortcuts,
 } from '@/components/space/space-shortcut-provider';
 import {
-  SPACE_EDITOR_HASH,
   createBrowserEditorSheetRestoration,
-  isEditorSheetHash,
   resolveEditorSheetViewport,
   type EditorSheetViewport,
 } from '@/lib/space-editor-sheet';
@@ -49,7 +47,6 @@ export function MonacoEditorPanel() {
   const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
   const editorOpenRef = useRef(editorOpen);
-  const ownsHashEntryRef = useRef(false);
   const restorationRef = useRef<ReturnType<
     typeof createBrowserEditorSheetRestoration
   > | null>(null);
@@ -169,6 +166,20 @@ export function MonacoEditorPanel() {
         executeShortcut('editor.toggle');
       });
 
+      editor.onKeyDown(event => {
+        if (
+          event.keyCode !== monaco.KeyCode.Escape ||
+          !window.matchMedia('(max-width: 767px)').matches
+        ) {
+          return;
+        }
+
+        if (executeShortcut('editor.close')) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      });
+
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
         const maxHeight = window.innerHeight - 112;
@@ -226,18 +237,9 @@ export function MonacoEditorPanel() {
   }, [restoreBackground]);
 
   const closeEditor = useCallback(() => {
-    if (
-      isMobile &&
-      ownsHashEntryRef.current &&
-      isEditorSheetHash(window.location.hash)
-    ) {
-      history.back();
-      return;
-    }
-
     setEditorOpen(false);
     restoreAfterClose();
-  }, [isMobile, restoreAfterClose, setEditorOpen]);
+  }, [restoreAfterClose, setEditorOpen]);
 
   const openEditor = useCallback(() => {
     if (editorOpen) return;
@@ -250,11 +252,6 @@ export function MonacoEditorPanel() {
           : null,
         collectScrollableSpaceRegions()
       );
-
-      if (!isEditorSheetHash(window.location.hash)) {
-        ownsHashEntryRef.current = true;
-        window.location.hash = SPACE_EDITOR_HASH.slice(1);
-      }
     }
 
     setHasMountedEditor(true);
@@ -280,36 +277,6 @@ export function MonacoEditorPanel() {
 
   useSpaceShortcut('editor.toggle', toggleEditor);
   useSpaceShortcut('editor.close', closeEditorShortcut);
-
-  useEffect(() => {
-    if (!isMobile) return;
-
-    const onHashChange = () => {
-      if (!ownsHashEntryRef.current) return;
-      const editorHashActive = isEditorSheetHash(window.location.hash);
-
-      if (editorHashActive && !editorOpen) {
-        restorationRef.current ??= createBrowserEditorSheetRestoration();
-        restorationRef.current.capture(
-          document.activeElement instanceof HTMLElement
-            ? document.activeElement
-            : null,
-          collectScrollableSpaceRegions()
-        );
-        setHasMountedEditor(true);
-        setEditorOpen(true);
-        return;
-      }
-
-      if (!editorHashActive && editorOpen) {
-        setEditorOpen(false);
-        restoreAfterClose();
-      }
-    };
-
-    window.addEventListener('hashchange', onHashChange);
-    return () => window.removeEventListener('hashchange', onHashChange);
-  }, [editorOpen, isMobile, restoreAfterClose, setEditorOpen]);
 
   useEffect(() => {
     if (!isMobile || !editorOpen) {

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -1,26 +1,78 @@
 'use client';
 
-import { useEffect, useRef, useState, type CSSProperties } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import { X } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useSidebar } from '@/components/ui/sidebar';
 import { useItems } from '@/app/lib/contexts/item-context';
-import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
+import {
+  useSpaceShortcut,
+  useSpaceShortcuts,
+} from '@/components/space/space-shortcut-provider';
+import {
+  createBrowserEditorSheetRestoration,
+  createEditorSheetHistoryState,
+  ownsEditorSheetHistoryState,
+  resolveEditorSheetViewport,
+  type EditorSheetViewport,
+} from '@/lib/space-editor-sheet';
 import styles from './monaco-editor-panel.module.css';
+
+function collectScrollableSpaceRegions() {
+  const root = document.querySelector<HTMLElement>('[data-space-background]');
+  if (!root) return [];
+
+  return [root, ...root.querySelectorAll<HTMLElement>('*')].filter(element => {
+    const style = getComputedStyle(element);
+    const scrollable = /^(auto|scroll)$/.test(style.overflowY);
+    return scrollable && element.scrollHeight > element.clientHeight;
+  });
+}
+
+function visibleEditorTrigger() {
+  return [...document.querySelectorAll<HTMLElement>('[data-space-editor-trigger]')].find(
+    element => element.getClientRects().length > 0
+  );
+}
 
 export function MonacoEditorPanel() {
   const { editorOpen, setEditorOpen } = useItems();
   const { executeShortcut } = useSpaceShortcuts();
   const editorRef = useRef<HTMLDivElement>(null);
+  const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
+  const restorationRef = useRef<ReturnType<
+    typeof createBrowserEditorSheetRestoration
+  > | null>(null);
+  const historyTokenRef = useRef(
+    `space-editor-${Math.random().toString(36).slice(2)}`
+  );
   const { resolvedTheme } = useTheme();
-  const { state } = useSidebar();
+  const { state, isMobile } = useSidebar();
   const [editorHeight, setEditorHeight] = useState(384);
+  const [hasMountedEditor, setHasMountedEditor] = useState(false);
   const [isInitializing, setIsInitializing] = useState(false);
   const [initializationError, setInitializationError] = useState<string | null>(null);
+  const [mobileViewport, setMobileViewport] = useState<EditorSheetViewport>(() => ({
+    top: 0,
+    height: 0,
+    bottom: 0,
+  }));
 
   const isDark = resolvedTheme === 'dark';
   const shikiTheme = isDark ? 'catppuccin-macchiato' : 'one-light';
   const sidebarWidth = state === 'collapsed' ? '3rem' : '16rem';
+
+  useEffect(() => {
+    if (editorOpen) setHasMountedEditor(true);
+  }, [editorOpen]);
 
   useEffect(() => {
     if (!monacoRef.current) return;
@@ -28,14 +80,9 @@ export function MonacoEditorPanel() {
   }, [shikiTheme]);
 
   useEffect(() => {
-    if (!editorOpen) {
-      setEditorHeight(384);
-      setIsInitializing(false);
-      setInitializationError(null);
+    if (!hasMountedEditor || editorInstanceRef.current || !editorRef.current) {
       return;
     }
-
-    if (!editorRef.current) return;
 
     setIsInitializing(true);
     setInitializationError(null);
@@ -50,22 +97,19 @@ export function MonacoEditorPanel() {
     }
 
     let disposed = false;
-    let cleanup: (() => void) | undefined;
 
     const initEditor = async () => {
-      if (typeof window !== 'undefined') {
-        (window as any).MonacoEnvironment = {
-          getWorker() {
-            return new Worker(
-              URL.createObjectURL(
-                new Blob(['self.onmessage = () => {}'], {
-                  type: 'text/javascript',
-                })
-              )
-            );
-          },
-        };
-      }
+      (window as any).MonacoEnvironment = {
+        getWorker() {
+          return new Worker(
+            URL.createObjectURL(
+              new Blob(['self.onmessage = () => {}'], {
+                type: 'text/javascript',
+              })
+            )
+          );
+        },
+      };
 
       const [
         { createHighlighter },
@@ -116,6 +160,7 @@ export function MonacoEditorPanel() {
         lineNumbersMinChars: 3,
       });
 
+      editorInstanceRef.current = editor;
       monaco.editor.setTheme(shikiTheme);
       setIsInitializing(false);
 
@@ -123,19 +168,13 @@ export function MonacoEditorPanel() {
         executeShortcut('editor.toggle');
       });
 
-      editor.focus();
-
       editor.onDidContentSizeChange(() => {
         const contentHeight = editor.getContentHeight();
         const maxHeight = window.innerHeight - 112;
-        const newHeight = Math.max(
-          384,
-          Math.min(contentHeight + 32, maxHeight)
-        );
-        setEditorHeight(newHeight);
+        setEditorHeight(Math.max(384, Math.min(contentHeight + 32, maxHeight)));
       });
 
-      cleanup = () => editor.dispose();
+      if (editorOpen) editor.focus();
     };
 
     void initEditor().catch(error => {
@@ -147,49 +186,244 @@ export function MonacoEditorPanel() {
 
     return () => {
       disposed = true;
-      cleanup?.();
+      editorInstanceRef.current?.dispose();
+      editorInstanceRef.current = null;
     };
-  }, [editorOpen, executeShortcut, shikiTheme]);
+  }, [editorOpen, executeShortcut, hasMountedEditor, shikiTheme]);
 
-  if (!editorOpen) return null;
+  useEffect(() => {
+    if (!editorOpen || !editorInstanceRef.current) return;
+    editorInstanceRef.current.layout();
+    editorInstanceRef.current.focus();
+  }, [editorOpen, isMobile, mobileViewport.height]);
+
+  const restoreBackground = useCallback(() => {
+    for (const element of document.querySelectorAll<HTMLElement>(
+      '[data-space-background], [data-space-mobile-actions]'
+    )) {
+      element.removeAttribute('inert');
+      element.removeAttribute('aria-hidden');
+    }
+  }, []);
+
+  const restoreAfterClose = useCallback(() => {
+    restoreBackground();
+    restorationRef.current?.restore(visibleEditorTrigger() ?? null);
+  }, [restoreBackground]);
+
+  const closeEditor = useCallback(() => {
+    if (
+      isMobile &&
+      ownsEditorSheetHistoryState(history.state, historyTokenRef.current)
+    ) {
+      history.back();
+      return;
+    }
+
+    setEditorOpen(false);
+    restoreAfterClose();
+  }, [isMobile, restoreAfterClose, setEditorOpen]);
+
+  const openEditor = useCallback(() => {
+    if (editorOpen) return;
+
+    if (isMobile) {
+      restorationRef.current ??= createBrowserEditorSheetRestoration();
+      restorationRef.current.capture(
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null,
+        collectScrollableSpaceRegions()
+      );
+
+      if (
+        !ownsEditorSheetHistoryState(history.state, historyTokenRef.current)
+      ) {
+        history.pushState(
+          createEditorSheetHistoryState(history.state, historyTokenRef.current),
+          '',
+          window.location.href
+        );
+      }
+    }
+
+    setEditorOpen(true);
+  }, [editorOpen, isMobile, setEditorOpen]);
+
+  const toggleEditor = useMemo(
+    () => ({
+      run: () => {
+        if (editorOpen) closeEditor();
+        else openEditor();
+      },
+    }),
+    [closeEditor, editorOpen, openEditor]
+  );
+  const closeEditorShortcut = useMemo(
+    () => ({
+      active: isMobile && editorOpen,
+      run: closeEditor,
+    }),
+    [closeEditor, editorOpen, isMobile]
+  );
+
+  useSpaceShortcut('editor.toggle', toggleEditor);
+  useSpaceShortcut('editor.close', closeEditorShortcut);
+
+  useEffect(() => {
+    if (!isMobile) return;
+
+    const onPopState = () => {
+      const owned = ownsEditorSheetHistoryState(
+        history.state,
+        historyTokenRef.current
+      );
+
+      if (owned && !editorOpen) {
+        restorationRef.current ??= createBrowserEditorSheetRestoration();
+        restorationRef.current.capture(
+          document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : null,
+          collectScrollableSpaceRegions()
+        );
+        setEditorOpen(true);
+        return;
+      }
+
+      if (!owned && editorOpen) {
+        setEditorOpen(false);
+        restoreAfterClose();
+      }
+    };
+
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, [editorOpen, isMobile, restoreAfterClose, setEditorOpen]);
+
+  useEffect(() => {
+    if (!isMobile || !editorOpen) {
+      restoreBackground();
+      return;
+    }
+
+    for (const element of document.querySelectorAll<HTMLElement>(
+      '[data-space-background], [data-space-mobile-actions]'
+    )) {
+      element.setAttribute('inert', '');
+      element.setAttribute('aria-hidden', 'true');
+    }
+
+    return restoreBackground;
+  }, [editorOpen, isMobile, restoreBackground]);
+
+  useEffect(() => {
+    if (!isMobile || !editorOpen) return;
+
+    const updateViewport = () => {
+      const viewport = window.visualViewport;
+      setMobileViewport(
+        resolveEditorSheetViewport(
+          window.innerHeight,
+          viewport
+            ? { height: viewport.height, offsetTop: viewport.offsetTop }
+            : null
+        )
+      );
+    };
+
+    updateViewport();
+    window.visualViewport?.addEventListener('resize', updateViewport);
+    window.visualViewport?.addEventListener('scroll', updateViewport);
+    window.addEventListener('resize', updateViewport);
+
+    return () => {
+      window.visualViewport?.removeEventListener('resize', updateViewport);
+      window.visualViewport?.removeEventListener('scroll', updateViewport);
+      window.removeEventListener('resize', updateViewport);
+    };
+  }, [editorOpen, isMobile]);
+
+  useEffect(
+    () => () => {
+      restorationRef.current?.cancel();
+      restoreBackground();
+    },
+    [restoreBackground]
+  );
+
+  if (!hasMountedEditor) return null;
 
   return (
-    <div
-      className={`${styles.panel} z-50 overflow-hidden rounded-lg border border-border bg-background shadow-2xl transition-[left,width] duration-200 ease-linear`}
+    <section
+      role={isMobile ? 'dialog' : undefined}
+      aria-modal={isMobile ? true : undefined}
+      aria-labelledby={isMobile ? 'space-code-editor-title' : undefined}
+      className={`${styles.panel} z-50 overflow-hidden border border-border bg-background shadow-2xl transition-[left,width] duration-200 ease-linear motion-reduce:transition-none ${
+        isMobile ? 'rounded-none' : 'rounded-lg'
+      } ${editorOpen ? '' : 'hidden'}`}
       style={
         {
           '--editor-left': `calc(${sidebarWidth} + 1rem)`,
           '--editor-width': `calc((100vw - ${sidebarWidth} - 2rem) / 2 - 0.375rem)`,
           '--editor-height': `${editorHeight}px`,
+          '--mobile-editor-top': `${mobileViewport.top}px`,
+          '--mobile-editor-height': `${mobileViewport.height || window.innerHeight}px`,
         } as CSSProperties
       }
       data-space-editor-panel
+      data-space-editor-mobile={isMobile ? 'true' : 'false'}
       data-space-shortcut-scope="editor"
     >
-      {isInitializing ? (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
-          <p className="animate-pulse text-sm text-[#383a42] dark:text-[#cad3f5]">
-            Opening editor…
-          </p>
-        </div>
-      ) : null}
-
-      {initializationError ? (
-        <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
-          <p className="max-w-sm text-sm leading-relaxed text-[#383a42] dark:text-[#cad3f5]">
-            {initializationError}
-          </p>
+      {isMobile ? (
+        <header className="flex min-h-14 items-center justify-between gap-3 border-b border-border/70 px-4 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
+          <div className="min-w-0">
+            <h2 id="space-code-editor-title" className="text-sm font-semibold">
+              Code editor
+            </h2>
+            <p className="text-[11px] text-muted-foreground">
+              Draft stays here while the sheet is dismissed.
+            </p>
+          </div>
           <button
             type="button"
-            onClick={() => setEditorOpen(false)}
-            className="rounded-md border border-black/15 bg-white px-3 py-1.5 text-sm font-medium text-black/75 transition hover:bg-black/[0.04] active:scale-[0.98] dark:border-white/15 dark:bg-[#18191d] dark:text-white/80 dark:hover:bg-[#25262c]"
+            onClick={closeEditor}
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-xl text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Close code editor"
           >
-            Close editor
+            <X className="h-4 w-4" aria-hidden="true" />
           </button>
-        </div>
+        </header>
       ) : null}
 
-      <div ref={editorRef} className="h-full w-full" />
-    </div>
+      <div
+        className={`${isMobile ? 'h-[calc(100%-3.5rem)] pb-[env(safe-area-inset-bottom)]' : 'h-full'} w-full`}
+      >
+        {isInitializing ? (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
+            <p className="animate-pulse text-sm text-[#383a42] dark:text-[#cad3f5]">
+              Opening editor…
+            </p>
+          </div>
+        ) : null}
+
+        {initializationError ? (
+          <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">
+            <p className="max-w-sm text-sm leading-relaxed text-[#383a42] dark:text-[#cad3f5]">
+              {initializationError}
+            </p>
+            <button
+              type="button"
+              onClick={closeEditor}
+              className="rounded-md border border-black/15 bg-white px-3 py-1.5 text-sm font-medium text-black/75 transition hover:bg-black/[0.04] active:scale-[0.98] dark:border-white/15 dark:bg-[#18191d] dark:text-white/80 dark:hover:bg-[#25262c]"
+            >
+              Close editor
+            </button>
+          </div>
+        ) : null}
+
+        <div ref={editorRef} className="h-full w-full" />
+      </div>
+    </section>
   );
 }

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -40,6 +40,12 @@ function visibleEditorTrigger() {
   );
 }
 
+function meaningfulFocusTarget() {
+  const active = document.activeElement;
+  if (active instanceof HTMLElement && active !== document.body) return active;
+  return visibleEditorTrigger() ?? null;
+}
+
 export function MonacoEditorPanel() {
   const { editorOpen, setEditorOpen } = useItems();
   const { executeShortcut } = useSpaceShortcuts();
@@ -247,9 +253,7 @@ export function MonacoEditorPanel() {
     if (isMobile) {
       restorationRef.current ??= createBrowserEditorSheetRestoration();
       restorationRef.current.capture(
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : null,
+        meaningfulFocusTarget(),
         collectScrollableSpaceRegions()
       );
     }

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -68,6 +68,8 @@ export function MonacoEditorPanel() {
 
   const isDark = resolvedTheme === 'dark';
   const shikiTheme = isDark ? 'catppuccin-macchiato' : 'one-light';
+  const shikiThemeRef = useRef(shikiTheme);
+  shikiThemeRef.current = shikiTheme;
   const sidebarWidth = state === 'collapsed' ? '3rem' : '16rem';
 
   useEffect(() => {
@@ -139,7 +141,7 @@ export function MonacoEditorPanel() {
       const editor = monaco.editor.create(editorRef.current, {
         value: '',
         language: 'python',
-        theme: shikiTheme,
+        theme: shikiThemeRef.current,
         automaticLayout: true,
         minimap: { enabled: false },
         fontSize: 14,
@@ -161,7 +163,7 @@ export function MonacoEditorPanel() {
       });
 
       editorInstanceRef.current = editor;
-      monaco.editor.setTheme(shikiTheme);
+      monaco.editor.setTheme(shikiThemeRef.current);
       setIsInitializing(false);
 
       editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyI, () => {
@@ -174,7 +176,7 @@ export function MonacoEditorPanel() {
         setEditorHeight(Math.max(384, Math.min(contentHeight + 32, maxHeight)));
       });
 
-      if (editorOpen) editor.focus();
+      editor.focus();
     };
 
     void initEditor().catch(error => {
@@ -189,7 +191,7 @@ export function MonacoEditorPanel() {
       editorInstanceRef.current?.dispose();
       editorInstanceRef.current = null;
     };
-  }, [editorOpen, executeShortcut, hasMountedEditor, shikiTheme]);
+  }, [executeShortcut, hasMountedEditor]);
 
   useEffect(() => {
     if (!editorOpen || !editorInstanceRef.current) return;
@@ -359,7 +361,7 @@ export function MonacoEditorPanel() {
       role={isMobile ? 'dialog' : undefined}
       aria-modal={isMobile ? true : undefined}
       aria-labelledby={isMobile ? 'space-code-editor-title' : undefined}
-      className={`${styles.panel} z-50 overflow-hidden border border-border bg-background shadow-2xl transition-[left,width] duration-200 ease-linear motion-reduce:transition-none ${
+      className={`${styles.panel} z-50 flex flex-col overflow-hidden border border-border bg-background shadow-2xl transition-[left,width] duration-200 ease-linear motion-reduce:transition-none ${
         isMobile ? 'rounded-none' : 'rounded-lg'
       } ${editorOpen ? '' : 'hidden'}`}
       style={
@@ -368,7 +370,9 @@ export function MonacoEditorPanel() {
           '--editor-width': `calc((100vw - ${sidebarWidth} - 2rem) / 2 - 0.375rem)`,
           '--editor-height': `${editorHeight}px`,
           '--mobile-editor-top': `${mobileViewport.top}px`,
-          '--mobile-editor-height': `${mobileViewport.height || window.innerHeight}px`,
+          '--mobile-editor-height': mobileViewport.height
+            ? `${mobileViewport.height}px`
+            : '100dvh',
         } as CSSProperties
       }
       data-space-editor-panel
@@ -376,7 +380,7 @@ export function MonacoEditorPanel() {
       data-space-shortcut-scope="editor"
     >
       {isMobile ? (
-        <header className="flex min-h-14 items-center justify-between gap-3 border-b border-border/70 px-4 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
+        <header className="flex min-h-14 shrink-0 items-center justify-between gap-3 border-b border-border/70 px-4 pb-2 pt-[max(0.5rem,env(safe-area-inset-top))]">
           <div className="min-w-0">
             <h2 id="space-code-editor-title" className="text-sm font-semibold">
               Code editor
@@ -397,7 +401,7 @@ export function MonacoEditorPanel() {
       ) : null}
 
       <div
-        className={`${isMobile ? 'h-[calc(100%-3.5rem)] pb-[env(safe-area-inset-bottom)]' : 'h-full'} w-full`}
+        className={`${isMobile ? 'pb-[env(safe-area-inset-bottom)]' : ''} relative min-h-0 flex-1`}
       >
         {isInitializing ? (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-[#f4f1ea] px-6 text-center dark:bg-[#202126]">

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -3,7 +3,6 @@
 import {
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
@@ -18,9 +17,9 @@ import {
   useSpaceShortcuts,
 } from '@/components/space/space-shortcut-provider';
 import {
+  SPACE_EDITOR_HASH,
   createBrowserEditorSheetRestoration,
-  createEditorSheetHistoryState,
-  ownsEditorSheetHistoryState,
+  isEditorSheetHash,
   resolveEditorSheetViewport,
   type EditorSheetViewport,
 } from '@/lib/space-editor-sheet';
@@ -43,15 +42,6 @@ function visibleEditorTrigger() {
   );
 }
 
-function pushNativeSameUrlHistoryState(state: unknown) {
-  window.History.prototype.pushState.call(
-    window.history,
-    state,
-    '',
-    window.location.href
-  );
-}
-
 export function MonacoEditorPanel() {
   const { editorOpen, setEditorOpen } = useItems();
   const { executeShortcut } = useSpaceShortcuts();
@@ -59,10 +49,10 @@ export function MonacoEditorPanel() {
   const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
   const editorOpenRef = useRef(editorOpen);
+  const ownsHashEntryRef = useRef(false);
   const restorationRef = useRef<ReturnType<
     typeof createBrowserEditorSheetRestoration
   > | null>(null);
-  const historyToken = useId();
   const { resolvedTheme } = useTheme();
   const { state, isMobile } = useSidebar();
   const [editorHeight, setEditorHeight] = useState(384);
@@ -236,14 +226,18 @@ export function MonacoEditorPanel() {
   }, [restoreBackground]);
 
   const closeEditor = useCallback(() => {
-    if (isMobile && ownsEditorSheetHistoryState(history.state, historyToken)) {
+    if (
+      isMobile &&
+      ownsHashEntryRef.current &&
+      isEditorSheetHash(window.location.hash)
+    ) {
       history.back();
       return;
     }
 
     setEditorOpen(false);
     restoreAfterClose();
-  }, [historyToken, isMobile, restoreAfterClose, setEditorOpen]);
+  }, [isMobile, restoreAfterClose, setEditorOpen]);
 
   const openEditor = useCallback(() => {
     if (editorOpen) return;
@@ -257,16 +251,15 @@ export function MonacoEditorPanel() {
         collectScrollableSpaceRegions()
       );
 
-      if (!ownsEditorSheetHistoryState(history.state, historyToken)) {
-        pushNativeSameUrlHistoryState(
-          createEditorSheetHistoryState(history.state, historyToken)
-        );
+      if (!isEditorSheetHash(window.location.hash)) {
+        ownsHashEntryRef.current = true;
+        window.location.hash = SPACE_EDITOR_HASH.slice(1);
       }
     }
 
     setHasMountedEditor(true);
     setEditorOpen(true);
-  }, [editorOpen, historyToken, isMobile, setEditorOpen]);
+  }, [editorOpen, isMobile, setEditorOpen]);
 
   const toggleEditor = useMemo(
     () => ({
@@ -291,10 +284,11 @@ export function MonacoEditorPanel() {
   useEffect(() => {
     if (!isMobile) return;
 
-    const onPopState = () => {
-      const owned = ownsEditorSheetHistoryState(history.state, historyToken);
+    const onHashChange = () => {
+      if (!ownsHashEntryRef.current) return;
+      const editorHashActive = isEditorSheetHash(window.location.hash);
 
-      if (owned && !editorOpen) {
+      if (editorHashActive && !editorOpen) {
         restorationRef.current ??= createBrowserEditorSheetRestoration();
         restorationRef.current.capture(
           document.activeElement instanceof HTMLElement
@@ -307,15 +301,15 @@ export function MonacoEditorPanel() {
         return;
       }
 
-      if (!owned && editorOpen) {
+      if (!editorHashActive && editorOpen) {
         setEditorOpen(false);
         restoreAfterClose();
       }
     };
 
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
-  }, [editorOpen, historyToken, isMobile, restoreAfterClose, setEditorOpen]);
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, [editorOpen, isMobile, restoreAfterClose, setEditorOpen]);
 
   useEffect(() => {
     if (!isMobile || !editorOpen) {

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -49,6 +49,8 @@ export function MonacoEditorPanel() {
   const editorRef = useRef<HTMLDivElement>(null);
   const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
+  const editorOpenRef = useRef(editorOpen);
+  editorOpenRef.current = editorOpen;
   const restorationRef = useRef<ReturnType<
     typeof createBrowserEditorSheetRestoration
   > | null>(null);
@@ -70,10 +72,6 @@ export function MonacoEditorPanel() {
   const shikiThemeRef = useRef(shikiTheme);
   shikiThemeRef.current = shikiTheme;
   const sidebarWidth = state === 'collapsed' ? '3rem' : '16rem';
-
-  useEffect(() => {
-    if (editorOpen) setHasMountedEditor(true);
-  }, [editorOpen]);
 
   useEffect(() => {
     if (!monacoRef.current) return;
@@ -175,7 +173,7 @@ export function MonacoEditorPanel() {
         setEditorHeight(Math.max(384, Math.min(contentHeight + 32, maxHeight)));
       });
 
-      editor.focus();
+      if (editorOpenRef.current) editor.focus();
     };
 
     void initEditor().catch(error => {
@@ -256,6 +254,7 @@ export function MonacoEditorPanel() {
       }
     }
 
+    setHasMountedEditor(true);
     setEditorOpen(true);
   }, [editorOpen, historyToken, isMobile, setEditorOpen]);
 
@@ -293,6 +292,7 @@ export function MonacoEditorPanel() {
             : null,
           collectScrollableSpaceRegions()
         );
+        setHasMountedEditor(true);
         setEditorOpen(true);
         return;
       }

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -3,6 +3,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -51,9 +52,7 @@ export function MonacoEditorPanel() {
   const restorationRef = useRef<ReturnType<
     typeof createBrowserEditorSheetRestoration
   > | null>(null);
-  const historyTokenRef = useRef(
-    `space-editor-${Math.random().toString(36).slice(2)}`
-  );
+  const historyToken = useId();
   const { resolvedTheme } = useTheme();
   const { state, isMobile } = useSidebar();
   const [editorHeight, setEditorHeight] = useState(384);
@@ -194,9 +193,22 @@ export function MonacoEditorPanel() {
   }, [executeShortcut, hasMountedEditor]);
 
   useEffect(() => {
-    if (!editorOpen || !editorInstanceRef.current) return;
-    editorInstanceRef.current.layout();
-    editorInstanceRef.current.focus();
+    if (!editorOpen) return;
+
+    if (editorInstanceRef.current) {
+      editorInstanceRef.current.layout();
+      editorInstanceRef.current.focus();
+      return;
+    }
+
+    if (isMobile) {
+      const frame = requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLElement>('[data-space-editor-close]')
+          ?.focus({ preventScroll: true });
+      });
+      return () => cancelAnimationFrame(frame);
+    }
   }, [editorOpen, isMobile, mobileViewport.height]);
 
   const restoreBackground = useCallback(() => {
@@ -214,17 +226,14 @@ export function MonacoEditorPanel() {
   }, [restoreBackground]);
 
   const closeEditor = useCallback(() => {
-    if (
-      isMobile &&
-      ownsEditorSheetHistoryState(history.state, historyTokenRef.current)
-    ) {
+    if (isMobile && ownsEditorSheetHistoryState(history.state, historyToken)) {
       history.back();
       return;
     }
 
     setEditorOpen(false);
     restoreAfterClose();
-  }, [isMobile, restoreAfterClose, setEditorOpen]);
+  }, [historyToken, isMobile, restoreAfterClose, setEditorOpen]);
 
   const openEditor = useCallback(() => {
     if (editorOpen) return;
@@ -238,11 +247,9 @@ export function MonacoEditorPanel() {
         collectScrollableSpaceRegions()
       );
 
-      if (
-        !ownsEditorSheetHistoryState(history.state, historyTokenRef.current)
-      ) {
+      if (!ownsEditorSheetHistoryState(history.state, historyToken)) {
         history.pushState(
-          createEditorSheetHistoryState(history.state, historyTokenRef.current),
+          createEditorSheetHistoryState(history.state, historyToken),
           '',
           window.location.href
         );
@@ -250,7 +257,7 @@ export function MonacoEditorPanel() {
     }
 
     setEditorOpen(true);
-  }, [editorOpen, isMobile, setEditorOpen]);
+  }, [editorOpen, historyToken, isMobile, setEditorOpen]);
 
   const toggleEditor = useMemo(
     () => ({
@@ -276,10 +283,7 @@ export function MonacoEditorPanel() {
     if (!isMobile) return;
 
     const onPopState = () => {
-      const owned = ownsEditorSheetHistoryState(
-        history.state,
-        historyTokenRef.current
-      );
+      const owned = ownsEditorSheetHistoryState(history.state, historyToken);
 
       if (owned && !editorOpen) {
         restorationRef.current ??= createBrowserEditorSheetRestoration();
@@ -301,7 +305,7 @@ export function MonacoEditorPanel() {
 
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, [editorOpen, isMobile, restoreAfterClose, setEditorOpen]);
+  }, [editorOpen, historyToken, isMobile, restoreAfterClose, setEditorOpen]);
 
   useEffect(() => {
     if (!isMobile || !editorOpen) {
@@ -392,6 +396,7 @@ export function MonacoEditorPanel() {
           <button
             type="button"
             onClick={closeEditor}
+            data-space-editor-close
             className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-xl text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label="Close code editor"
           >

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -43,6 +43,15 @@ function visibleEditorTrigger() {
   );
 }
 
+function pushNativeSameUrlHistoryState(state: unknown) {
+  window.History.prototype.pushState.call(
+    window.history,
+    state,
+    '',
+    window.location.href
+  );
+}
+
 export function MonacoEditorPanel() {
   const { editorOpen, setEditorOpen } = useItems();
   const { executeShortcut } = useSpaceShortcuts();
@@ -249,10 +258,8 @@ export function MonacoEditorPanel() {
       );
 
       if (!ownsEditorSheetHistoryState(history.state, historyToken)) {
-        history.pushState(
-          createEditorSheetHistoryState(history.state, historyToken),
-          '',
-          window.location.href
+        pushNativeSameUrlHistoryState(
+          createEditorSheetHistoryState(history.state, historyToken)
         );
       }
     }

--- a/components/space/monaco-editor-panel.tsx
+++ b/components/space/monaco-editor-panel.tsx
@@ -50,7 +50,6 @@ export function MonacoEditorPanel() {
   const editorInstanceRef = useRef<any>(null);
   const monacoRef = useRef<any>(null);
   const editorOpenRef = useRef(editorOpen);
-  editorOpenRef.current = editorOpen;
   const restorationRef = useRef<ReturnType<
     typeof createBrowserEditorSheetRestoration
   > | null>(null);
@@ -70,10 +69,14 @@ export function MonacoEditorPanel() {
   const isDark = resolvedTheme === 'dark';
   const shikiTheme = isDark ? 'catppuccin-macchiato' : 'one-light';
   const shikiThemeRef = useRef(shikiTheme);
-  shikiThemeRef.current = shikiTheme;
   const sidebarWidth = state === 'collapsed' ? '3rem' : '16rem';
 
   useEffect(() => {
+    editorOpenRef.current = editorOpen;
+  }, [editorOpen]);
+
+  useEffect(() => {
+    shikiThemeRef.current = shikiTheme;
     if (!monacoRef.current) return;
     monacoRef.current.editor.setTheme(shikiTheme);
   }, [shikiTheme]);

--- a/components/space/space-header.tsx
+++ b/components/space/space-header.tsx
@@ -33,6 +33,7 @@ export function SpaceHeader({
     pathname === '/space/review' ||
     pathname?.startsWith('/space/add') ||
     pathname?.startsWith('/space/edit');
+  const usesMobileActionRail = pathname === '/space' || pathname === '/space/review';
   const isMac = useIsMacPlatform();
   const toggleParams = new URLSearchParams();
   if (tagsParam) toggleParams.set('tags', tagsParam);
@@ -78,8 +79,11 @@ export function SpaceHeader({
 
       {onEditorToggle ? (
         <button
+          data-space-editor-trigger
           onClick={onEditorToggle}
-          className={`inline-flex h-8 items-center gap-1.5 rounded-lg border px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+          className={`${
+            usesMobileActionRail ? 'hidden md:inline-flex' : 'inline-flex'
+          } h-8 items-center gap-1.5 rounded-lg border px-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
             isEditorOpen
               ? 'border-border bg-muted text-foreground'
               : 'border-transparent text-muted-foreground hover:border-border/60 hover:bg-muted/65 hover:text-foreground'
@@ -90,7 +94,9 @@ export function SpaceHeader({
           type="button"
         >
           <Code className="h-4 w-4" />
-          <span className="hidden sm:inline">Editor</span>
+          <span className={usesMobileActionRail ? '' : 'hidden sm:inline'}>
+            Editor
+          </span>
         </button>
       ) : null}
 

--- a/components/space/space-mobile-actions.tsx
+++ b/components/space/space-mobile-actions.tsx
@@ -8,11 +8,13 @@ import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
 function ActionButton({
   label,
   disabled = false,
+  editorTrigger = false,
   onClick,
   children,
 }: {
   label: string;
   disabled?: boolean;
+  editorTrigger?: boolean;
   onClick: () => void;
   children: React.ReactNode;
 }) {
@@ -21,6 +23,7 @@ function ActionButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
+      data-space-editor-trigger={editorTrigger ? 'true' : undefined}
       className="inline-flex min-h-11 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-xl px-1.5 py-1.5 text-[10px] font-semibold text-muted-foreground transition-[background-color,color,transform] hover:bg-muted/70 hover:text-foreground active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none"
       aria-label={label}
     >
@@ -63,6 +66,7 @@ export function SpaceMobileActions() {
         </ActionButton>
         <ActionButton
           label={editorOpen ? 'Close code editor' : 'Open code editor'}
+          editorTrigger
           onClick={() => void executeShortcut('editor.toggle')}
         >
           <Code className="h-4 w-4" aria-hidden="true" />

--- a/components/space/space-mobile-actions.tsx
+++ b/components/space/space-mobile-actions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Code, Plus, Rows3, Search } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useItems } from '@/app/lib/contexts/item-context';
@@ -39,6 +40,19 @@ export function SpaceMobileActions() {
   const { executeShortcut } = useSpaceShortcuts();
   const inReader = pathname === '/space/review';
   const visible = pathname === '/space' || inReader;
+
+  useEffect(() => {
+    const background = document.querySelector<HTMLElement>('[data-space-background]');
+    if (!background || !visible) return;
+
+    background.style.setProperty(
+      '--space-mobile-actions-offset',
+      'calc(4.75rem + env(safe-area-inset-bottom))'
+    );
+    return () => {
+      background.style.removeProperty('--space-mobile-actions-offset');
+    };
+  }, [visible]);
 
   if (!visible) return null;
 

--- a/components/space/space-mobile-actions.tsx
+++ b/components/space/space-mobile-actions.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Code, Plus, Rows3, Search } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { useItems } from '@/app/lib/contexts/item-context';
+import { useSpaceShortcuts } from '@/components/space/space-shortcut-provider';
+
+function ActionButton({
+  label,
+  disabled = false,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="inline-flex min-h-11 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-xl px-1.5 py-1.5 text-[10px] font-semibold text-muted-foreground transition-[background-color,color,transform] hover:bg-muted/70 hover:text-foreground active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-40 motion-reduce:transition-none"
+      aria-label={label}
+    >
+      {children}
+      <span className="max-w-full truncate">{label}</span>
+    </button>
+  );
+}
+
+export function SpaceMobileActions() {
+  const pathname = usePathname();
+  const { isAdmin, editorOpen } = useItems();
+  const { executeShortcut } = useSpaceShortcuts();
+  const inReader = pathname === '/space/review';
+  const visible = pathname === '/space' || inReader;
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-40 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] md:hidden"
+      data-space-mobile-actions
+    >
+      <div
+        role="toolbar"
+        aria-label="Space mobile actions"
+        className="mx-auto flex max-w-md items-stretch gap-1 rounded-2xl border border-border/75 bg-background/92 p-1.5 shadow-[0_-10px_32px_rgba(30,28,24,0.12)] backdrop-blur-xl dark:shadow-[0_-12px_34px_rgba(0,0,0,0.28)]"
+      >
+        <ActionButton
+          label="Search items"
+          onClick={() => void executeShortcut('search.toggle')}
+        >
+          <Search className="h-4 w-4" aria-hidden="true" />
+        </ActionButton>
+        <ActionButton
+          label={inReader ? 'Open list' : 'Open reader'}
+          onClick={() => void executeShortcut('navigation.toggle-view')}
+        >
+          <Rows3 className="h-4 w-4" aria-hidden="true" />
+        </ActionButton>
+        <ActionButton
+          label={editorOpen ? 'Close code editor' : 'Open code editor'}
+          onClick={() => void executeShortcut('editor.toggle')}
+        >
+          <Code className="h-4 w-4" aria-hidden="true" />
+        </ActionButton>
+        <ActionButton
+          label="Add item"
+          disabled={!isAdmin}
+          onClick={() => void executeShortcut('navigation.add')}
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </ActionButton>
+      </div>
+    </div>
+  );
+}

--- a/docs/space-mobile-editor-checklist.md
+++ b/docs/space-mobile-editor-checklist.md
@@ -1,0 +1,71 @@
+# Space mobile actions and editor verification
+
+Use this checklist when the Space mobile action rail or code editor sheet changes. The goal is continuity under real phone constraints, especially browser chrome and the software keyboard, while desktop keeps the existing floating editor geometry.
+
+## Viewports
+
+Test at minimum:
+
+- portrait: `390 × 844`;
+- reduced-height landscape: `740 × 390`;
+- the same layouts with the visual viewport reduced by a software keyboard;
+- one desktop width at `>= 1024px` to confirm the legacy floating editor remains intact.
+
+## Mobile action rail
+
+- Search, List/Reader, and Editor are visible 44px-or-larger touch targets on `/space` and `/space/review`.
+- Add is visible but disabled for non-admin users and enabled only with the existing admin contract.
+- Actions execute the central Space shortcut registry rather than duplicating command logic.
+- The fixed rail respects `env(safe-area-inset-bottom)`.
+- Space reserves enough bottom room that the final list/review controls are not hidden behind the rail.
+- No horizontal page overflow appears in portrait or reduced-height landscape.
+- The Next development diagnostics portal is outside product UI; CI may disable pointer events on `nextjs-portal` when it overlaps the rail.
+
+## Editor opening and lifetime
+
+- First open lazily initializes Monaco/Shiki.
+- After first open, dismiss/reopen reuses the same Monaco instance for the current Space session.
+- Unsaved text and selection survive Escape, close-button, and browser Back dismissal followed by reopen.
+- A slow first Monaco import cannot steal focus after the sheet was already dismissed.
+- Desktop still uses the existing breakpoint geometry and `CtrlCmd+I` registry bridge.
+
+## Visual viewport and safe areas
+
+While the mobile editor is open:
+
+- the dialog top equals `visualViewport.offsetTop`;
+- the dialog bottom equals `visualViewport.offsetTop + visualViewport.height`;
+- delayed or oversized viewport readings are clamped to the layout viewport;
+- safe-area top/bottom padding remains usable;
+- orientation or visual-viewport resize relayouts Monaco without horizontal overflow.
+
+## Modal boundary
+
+- the editor is exposed as a named modal dialog;
+- underlying Space content and the mobile rail are inert and `aria-hidden` while open;
+- Escape is owned by the hidden sheet-scope `editor.close` command before reader Escape;
+- focus enters Monaco when ready, with the close control as the pre-initialization fallback;
+- close restores the previously focused visible editor trigger;
+- captured scroll regions restore to their exact previous positions;
+- stale restoration is cancelled if the sheet reopens before the restore frame runs.
+
+## Browser history
+
+The mobile editor uses the transient fragment `#space-editor` as its same-document history entry.
+
+- opening from a canonical Space URL adds `#space-editor` without changing route/query state;
+- browser Back removes the fragment and dismisses the sheet;
+- browser Forward restores the fragment and reopens the same in-memory Monaco draft;
+- if the underlying Space URL already had a fragment (for example a Trail return anchor), Back restores that exact previous fragment;
+- closing leaves no editor-only fragment behind;
+- direct durable learning state never lives in the editor fragment.
+
+## Regression gate
+
+Before merge, require:
+
+- helper unit tests for viewport clamping and focus/scroll restoration;
+- shortcut unit tests proving sheet Escape precedence;
+- focused Chromium coverage for portrait and reduced-height landscape;
+- full repository lint, typecheck, unit suite, production build, and Chromium regression job;
+- a self-review confirming no Space data model, auth, review scheduling, ranking, or draft-storage schema was added accidentally.

--- a/docs/space-mobile-editor-checklist.md
+++ b/docs/space-mobile-editor-checklist.md
@@ -25,7 +25,7 @@ Test at minimum:
 
 - First open lazily initializes Monaco/Shiki.
 - After first open, dismiss/reopen reuses the same Monaco instance for the current Space session.
-- Unsaved text and selection survive Escape, close-button, and browser Back dismissal followed by reopen.
+- Unsaved text and selection survive Escape and close-button dismissal followed by reopen.
 - A slow first Monaco import cannot steal focus after the sheet was already dismissed.
 - Desktop still uses the existing breakpoint geometry and `CtrlCmd+I` registry bridge.
 
@@ -44,21 +44,19 @@ While the mobile editor is open:
 - the editor is exposed as a named modal dialog;
 - underlying Space content and the mobile rail are inert and `aria-hidden` while open;
 - Escape is owned by the hidden sheet-scope `editor.close` command before reader Escape;
+- Monaco bridges its own Escape keydown into that same registry command on mobile so editor focus cannot swallow dismissal;
 - focus enters Monaco when ready, with the close control as the pre-initialization fallback;
 - close restores the previously focused visible editor trigger;
 - captured scroll regions restore to their exact previous positions;
 - stale restoration is cancelled if the sheet reopens before the restore frame runs.
 
-## Browser history
+## Navigation boundary
 
-The mobile editor uses the transient fragment `#space-editor` as its same-document history entry.
+The editor sheet stays history-neutral in this slice:
 
-- opening from a canonical Space URL adds `#space-editor` without changing route/query state;
-- browser Back removes the fragment and dismisses the sheet;
-- browser Forward restores the fragment and reopens the same in-memory Monaco draft;
-- if the underlying Space URL already had a fragment (for example a Trail return anchor), Back restores that exact previous fragment;
-- closing leaves no editor-only fragment behind;
-- direct durable learning state never lives in the editor fragment.
+- opening and closing the editor do not mutate the Space URL, hash, or `history.state`;
+- browser Back/Forward, canonical view state, and exact reading-position restoration remain owned by Space continuity work in #553;
+- durable learning/review state never lives in editor UI state.
 
 ## Regression gate
 
@@ -68,4 +66,4 @@ Before merge, require:
 - shortcut unit tests proving sheet Escape precedence;
 - focused Chromium coverage for portrait and reduced-height landscape;
 - full repository lint, typecheck, unit suite, production build, and Chromium regression job;
-- a self-review confirming no Space data model, auth, review scheduling, ranking, or draft-storage schema was added accidentally.
+- a self-review confirming no Space data model, auth, review scheduling, ranking, navigation-history mechanism, or draft-storage schema was added accidentally.

--- a/docs/space-shortcut-registry.md
+++ b/docs/space-shortcut-registry.md
@@ -2,7 +2,7 @@
 
 Space keyboard commands are defined in `lib/space-shortcuts.ts` and dispatched by `SpaceShortcutProvider` in `components/space/space-shortcut-provider.tsx`.
 
-The same typed definitions generate the visible `?` reference. A command cannot acquire a runtime key without also appearing in that reference unless it is an internal modal command marked `hiddenFromReference`.
+The same typed definitions generate the visible `?` reference. A command cannot acquire a runtime key without also appearing in that reference unless it is an internal modal/sheet command marked `hiddenFromReference`.
 
 ## Adding a command
 
@@ -21,10 +21,10 @@ Do not add another document or window `keydown` listener. Embedded editors that 
 - Editable controls, contenteditable regions, textbox, searchbox, and combobox roles, and IME composition are ignored by default.
 - A command may opt into editable targets only for a narrow documented reason. `Mod+K` is allowed so the search palette can close while its input owns focus. The editor toggle is limited to the Space editor scope and its Monaco command bridges into the registry.
 - Repeat behaviour is explicit per command. Reader and Trail movement allow key repeat; toggles and navigation commands do not.
-- A higher modal, sheet, or local scope wins before command priority. A disabled winner blocks a lower-scope command with the same keys.
+- A higher modal, sheet, or local scope wins before command priority. The mobile editor's hidden `editor.close` command therefore owns `Escape` ahead of reader exit while the sheet is open.
 - The dispatcher respects `defaultPrevented` and calls `preventDefault()` only after an enabled command wins.
 - The Space `Mod+B` handler stops propagation after toggling because the shared `SidebarProvider` retains a window-level fallback for non-Space consumers. This prevents a second toggle without changing other sidebar users.
-- Mobile continues to use visible controls. The reference is available from the sidebar without requiring a hardware keyboard.
+- Mobile uses the same registry through a visible action rail: search, list/reader, editor, and add all call `executeShortcut` rather than maintaining a second interaction system.
 
 ## Current inventory
 
@@ -34,6 +34,7 @@ Do not add another document or window `keydown` listener. Embedded editors that 
 | Item search | `Mod+K` | Global | Ignore |
 | Navigation sidebar | `Mod+B` | Global/shared-provider bridge | Ignore |
 | Code editor | `Mod+I` | Global/editor bridge | Ignore |
+| Mobile editor close | `Escape` | Sheet, hidden from reference | Ignore |
 | Add item | `Mod+Alt+A` | Global | Ignore |
 | List/reader switch | `Mod+E`, `Mod+Shift+E` | Global | Ignore |
 | Next reader item | `→`, `J` | Local | Allow |

--- a/lib/space-editor-sheet.test.ts
+++ b/lib/space-editor-sheet.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  SPACE_EDITOR_HISTORY_KEY,
+  createEditorSheetHistoryState,
+  createEditorSheetRestoration,
+  ownsEditorSheetHistoryState,
+  resolveEditorSheetViewport,
+  type FocusTargetLike,
+  type ScrollRegionLike,
+} from './space-editor-sheet';
+
+class FakeRuntime {
+  private nextFrameId = 1;
+  private frames = new Map<number, () => void>();
+
+  requestAnimationFrame = (callback: () => void) => {
+    const id = this.nextFrameId++;
+    this.frames.set(id, callback);
+    return id;
+  };
+
+  cancelAnimationFrame = (id: number) => {
+    this.frames.delete(id);
+  };
+
+  flushFrames() {
+    const callbacks = [...this.frames.values()];
+    this.frames.clear();
+    for (const callback of callbacks) callback();
+  }
+
+  pendingFrameCount() {
+    return this.frames.size;
+  }
+}
+
+function focusTarget(isConnected = true) {
+  return {
+    isConnected,
+    focus: vi.fn(),
+  } satisfies FocusTargetLike;
+}
+
+function scrollRegion(left: number, top: number) {
+  return { scrollLeft: left, scrollTop: top } satisfies ScrollRegionLike;
+}
+
+describe('mobile Space editor sheet helpers', () => {
+  it('uses the visual viewport while a software keyboard reduces the visible area', () => {
+    expect(resolveEditorSheetViewport(844, { offsetTop: 24, height: 500 })).toEqual({
+      top: 24,
+      height: 500,
+      bottom: 524,
+    });
+  });
+
+  it('clamps delayed viewport values to the layout viewport', () => {
+    expect(resolveEditorSheetViewport(390, { offsetTop: 380, height: 240 })).toEqual({
+      top: 380,
+      height: 10,
+      bottom: 390,
+    });
+    expect(resolveEditorSheetViewport(390, null)).toEqual({
+      top: 0,
+      height: 390,
+      bottom: 390,
+    });
+  });
+
+  it('adds an owned same-page history marker without dropping router state', () => {
+    const state = createEditorSheetHistoryState({ __NA: true, index: 4 }, 'editor-1');
+
+    expect(state).toEqual({
+      __NA: true,
+      index: 4,
+      [SPACE_EDITOR_HISTORY_KEY]: 'editor-1',
+    });
+    expect(ownsEditorSheetHistoryState(state, 'editor-1')).toBe(true);
+    expect(ownsEditorSheetHistoryState(state, 'editor-2')).toBe(false);
+  });
+
+  it('restores captured scroll regions and the original focus target', () => {
+    const runtime = new FakeRuntime();
+    const restoration = createEditorSheetRestoration(runtime);
+    const target = focusTarget();
+    const first = scrollRegion(8, 120);
+    const second = scrollRegion(0, 44);
+
+    restoration.capture(target, [first, second]);
+    first.scrollLeft = 30;
+    first.scrollTop = 900;
+    second.scrollTop = 700;
+    restoration.restore();
+
+    expect(target.focus).not.toHaveBeenCalled();
+    runtime.flushFrames();
+
+    expect(first).toEqual({ scrollLeft: 8, scrollTop: 120 });
+    expect(second).toEqual({ scrollLeft: 0, scrollTop: 44 });
+    expect(target.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('uses a visible fallback when the original focus target disconnected', () => {
+    const runtime = new FakeRuntime();
+    const restoration = createEditorSheetRestoration(runtime);
+    const disconnected = focusTarget(false);
+    const fallback = focusTarget();
+
+    restoration.capture(disconnected, []);
+    restoration.restore(fallback);
+    runtime.flushFrames();
+
+    expect(disconnected.focus).not.toHaveBeenCalled();
+    expect(fallback.focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  it('cancels stale restoration when the sheet reopens before the frame', () => {
+    const runtime = new FakeRuntime();
+    const restoration = createEditorSheetRestoration(runtime);
+    const firstTarget = focusTarget();
+    const secondTarget = focusTarget();
+    const region = scrollRegion(0, 100);
+
+    restoration.capture(firstTarget, [region]);
+    region.scrollTop = 400;
+    restoration.restore();
+    expect(runtime.pendingFrameCount()).toBe(1);
+
+    restoration.capture(secondTarget, [region]);
+    runtime.flushFrames();
+
+    expect(region.scrollTop).toBe(400);
+    expect(firstTarget.focus).not.toHaveBeenCalled();
+    expect(secondTarget.focus).not.toHaveBeenCalled();
+  });
+});

--- a/lib/space-editor-sheet.test.ts
+++ b/lib/space-editor-sheet.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  SPACE_EDITOR_HASH,
   createEditorSheetRestoration,
-  isEditorSheetHash,
   resolveEditorSheetViewport,
   type FocusTargetLike,
   type ScrollRegionLike,
@@ -65,13 +63,6 @@ describe('mobile Space editor sheet helpers', () => {
       height: 390,
       bottom: 390,
     });
-  });
-
-  it('recognizes only the dedicated transient editor hash', () => {
-    expect(SPACE_EDITOR_HASH).toBe('#space-editor');
-    expect(isEditorSheetHash('#space-editor')).toBe(true);
-    expect(isEditorSheetHash('')).toBe(false);
-    expect(isEditorSheetHash('#trail-item-1')).toBe(false);
   });
 
   it('restores captured scroll regions and the original focus target', () => {

--- a/lib/space-editor-sheet.test.ts
+++ b/lib/space-editor-sheet.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  SPACE_EDITOR_HISTORY_KEY,
-  createEditorSheetHistoryState,
+  SPACE_EDITOR_HASH,
   createEditorSheetRestoration,
-  ownsEditorSheetHistoryState,
+  isEditorSheetHash,
   resolveEditorSheetViewport,
   type FocusTargetLike,
   type ScrollRegionLike,
@@ -68,16 +67,11 @@ describe('mobile Space editor sheet helpers', () => {
     });
   });
 
-  it('adds an owned same-page history marker without dropping router state', () => {
-    const state = createEditorSheetHistoryState({ __NA: true, index: 4 }, 'editor-1');
-
-    expect(state).toEqual({
-      __NA: true,
-      index: 4,
-      [SPACE_EDITOR_HISTORY_KEY]: 'editor-1',
-    });
-    expect(ownsEditorSheetHistoryState(state, 'editor-1')).toBe(true);
-    expect(ownsEditorSheetHistoryState(state, 'editor-2')).toBe(false);
+  it('recognizes only the dedicated transient editor hash', () => {
+    expect(SPACE_EDITOR_HASH).toBe('#space-editor');
+    expect(isEditorSheetHash('#space-editor')).toBe(true);
+    expect(isEditorSheetHash('')).toBe(false);
+    expect(isEditorSheetHash('#trail-item-1')).toBe(false);
   });
 
   it('restores captured scroll regions and the original focus target', () => {

--- a/lib/space-editor-sheet.ts
+++ b/lib/space-editor-sheet.ts
@@ -1,4 +1,4 @@
-export const SPACE_EDITOR_HISTORY_KEY = '__spaceEditorSheet';
+export const SPACE_EDITOR_HASH = '#space-editor';
 
 export type VisualViewportSnapshot = {
   height: number;
@@ -25,20 +25,8 @@ export function resolveEditorSheetViewport(
   return { top, height, bottom: top + height };
 }
 
-export function createEditorSheetHistoryState(baseState: unknown, token: string) {
-  const base =
-    baseState && typeof baseState === 'object'
-      ? (baseState as Record<string, unknown>)
-      : {};
-  return { ...base, [SPACE_EDITOR_HISTORY_KEY]: token };
-}
-
-export function ownsEditorSheetHistoryState(
-  state: unknown,
-  token: string | null
-) {
-  if (!token || !state || typeof state !== 'object') return false;
-  return (state as Record<string, unknown>)[SPACE_EDITOR_HISTORY_KEY] === token;
+export function isEditorSheetHash(hash: string) {
+  return hash === SPACE_EDITOR_HASH;
 }
 
 export type FocusTargetLike = {

--- a/lib/space-editor-sheet.ts
+++ b/lib/space-editor-sheet.ts
@@ -1,5 +1,3 @@
-export const SPACE_EDITOR_HASH = '#space-editor';
-
 export type VisualViewportSnapshot = {
   height: number;
   offsetTop: number;
@@ -23,10 +21,6 @@ export function resolveEditorSheetViewport(
   const top = Math.max(0, Math.min(viewport.offsetTop, safeLayoutHeight));
   const height = Math.max(0, Math.min(viewport.height, safeLayoutHeight - top));
   return { top, height, bottom: top + height };
-}
-
-export function isEditorSheetHash(hash: string) {
-  return hash === SPACE_EDITOR_HASH;
 }
 
 export type FocusTargetLike = {

--- a/lib/space-editor-sheet.ts
+++ b/lib/space-editor-sheet.ts
@@ -1,0 +1,129 @@
+export const SPACE_EDITOR_HISTORY_KEY = '__spaceEditorSheet';
+
+export type VisualViewportSnapshot = {
+  height: number;
+  offsetTop: number;
+};
+
+export type EditorSheetViewport = {
+  top: number;
+  height: number;
+  bottom: number;
+};
+
+export function resolveEditorSheetViewport(
+  layoutHeight: number,
+  viewport?: VisualViewportSnapshot | null
+): EditorSheetViewport {
+  const safeLayoutHeight = Math.max(0, layoutHeight);
+  if (!viewport) {
+    return { top: 0, height: safeLayoutHeight, bottom: safeLayoutHeight };
+  }
+
+  const top = Math.max(0, Math.min(viewport.offsetTop, safeLayoutHeight));
+  const height = Math.max(0, Math.min(viewport.height, safeLayoutHeight - top));
+  return { top, height, bottom: top + height };
+}
+
+export function createEditorSheetHistoryState(baseState: unknown, token: string) {
+  const base =
+    baseState && typeof baseState === 'object'
+      ? (baseState as Record<string, unknown>)
+      : {};
+  return { ...base, [SPACE_EDITOR_HISTORY_KEY]: token };
+}
+
+export function ownsEditorSheetHistoryState(
+  state: unknown,
+  token: string | null
+) {
+  if (!token || !state || typeof state !== 'object') return false;
+  return (state as Record<string, unknown>)[SPACE_EDITOR_HISTORY_KEY] === token;
+}
+
+export type FocusTargetLike = {
+  isConnected?: boolean;
+  focus: (options?: { preventScroll?: boolean }) => void;
+};
+
+export type ScrollRegionLike = {
+  scrollLeft: number;
+  scrollTop: number;
+};
+
+export type EditorSheetRestorationRuntime = {
+  requestAnimationFrame: (callback: () => void) => number;
+  cancelAnimationFrame: (id: number) => void;
+};
+
+export type EditorSheetRestoration = {
+  capture: (
+    focusTarget: FocusTargetLike | null,
+    regions: Iterable<ScrollRegionLike>
+  ) => void;
+  restore: (fallbackFocus?: FocusTargetLike | null) => void;
+  cancel: () => void;
+};
+
+export function createEditorSheetRestoration(
+  runtime: EditorSheetRestorationRuntime
+): EditorSheetRestoration {
+  let generation = 0;
+  let frameId: number | null = null;
+  let focusTarget: FocusTargetLike | null = null;
+  let scrollSnapshots: Array<{
+    region: ScrollRegionLike;
+    left: number;
+    top: number;
+  }> = [];
+
+  const cancelFrame = () => {
+    if (frameId !== null) runtime.cancelAnimationFrame(frameId);
+    frameId = null;
+  };
+
+  const cancel = () => {
+    generation += 1;
+    cancelFrame();
+  };
+
+  const capture = (
+    nextFocusTarget: FocusTargetLike | null,
+    regions: Iterable<ScrollRegionLike>
+  ) => {
+    cancel();
+    focusTarget = nextFocusTarget;
+    scrollSnapshots = Array.from(regions, region => ({
+      region,
+      left: region.scrollLeft,
+      top: region.scrollTop,
+    }));
+  };
+
+  const restore = (fallbackFocus: FocusTargetLike | null = null) => {
+    cancelFrame();
+    const activeGeneration = generation;
+    frameId = runtime.requestAnimationFrame(() => {
+      frameId = null;
+      if (activeGeneration !== generation) return;
+
+      for (const snapshot of scrollSnapshots) {
+        snapshot.region.scrollLeft = snapshot.left;
+        snapshot.region.scrollTop = snapshot.top;
+      }
+
+      const target =
+        focusTarget?.isConnected === false ? fallbackFocus : focusTarget;
+      target?.focus({ preventScroll: true });
+    });
+  };
+
+  return { capture, restore, cancel };
+}
+
+export function createBrowserEditorSheetRestoration() {
+  return createEditorSheetRestoration({
+    requestAnimationFrame: callback => window.requestAnimationFrame(callback),
+    cancelAnimationFrame: id => window.cancelAnimationFrame(id),
+  });
+}

--- a/lib/space-shortcuts.test.ts
+++ b/lib/space-shortcuts.test.ts
@@ -64,7 +64,7 @@ function fakeTarget(options: { editable?: boolean; editor?: boolean } = {}) {
 }
 
 describe('Space shortcut matching', () => {
-  it('keeps stable unique registry IDs, including Trail commands', () => {
+  it('keeps stable unique registry IDs, including Trail and sheet commands', () => {
     const ids = SPACE_SHORTCUTS.map(shortcut => shortcut.id);
     expect(new Set(ids).size).toBe(ids.length);
     expect(ids).toEqual([
@@ -73,6 +73,7 @@ describe('Space shortcut matching', () => {
       'search.toggle',
       'sidebar.toggle',
       'editor.toggle',
+      'editor.close',
       'navigation.add',
       'navigation.toggle-view',
       'review.next',
@@ -233,6 +234,22 @@ describe('Space shortcut matching', () => {
     expect(resolution?.enabled).toBe(false);
   });
 
+  it('lets the mobile editor sheet own Escape ahead of reader exit', () => {
+    const commands = registrations({
+      'review.exit': { run: vi.fn() },
+      'editor.close': { run: vi.fn() },
+    });
+
+    const resolution = resolveSpaceShortcut(
+      keyboardEvent('Escape', {
+        target: fakeTarget({ editable: true, editor: true }),
+      }),
+      commands
+    );
+    expect(resolution?.definition.id).toBe('editor.close');
+    expect(resolution?.enabled).toBe(true);
+  });
+
   it('respects events already owned by the browser or another widget', () => {
     const commands = registrations({ 'search.toggle': { run: vi.fn() } });
     expect(
@@ -243,7 +260,7 @@ describe('Space shortcut matching', () => {
     ).toBeNull();
   });
 
-  it('returns disabled reasons from the generated reference', () => {
+  it('returns disabled reasons from the generated reference and hides internal closes', () => {
     const reference = getSpaceShortcutReference(
       registrations({
         'help.open': { run: vi.fn() },
@@ -263,6 +280,9 @@ describe('Space shortcut matching', () => {
         ?.unavailableReason
     ).toBe('Admin access is required');
     expect(reference.some(entry => entry.definition.id === 'help.close')).toBe(
+      false
+    );
+    expect(reference.some(entry => entry.definition.id === 'editor.close')).toBe(
       false
     );
   });

--- a/lib/space-shortcuts.ts
+++ b/lib/space-shortcuts.ts
@@ -8,6 +8,7 @@ export type SpaceShortcutId =
   | 'search.toggle'
   | 'sidebar.toggle'
   | 'editor.toggle'
+  | 'editor.close'
   | 'navigation.add'
   | 'navigation.toggle-view'
   | 'review.next'
@@ -132,6 +133,17 @@ export const SPACE_SHORTCUTS: readonly SpaceShortcutDefinition[] = [
     priority: 80,
     repeat: 'ignore',
     editable: 'editor',
+  },
+  {
+    id: 'editor.close',
+    keys: [{ key: 'Escape', keyLabel: 'Esc' }],
+    scope: 'sheet',
+    category: 'Editor',
+    description: 'Close the mobile code editor',
+    priority: 1_000,
+    repeat: 'ignore',
+    editable: 'allow',
+    hiddenFromReference: true,
   },
   {
     id: 'navigation.add',

--- a/tests/e2e/space-mobile-editor-sheet.spec.ts
+++ b/tests/e2e/space-mobile-editor-sheet.spec.ts
@@ -115,43 +115,6 @@ async function monacoInput(dialog: Locator) {
   return input;
 }
 
-async function addScrollableSpace(page: Page) {
-  return page.evaluate(() => {
-    const root = document.querySelector<HTMLElement>('[data-space-background]');
-    if (!root) throw new Error('Missing Space background');
-
-    const region = [root, ...root.querySelectorAll<HTMLElement>('*')].find(
-      element => {
-        const style = getComputedStyle(element);
-        return /^(auto|scroll)$/.test(style.overflowY);
-      }
-    );
-    if (!region) throw new Error('Missing Space scroll region');
-
-    region.dataset.spaceTestScroll = 'true';
-    const spacer = document.createElement('div');
-    spacer.dataset.spaceTestSpacer = 'true';
-    spacer.style.height = '1400px';
-    spacer.style.minHeight = '1400px';
-    region.appendChild(spacer);
-    region.scrollTop = 240;
-    return region.scrollTop;
-  });
-}
-
-async function expectScroll(page: Page, expected: number) {
-  await expect
-    .poll(() =>
-      page.evaluate((top) => {
-        const region = document.querySelector<HTMLElement>(
-          '[data-space-test-scroll="true"]'
-        );
-        return region ? Math.abs(region.scrollTop - top) : Number.POSITIVE_INFINITY;
-      }, expected)
-    )
-    .toBeLessThanOrEqual(2);
-}
-
 async function expectNoHorizontalOverflow(page: Page) {
   await expect
     .poll(() =>
@@ -199,11 +162,10 @@ test.describe('mobile Space editor sheet', () => {
   test.use({ hasTouch: true });
 
   for (const scenario of [portrait, landscape]) {
-    test(`${scenario.name} keeps the Monaco draft, viewport, focus, and scroll across dismissal`, async ({
+    test(`${scenario.name} keeps the Monaco draft, viewport, and focus across dismissal`, async ({
       page,
     }) => {
       await gotoMobile(page, scenario);
-      const savedScroll = await addScrollableSpace(page);
       const { trigger, dialog } = await openEditor(page);
       await monacoInput(dialog);
       await page.keyboard.type('alpha');
@@ -238,7 +200,6 @@ test.describe('mobile Space editor sheet', () => {
       await expect(dialog).toBeHidden();
       await expect(trigger).toBeFocused();
       await expect(page).toHaveURL(/\/space$/);
-      await expectScroll(page, savedScroll);
 
       await setSyntheticVisualViewport(page, scenario.height, 0);
       const reopened = await openEditor(page);

--- a/tests/e2e/space-mobile-editor-sheet.spec.ts
+++ b/tests/e2e/space-mobile-editor-sheet.spec.ts
@@ -105,9 +105,6 @@ async function openEditor(page: Page) {
   const dialog = page.getByRole('dialog', { name: 'Code editor' });
   await expect(dialog).toBeVisible();
   await expect(dialog.locator('.monaco-editor')).toBeVisible({ timeout: 30_000 });
-  await expect
-    .poll(() => page.evaluate(() => window.location.hash))
-    .toBe('#space-editor');
   return { trigger, dialog };
 }
 
@@ -254,25 +251,4 @@ test.describe('mobile Space editor sheet', () => {
       await expectNoHorizontalOverflow(page);
     });
   }
-
-  test('portrait browser back dismisses the sheet and browser forward reopens the same draft', async ({
-    page,
-  }) => {
-    await gotoMobile(page, portrait);
-    const { trigger, dialog } = await openEditor(page);
-    await monacoInput(dialog);
-    await page.keyboard.type('browser back draft');
-
-    await page.goBack();
-    await expect(dialog).toBeHidden();
-    await expect(page).toHaveURL(/\/space$/);
-    await expect(trigger).toBeFocused();
-
-    await page.goForward();
-    await expect(dialog).toBeVisible();
-    await expect(page).toHaveURL(/#space-editor$/);
-    await expect(dialog.locator('.view-lines')).toContainText('browser back draft');
-    await dialog.getByRole('button', { name: 'Close code editor' }).click();
-    await expect(dialog).toBeHidden();
-  });
 });

--- a/tests/e2e/space-mobile-editor-sheet.spec.ts
+++ b/tests/e2e/space-mobile-editor-sheet.spec.ts
@@ -1,0 +1,270 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+type MobileScenario = {
+  name: string;
+  width: number;
+  height: number;
+  keyboardHeight: number;
+  keyboardOffsetTop: number;
+};
+
+const portrait: MobileScenario = {
+  name: 'portrait 390x844',
+  width: 390,
+  height: 844,
+  keyboardHeight: 500,
+  keyboardOffsetTop: 0,
+};
+
+const landscape: MobileScenario = {
+  name: 'reduced-height landscape 740x390',
+  width: 740,
+  height: 390,
+  keyboardHeight: 238,
+  keyboardOffsetTop: 18,
+};
+
+async function installSyntheticVisualViewport(page: Page, scenario: MobileScenario) {
+  await page.addInitScript(({ width, height }) => {
+    class TestVisualViewport extends EventTarget {
+      width = width;
+      height = height;
+      offsetTop = 0;
+      offsetLeft = 0;
+      pageTop = 0;
+      pageLeft = 0;
+      scale = 1;
+
+      setGeometry(nextHeight: number, nextOffsetTop: number) {
+        this.height = nextHeight;
+        this.offsetTop = nextOffsetTop;
+        this.dispatchEvent(new Event('resize'));
+        this.dispatchEvent(new Event('scroll'));
+      }
+    }
+
+    const viewport = new TestVisualViewport();
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: viewport,
+    });
+    (
+      window as Window & {
+        __setSpaceVisualViewport?: (
+          nextHeight: number,
+          nextOffsetTop: number
+        ) => void;
+      }
+    ).__setSpaceVisualViewport = (nextHeight, nextOffsetTop) =>
+      viewport.setGeometry(nextHeight, nextOffsetTop);
+  }, scenario);
+}
+
+async function setSyntheticVisualViewport(
+  page: Page,
+  height: number,
+  offsetTop: number
+) {
+  await page.evaluate(
+    ({ nextHeight, nextOffsetTop }) => {
+      const setter = (
+        window as Window & {
+          __setSpaceVisualViewport?: (height: number, top: number) => void;
+        }
+      ).__setSpaceVisualViewport;
+      if (!setter) throw new Error('Missing synthetic Space visual viewport');
+      setter(nextHeight, nextOffsetTop);
+    },
+    { nextHeight: height, nextOffsetTop: offsetTop }
+  );
+}
+
+async function gotoMobile(page: Page, scenario: MobileScenario) {
+  await page.setViewportSize({ width: scenario.width, height: scenario.height });
+  await installSyntheticVisualViewport(page, scenario);
+  const response = await page.goto('/space');
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole('heading', { name: 'Space' })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    page.getByRole('toolbar', { name: 'Space mobile actions' })
+  ).toBeVisible();
+}
+
+async function openEditor(page: Page) {
+  const trigger = page.getByRole('button', { name: 'Open code editor' });
+  await trigger.click();
+  const dialog = page.getByRole('dialog', { name: 'Code editor' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator('.monaco-editor')).toBeVisible({ timeout: 30_000 });
+  await expect
+    .poll(() => page.evaluate(() => Boolean(history.state?.__spaceEditorSheet)))
+    .toBe(true);
+  return { trigger, dialog };
+}
+
+async function monacoInput(dialog: Locator) {
+  const input = dialog.locator('textarea.inputarea');
+  await expect(input).toBeVisible();
+  await input.click();
+  return input;
+}
+
+async function addScrollableSpace(page: Page) {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>('[data-space-background]');
+    if (!root) throw new Error('Missing Space background');
+
+    const region = [root, ...root.querySelectorAll<HTMLElement>('*')].find(
+      element => {
+        const style = getComputedStyle(element);
+        return /^(auto|scroll)$/.test(style.overflowY);
+      }
+    );
+    if (!region) throw new Error('Missing Space scroll region');
+
+    region.dataset.spaceTestScroll = 'true';
+    const spacer = document.createElement('div');
+    spacer.dataset.spaceTestSpacer = 'true';
+    spacer.style.height = '1400px';
+    spacer.style.minHeight = '1400px';
+    region.appendChild(spacer);
+    region.scrollTop = 240;
+    return region.scrollTop;
+  });
+}
+
+async function expectScroll(page: Page, expected: number) {
+  await expect
+    .poll(() =>
+      page.evaluate((top) => {
+        const region = document.querySelector<HTMLElement>(
+          '[data-space-test-scroll="true"]'
+        );
+        return region ? Math.abs(region.scrollTop - top) : Number.POSITIVE_INFINITY;
+      }, expected)
+    )
+    .toBeLessThanOrEqual(2);
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          document.documentElement.scrollWidth -
+          document.documentElement.clientWidth
+      )
+    )
+    .toBeLessThanOrEqual(1);
+}
+
+test.describe('mobile Space actions', () => {
+  test.use({ hasTouch: true });
+
+  for (const scenario of [portrait, landscape]) {
+    test(`${scenario.name} exposes current registry actions without overflow`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await gotoMobile(page, scenario);
+
+      const toolbar = page.getByRole('toolbar', { name: 'Space mobile actions' });
+      await expect(toolbar.getByRole('button', { name: 'Search items' })).toBeVisible();
+      await expect(toolbar.getByRole('button', { name: 'Open reader' })).toBeVisible();
+      await expect(
+        toolbar.getByRole('button', { name: 'Open code editor' })
+      ).toBeVisible();
+      await expect(toolbar.getByRole('button', { name: 'Add item' })).toBeDisabled();
+
+      await toolbar.getByRole('button', { name: 'Search items' }).click();
+      const search = page.getByPlaceholder(/Search items/);
+      await expect(search).toBeFocused();
+      await search.fill('boundary');
+      await expect(search).toHaveValue('boundary');
+      await page.keyboard.press('Escape');
+      await expect(search).toBeHidden();
+
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+});
+
+test.describe('mobile Space editor sheet', () => {
+  test.use({ hasTouch: true });
+
+  for (const scenario of [portrait, landscape]) {
+    test(`${scenario.name} keeps the Monaco draft, viewport, focus, and scroll across dismissal`, async ({
+      page,
+    }) => {
+      await gotoMobile(page, scenario);
+      const savedScroll = await addScrollableSpace(page);
+      const { trigger, dialog } = await openEditor(page);
+      await monacoInput(dialog);
+      await page.keyboard.type('alpha');
+      await page.keyboard.press('Shift+ArrowLeft');
+
+      await setSyntheticVisualViewport(
+        page,
+        scenario.keyboardHeight,
+        scenario.keyboardOffsetTop
+      );
+      await expect
+        .poll(() =>
+          dialog.evaluate(element => {
+            const viewport = window.visualViewport;
+            const rect = element.getBoundingClientRect();
+            return {
+              top: Math.round(
+                Math.abs(rect.top - (viewport?.offsetTop ?? 0))
+              ),
+              bottom: Math.round(
+                Math.abs(
+                  rect.bottom -
+                    ((viewport?.offsetTop ?? 0) + (viewport?.height ?? 0))
+                )
+              ),
+            };
+          })
+        )
+        .toEqual({ top: 0, bottom: 0 });
+
+      await page.keyboard.press('Escape');
+      await expect(dialog).toBeHidden();
+      await expect(trigger).toBeFocused();
+      await expect(page).toHaveURL(/\/space$/);
+      await expectScroll(page, savedScroll);
+
+      await setSyntheticVisualViewport(page, scenario.height, 0);
+      const reopened = await openEditor(page);
+      await monacoInput(reopened.dialog);
+      await page.keyboard.type('X');
+      await expect(reopened.dialog.locator('.view-lines')).toContainText('alphX');
+      await reopened.dialog.getByRole('button', { name: 'Close code editor' }).click();
+      await expect(reopened.dialog).toBeHidden();
+      await expect(reopened.trigger).toBeFocused();
+      await expectNoHorizontalOverflow(page);
+    });
+  }
+
+  test('portrait browser back dismisses the sheet and browser forward reopens the same draft', async ({
+    page,
+  }) => {
+    await gotoMobile(page, portrait);
+    const { trigger, dialog } = await openEditor(page);
+    await monacoInput(dialog);
+    await page.keyboard.type('browser back draft');
+
+    await page.goBack();
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/\/space$/);
+    await expect(trigger).toBeFocused();
+
+    await page.goForward();
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator('.view-lines')).toContainText('browser back draft');
+    await dialog.getByRole('button', { name: 'Close code editor' }).click();
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/tests/e2e/space-mobile-editor-sheet.spec.ts
+++ b/tests/e2e/space-mobile-editor-sheet.spec.ts
@@ -106,15 +106,15 @@ async function openEditor(page: Page) {
   await expect(dialog).toBeVisible();
   await expect(dialog.locator('.monaco-editor')).toBeVisible({ timeout: 30_000 });
   await expect
-    .poll(() => page.evaluate(() => Boolean(history.state?.__spaceEditorSheet)))
-    .toBe(true);
+    .poll(() => page.evaluate(() => window.location.hash))
+    .toBe('#space-editor');
   return { trigger, dialog };
 }
 
 async function monacoInput(dialog: Locator) {
   const input = dialog.getByRole('textbox', { name: 'Editor content' });
   await expect(input).toBeVisible();
-  await input.click();
+  await expect(input).toBeFocused({ timeout: 15_000 });
   return input;
 }
 
@@ -270,6 +270,7 @@ test.describe('mobile Space editor sheet', () => {
 
     await page.goForward();
     await expect(dialog).toBeVisible();
+    await expect(page).toHaveURL(/#space-editor$/);
     await expect(dialog.locator('.view-lines')).toContainText('browser back draft');
     await dialog.getByRole('button', { name: 'Close code editor' }).click();
     await expect(dialog).toBeHidden();

--- a/tests/e2e/space-mobile-editor-sheet.spec.ts
+++ b/tests/e2e/space-mobile-editor-sheet.spec.ts
@@ -84,6 +84,13 @@ async function gotoMobile(page: Page, scenario: MobileScenario) {
   await installSyntheticVisualViewport(page, scenario);
   const response = await page.goto('/space');
   expect(response?.ok()).toBe(true);
+
+  // Hosted CI runs the Next development server. Its diagnostics portal is
+  // outside product UI and can overlap the bottom-right action rail.
+  await page.addStyleTag({
+    content: 'nextjs-portal { pointer-events: none !important; }',
+  });
+
   await expect(page.getByRole('heading', { name: 'Space' })).toBeVisible({
     timeout: 15_000,
   });
@@ -105,7 +112,7 @@ async function openEditor(page: Page) {
 }
 
 async function monacoInput(dialog: Locator) {
-  const input = dialog.locator('textarea.inputarea');
+  const input = dialog.getByRole('textbox', { name: 'Editor content' });
   await expect(input).toBeVisible();
   await input.click();
   return input;


### PR DESCRIPTION
## Why

Issue #414 has a substantial July design exploration in closed draft PR #426, but current Space has moved since then. PR #573 landed the typed command registry on current main, so the useful mobile ideas can be recovered without reviving the old data loader, fake archive fixture, or nineteen-file branch.

This selectively transplants the pieces that belong to mobile editor ergonomics while leaving canonical URL / Back-Forward continuity to #553.

## Change

- add a phone/reduced-height action rail for Search, List↔Reader, Editor, and Add;
- reserve shell space for the fixed rail through a route-owned CSS variable instead of covering final content controls;
- hide the duplicate header editor trigger on list/reader mobile routes while keeping it on desktop and other Space routes;
- add hidden sheet-scope `editor.close` so mobile Escape closes the editor ahead of reader Escape;
- bridge Monaco's own Escape keydown into that same registry command on mobile, so editor focus cannot swallow dismissal;
- make Monaco lazy on first open, then persistent across later close/reopen cycles;
- make the mobile editor a visual-viewport-sized full-screen dialog with safe-area handling;
- capture and restore a meaningful previously focused control plus active scrollable Space regions;
- inert/aria-hide the underlying Space content and mobile rail while the modal sheet is open;
- preserve the existing desktop editor geometry and native `CtrlCmd+I` registry bridge;
- keep the editor history-neutral: opening/closing does not mutate URL, hash, or `history.state`.

## Boundary correction from CI

Earlier iterations tried to make the editor own same-document Back/Forward state. Browser evidence showed Next/router history ownership fighting both custom state and transient hashes. That behavior belongs to #553, whose scope is canonical URLs, Back/Forward, exact return state, and resumable Space navigation.

The final PR therefore keeps one job: make the mobile controls obvious and make the editor sheet continuous during the current Space session.

## Verification

Exact head: `b142987234b6244641f1cceca9e1425d10ad6143`.

Both CI jobs are green on that head:

- lint;
- TypeScript typecheck;
- full unit suite;
- production build;
- complete Chromium regression suite;
- portrait 390×844 and reduced-height landscape 740×390 mobile action coverage;
- Search focus/dismissal and non-admin Add state;
- synthetic software-keyboard visual-viewport bounds;
- Monaco-owned Escape dismissal;
- draft + selection survival across dismiss/reopen;
- close-button dismissal;
- visible-trigger focus restoration and horizontal containment;
- homepage visual-review artifact upload.

Pure helper tests retain exact scroll restoration coverage without mutating React-owned browser DOM in the e2e suite.

`docs/space-mobile-editor-checklist.md` records the mobile/desktop review contract and explicitly leaves browser navigation continuity to #553.

## Boundary

No Space data model, auth, review scheduling, archive fixtures, ranking, publication state, navigation-history mechanism, or deployment controls change. No new storage is introduced for editor drafts; continuity comes from keeping the existing editor instance alive for the current Space session.

Closes #414