### PR TITLE
Pin invalid RSS publication dates in tests

### DIFF
--- a/lib/rss-feed.test.ts
+++ b/lib/rss-feed.test.ts
@@ -57,6 +57,16 @@ describe('createRssFeed', () => {
     ).toThrow('must stay on the site origin');
   });
 
+  it('rejects invalid publication dates before emitting RSS metadata', () => {
+    expect(() =>
+      feed([
+        item({
+          publishedAt: 'someday after lunch',
+        }),
+      ]),
+    ).toThrow('RSS feed date is invalid');
+  });
+
   it('rejects duplicate identities and bounds the item count', () => {
     expect(() => feed([item(), item()])).toThrow('item id is duplicated');
 


### PR DESCRIPTION
## Why

The RSS generator already rejects invalid `publishedAt` values before it emits `<pubDate>` / `<lastBuildDate>`, but that boundary was only implicit in implementation. Issue #312 still calls for malformed-metadata coverage.

## Change

- add one focused unit assertion proving an invalid publication date throws `RSS feed date is invalid`;
- leave feed generation and production behavior unchanged.

## Boundary

Test only. No feed URLs, XML format, caching, publication registry, or runtime behavior changes.

Related: #312