### PR TITLE
Define bounded Space continuity contracts

### DIFF
--- a/docs/space-continuity.md
+++ b/docs/space-continuity.md
@@ -1,0 +1,77 @@
+# Space continuity contracts
+
+Space should feel immediate on ordinary return navigation without making browser storage a second database. The continuity layer therefore separates three short-lived concerns and leaves durable learning/review state elsewhere.
+
+## 1. Canonical browse URL state
+
+`lib/space-browse-state.ts` owns the stable serialization for the ordinary list/reader state:
+
+- `lane`;
+- `tags`;
+- `item`.
+
+The parameter order is always `lane`, `tags`, `item`. Empty values disappear. The same serialization produces the per-view `viewKey` used by ephemeral history restoration.
+
+Reading-sheet and Trail-specific parameters remain outside this first codec until their current route helpers are migrated deliberately; do not duplicate `from`, `return`, `practice`, or `stage` in a second half-migrated helper.
+
+## 2. Bounded public archive snapshot
+
+`lib/space-public-snapshot.ts` and `lib/space-public-snapshot-storage.ts` define the only browser-persistent archive fallback.
+
+Rules:
+
+- versioned key: `scrapbook:space-public-snapshot:v1`;
+- maximum 100 items, matching the current first public page;
+- maximum age 24 hours;
+- tolerate at most five minutes of forward clock skew;
+- strip `review` and `userId` before serialization;
+- reject cached payloads that contain those fields;
+- restore cached items with `review: null` and `userId: null`;
+- do not write empty snapshots;
+- treat localStorage read/write/quota/security failures as cache misses;
+- remove invalid/stale payloads when storage permits.
+
+### Admission sequence
+
+The eventual `ItemsProvider` integration should stay one-way and conservative:
+
+1. Start with the server-provided public items exactly as today.
+2. After hydration, if the server supplied usable public items, keep them and write/update the bounded public snapshot.
+3. If the server supplied no usable public items and a valid cached public snapshot exists, admit the cached items immediately and mark the visible state as stale/cached.
+4. Revalidate through the existing `reload()` path; a successful public response replaces the cache-backed list and refreshes the snapshot.
+5. A refresh failure preserves the admitted list and surfaces the existing bounded error state.
+6. Private/admin review rows continue through their existing authenticated path and never enter the public snapshot.
+
+Do not merge cached public items with a partial server response in this first slice. Either the server supplied a usable current public page or the cache is a temporary fallback.
+
+## 3. Same-entry UI history
+
+`lib/space-history-ui.ts` owns ephemeral Back/Forward state that cannot be reconstructed from the URL:
+
+- scroll position;
+- expanded row IDs.
+
+Rules:
+
+- namespace under `__scrapbookSpaceUi` while preserving Next/router-owned history fields;
+- bind every snapshot to the exact canonical `viewKey`;
+- cap expanded IDs at 24 and deduplicate them;
+- clamp scroll positions to a finite non-negative bound;
+- reject wrong-version, cross-view, malformed, oversized, or out-of-range payloads;
+- never store review schedules, reactions, practice answers, learned state, or other durable learning data here.
+
+## Browser-history ownership
+
+Use ordinary canonical URLs for durable navigation identity. Use same-entry `history.state` only for ephemeral presentation restoration. Temporary modal state may use its own explicit same-document marker when that marker has independent Back/Forward semantics; it should disappear on close and must not become a durable learning identifier.
+
+## Measurement
+
+Evaluate continuity as separate journeys rather than one synthetic timing number:
+
+- cold load with healthy server data;
+- cold load with server archive failure + valid cached public snapshot;
+- warm in-app list ↔ reader return;
+- reading sheet ↔ prior list/Trail return;
+- Back/Forward restoration of filter, target, scroll, and expanded rows.
+
+Record the exact route, data condition, viewport, and cache state with each measurement. The useful result is immediate usable content and restored context, not merely a lower aggregate load number.

--- a/lib/space-browse-state.test.ts
+++ b/lib/space-browse-state.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSpaceBrowseHref,
+  createSpaceBrowseParams,
+  createSpaceBrowseViewKey,
+} from './space-browse-state';
+
+describe('Space browse state', () => {
+  it('uses one stable lane, tags, item ordering with URL encoding', () => {
+    const params = createSpaceBrowseParams({
+      item: 'item / 7',
+      tags: 'topic:dp source:fieldwork',
+      lane: 'archive',
+    });
+
+    expect(params.toString()).toBe(
+      'lane=archive&tags=topic%3Adp+source%3Afieldwork&item=item+%2F+7'
+    );
+    expect(
+      createSpaceBrowseHref('/space/review', {
+        item: 'item / 7',
+        tags: 'topic:dp source:fieldwork',
+        lane: 'archive',
+      })
+    ).toBe(
+      '/space/review?lane=archive&tags=topic%3Adp+source%3Afieldwork&item=item+%2F+7'
+    );
+  });
+
+  it('drops empty values instead of creating semantically empty URLs', () => {
+    expect(
+      createSpaceBrowseHref('/space', {
+        lane: ' ',
+        tags: '',
+        item: null,
+      })
+    ).toBe('/space');
+  });
+
+  it('generates history view keys from the same canonical serialization', () => {
+    const state = { tags: 'topic:systems', lane: 'open' };
+    expect(createSpaceBrowseViewKey('list', state)).toBe(
+      'list:lane=open&tags=topic%3Asystems'
+    );
+    expect(createSpaceBrowseViewKey('reader', state)).toBe(
+      'reader:lane=open&tags=topic%3Asystems'
+    );
+  });
+});

--- a/lib/space-browse-state.ts
+++ b/lib/space-browse-state.ts
@@ -1,0 +1,42 @@
+export type SpaceBrowseState = {
+  lane?: string | null;
+  tags?: string | null;
+  item?: string | null;
+};
+
+export type SpaceBrowseView = 'list' | 'reader';
+
+function cleanValue(value: string | null | undefined) {
+  const cleaned = value?.trim();
+  return cleaned ? cleaned : undefined;
+}
+
+export function createSpaceBrowseParams(state: SpaceBrowseState) {
+  const params = new URLSearchParams();
+  const lane = cleanValue(state.lane);
+  const tags = cleanValue(state.tags);
+  const item = cleanValue(state.item);
+
+  // Keep one stable parameter order everywhere so href equality, history keys,
+  // and tests do not depend on the order each caller happened to append fields.
+  if (lane) params.set('lane', lane);
+  if (tags) params.set('tags', tags);
+  if (item) params.set('item', item);
+  return params;
+}
+
+export function createSpaceBrowseHref(
+  pathname: '/space' | '/space/review',
+  state: SpaceBrowseState = {}
+) {
+  const query = createSpaceBrowseParams(state).toString();
+  return `${pathname}${query ? `?${query}` : ''}`;
+}
+
+export function createSpaceBrowseViewKey(
+  view: SpaceBrowseView,
+  state: SpaceBrowseState = {}
+) {
+  const query = createSpaceBrowseParams(state).toString();
+  return `${view}:${query}`;
+}

--- a/lib/space-history-ui.test.ts
+++ b/lib/space-history-ui.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SPACE_HISTORY_MAX_EXPANDED_IDS,
+  SPACE_HISTORY_MAX_SCROLL_PX,
+  SPACE_HISTORY_UI_KEY,
+  createSpaceHistoryUiSnapshot,
+  mergeSpaceHistoryUiState,
+  readSpaceHistoryUiState,
+} from './space-history-ui';
+
+describe('Space history UI state', () => {
+  it('preserves router-owned history fields while namespacing Space UI state', () => {
+    const snapshot = createSpaceHistoryUiSnapshot({
+      viewKey: 'list:open:',
+      scrollTop: 412.4,
+      expandedIds: ['item-1', 'item-2'],
+    });
+    const merged = mergeSpaceHistoryUiState(
+      { __NA: true, tree: ['space'] },
+      snapshot
+    );
+
+    expect(merged).toMatchObject({
+      __NA: true,
+      tree: ['space'],
+      [SPACE_HISTORY_UI_KEY]: {
+        viewKey: 'list:open:',
+        scrollTop: 412,
+        expandedIds: ['item-1', 'item-2'],
+      },
+    });
+  });
+
+  it('bounds scroll and deduplicates/caps expanded row IDs', () => {
+    const snapshot = createSpaceHistoryUiSnapshot({
+      viewKey: 'list:archive:tag',
+      scrollTop: Number.POSITIVE_INFINITY,
+      expandedIds: [
+        '',
+        ' item-1 ',
+        'item-1',
+        ...Array.from(
+          { length: SPACE_HISTORY_MAX_EXPANDED_IDS + 10 },
+          (_, index) => `item-${index + 2}`
+        ),
+      ],
+    });
+
+    expect(snapshot.scrollTop).toBe(0);
+    expect(snapshot.expandedIds).toHaveLength(SPACE_HISTORY_MAX_EXPANDED_IDS);
+    expect(snapshot.expandedIds[0]).toBe('item-1');
+    expect(new Set(snapshot.expandedIds).size).toBe(snapshot.expandedIds.length);
+
+    const clamped = createSpaceHistoryUiSnapshot({
+      viewKey: 'list:open:',
+      scrollTop: SPACE_HISTORY_MAX_SCROLL_PX + 500,
+    });
+    expect(clamped.scrollTop).toBe(SPACE_HISTORY_MAX_SCROLL_PX);
+  });
+
+  it('restores only the exact current view key', () => {
+    const state = mergeSpaceHistoryUiState(
+      null,
+      createSpaceHistoryUiSnapshot({
+        viewKey: 'reader:open:tag',
+        scrollTop: 88,
+        expandedIds: ['item-3'],
+      })
+    );
+
+    expect(readSpaceHistoryUiState(state, 'reader:open:tag')).toEqual({
+      version: 1,
+      viewKey: 'reader:open:tag',
+      scrollTop: 88,
+      expandedIds: ['item-3'],
+    });
+    expect(readSpaceHistoryUiState(state, 'list:open:tag')).toBeNull();
+  });
+
+  it('rejects malformed, oversized, wrong-version, and out-of-range payloads', () => {
+    expect(readSpaceHistoryUiState(null, 'list:open:')).toBeNull();
+    expect(
+      readSpaceHistoryUiState(
+        { [SPACE_HISTORY_UI_KEY]: { version: 99 } },
+        'list:open:'
+      )
+    ).toBeNull();
+    expect(
+      readSpaceHistoryUiState(
+        {
+          [SPACE_HISTORY_UI_KEY]: {
+            version: 1,
+            viewKey: 'list:open:',
+            scrollTop: -1,
+            expandedIds: [],
+          },
+        },
+        'list:open:'
+      )
+    ).toBeNull();
+    expect(
+      readSpaceHistoryUiState(
+        {
+          [SPACE_HISTORY_UI_KEY]: {
+            version: 1,
+            viewKey: 'list:open:',
+            scrollTop: 1,
+            expandedIds: Array.from(
+              { length: SPACE_HISTORY_MAX_EXPANDED_IDS + 1 },
+              (_, index) => `item-${index}`
+            ),
+          },
+        },
+        'list:open:'
+      )
+    ).toBeNull();
+  });
+});

--- a/lib/space-history-ui.ts
+++ b/lib/space-history-ui.ts
@@ -1,0 +1,96 @@
+export const SPACE_HISTORY_UI_KEY = '__scrapbookSpaceUi';
+export const SPACE_HISTORY_UI_VERSION = 1;
+export const SPACE_HISTORY_MAX_EXPANDED_IDS = 24;
+export const SPACE_HISTORY_MAX_SCROLL_PX = 10_000_000;
+
+export type SpaceHistoryUiSnapshot = {
+  version: typeof SPACE_HISTORY_UI_VERSION;
+  viewKey: string;
+  scrollTop: number;
+  expandedIds: string[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function clampScrollTop(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(Math.round(value), SPACE_HISTORY_MAX_SCROLL_PX));
+}
+
+function normaliseExpandedIds(ids: readonly string[]) {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const id of ids) {
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+    if (result.length >= SPACE_HISTORY_MAX_EXPANDED_IDS) break;
+  }
+
+  return result;
+}
+
+export function createSpaceHistoryUiSnapshot(options: {
+  viewKey: string;
+  scrollTop: number;
+  expandedIds?: readonly string[];
+}): SpaceHistoryUiSnapshot {
+  return {
+    version: SPACE_HISTORY_UI_VERSION,
+    viewKey: options.viewKey,
+    scrollTop: clampScrollTop(options.scrollTop),
+    expandedIds: normaliseExpandedIds(options.expandedIds ?? []),
+  };
+}
+
+export function mergeSpaceHistoryUiState(
+  baseState: unknown,
+  snapshot: SpaceHistoryUiSnapshot
+) {
+  const base = isRecord(baseState) ? baseState : {};
+  return { ...base, [SPACE_HISTORY_UI_KEY]: snapshot };
+}
+
+export function readSpaceHistoryUiState(
+  state: unknown,
+  expectedViewKey: string
+): SpaceHistoryUiSnapshot | null {
+  if (!isRecord(state)) return null;
+  const candidate = state[SPACE_HISTORY_UI_KEY];
+  if (!isRecord(candidate)) return null;
+  if (candidate.version !== SPACE_HISTORY_UI_VERSION) return null;
+  if (
+    typeof candidate.viewKey !== 'string' ||
+    candidate.viewKey !== expectedViewKey
+  ) {
+    return null;
+  }
+  if (
+    typeof candidate.scrollTop !== 'number' ||
+    !Number.isFinite(candidate.scrollTop) ||
+    candidate.scrollTop < 0 ||
+    candidate.scrollTop > SPACE_HISTORY_MAX_SCROLL_PX
+  ) {
+    return null;
+  }
+  if (
+    !Array.isArray(candidate.expandedIds) ||
+    candidate.expandedIds.length > SPACE_HISTORY_MAX_EXPANDED_IDS ||
+    !candidate.expandedIds.every(
+      id => typeof id === 'string' && id.length > 0
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    version: SPACE_HISTORY_UI_VERSION,
+    viewKey: candidate.viewKey,
+    scrollTop: candidate.scrollTop,
+    expandedIds: [...candidate.expandedIds],
+  };
+}

--- a/lib/space-public-snapshot-storage.test.ts
+++ b/lib/space-public-snapshot-storage.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Item } from '@/app/lib/item-types';
+import { SPACE_PUBLIC_SNAPSHOT_KEY } from './space-public-snapshot';
+import {
+  readStoredSpacePublicSnapshot,
+  writeStoredSpacePublicSnapshot,
+  type SpaceSnapshotStorage,
+} from './space-public-snapshot-storage';
+
+function item(): Item {
+  return {
+    id: 'item-1',
+    slug: 'item-1',
+    title: 'Cached item',
+    category: 'notes',
+    tags: ['topic:continuity'],
+    url: null,
+    versions: [{ label: 'main', contentHtml: '<p>Cached item</p>' }],
+    defaultIndex: 0,
+    userId: 'private-user',
+    review: { private: true } as unknown as Item['review'],
+  } as Item;
+}
+
+function memoryStorage(initial: string | null = null) {
+  let value = initial;
+  return {
+    getItem: vi.fn((key: string) =>
+      key === SPACE_PUBLIC_SNAPSHOT_KEY ? value : null
+    ),
+    setItem: vi.fn((key: string, next: string) => {
+      if (key === SPACE_PUBLIC_SNAPSHOT_KEY) value = next;
+    }),
+    removeItem: vi.fn((key: string) => {
+      if (key === SPACE_PUBLIC_SNAPSHOT_KEY) value = null;
+    }),
+  } satisfies SpaceSnapshotStorage;
+}
+
+describe('Space public snapshot storage', () => {
+  it('writes only non-empty public snapshots and can read them back', () => {
+    const storage = memoryStorage();
+
+    expect(
+      writeStoredSpacePublicSnapshot(storage, [], {
+        savedAt: 1_000,
+        hasMore: false,
+      })
+    ).toBe(false);
+    expect(storage.setItem).not.toHaveBeenCalled();
+
+    expect(
+      writeStoredSpacePublicSnapshot(storage, [item()], {
+        savedAt: 1_000,
+        hasMore: true,
+      })
+    ).toBe(true);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem.mock.calls[0]?.[1]).not.toContain('private-user');
+
+    const restored = readStoredSpacePublicSnapshot(storage, 1_500);
+    expect(restored?.items[0]).toMatchObject({
+      id: 'item-1',
+      review: null,
+      userId: null,
+    });
+    expect(restored?.hasMore).toBe(true);
+  });
+
+  it('removes invalid or stale stored payloads', () => {
+    const invalid = memoryStorage('{');
+    expect(readStoredSpacePublicSnapshot(invalid, 5_000)).toBeNull();
+    expect(invalid.removeItem).toHaveBeenCalledWith(SPACE_PUBLIC_SNAPSHOT_KEY);
+
+    const stale = memoryStorage();
+    writeStoredSpacePublicSnapshot(stale, [item()], {
+      savedAt: 1,
+      hasMore: false,
+    });
+    expect(
+      readStoredSpacePublicSnapshot(stale, 24 * 60 * 60 * 1000 + 2)
+    ).toBeNull();
+    expect(stale.removeItem).toHaveBeenCalledWith(SPACE_PUBLIC_SNAPSHOT_KEY);
+  });
+
+  it('treats unavailable or quota-limited storage as a cache miss', () => {
+    const unavailable = {
+      getItem: vi.fn(() => {
+        throw new Error('SecurityError');
+      }),
+      setItem: vi.fn(() => {
+        throw new Error('QuotaExceededError');
+      }),
+      removeItem: vi.fn(),
+    } satisfies SpaceSnapshotStorage;
+
+    expect(readStoredSpacePublicSnapshot(unavailable, 1_000)).toBeNull();
+    expect(
+      writeStoredSpacePublicSnapshot(unavailable, [item()], {
+        savedAt: 1_000,
+        hasMore: false,
+      })
+    ).toBe(false);
+  });
+
+  it('does not turn failed cleanup into a route failure', () => {
+    const storage = {
+      getItem: vi.fn(() => '{'),
+      setItem: vi.fn(),
+      removeItem: vi.fn(() => {
+        throw new Error('SecurityError');
+      }),
+    } satisfies SpaceSnapshotStorage;
+
+    expect(readStoredSpacePublicSnapshot(storage, 1_000)).toBeNull();
+  });
+});

--- a/lib/space-public-snapshot-storage.test.ts
+++ b/lib/space-public-snapshot-storage.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Item } from '@/app/lib/item-types';
-import { SPACE_PUBLIC_SNAPSHOT_KEY } from './space-public-snapshot';
+import {
+  SPACE_PUBLIC_SNAPSHOT_KEY,
+  SPACE_PUBLIC_SNAPSHOT_MAX_BYTES,
+} from './space-public-snapshot';
 import {
   readStoredSpacePublicSnapshot,
   writeStoredSpacePublicSnapshot,
   type SpaceSnapshotStorage,
 } from './space-public-snapshot-storage';
 
-function item(): Item {
+function item(overrides: Partial<Item> = {}): Item {
   return {
     id: 'item-1',
     slug: 'item-1',
@@ -15,11 +18,22 @@ function item(): Item {
     category: 'notes',
     tags: ['topic:continuity'],
     url: null,
-    versions: [{ label: 'main', contentHtml: '<p>Cached item</p>' }],
+    versions: [
+      {
+        label: 'main',
+        content: 'Cached item',
+        contentHtml: '<p>Cached item</p>',
+        code: null,
+        codeHtml: '',
+      },
+    ],
     defaultIndex: 0,
+    createdAt: 100,
+    updatedAt: 200,
     userId: 'private-user',
     review: { private: true } as unknown as Item['review'],
-  } as Item;
+    ...overrides,
+  };
 }
 
 function memoryStorage(initial: string | null = null) {
@@ -59,15 +73,13 @@ describe('Space public snapshot storage', () => {
     expect(storage.setItem.mock.calls[0]?.[1]).not.toContain('private-user');
 
     const restored = readStoredSpacePublicSnapshot(storage, 1_500);
-    expect(restored?.items[0]).toMatchObject({
-      id: 'item-1',
-      review: null,
-      userId: null,
-    });
+    expect(restored?.items[0]).toMatchObject({ id: 'item-1' });
+    expect(restored?.items[0]).not.toHaveProperty('review');
+    expect(restored?.items[0]).not.toHaveProperty('userId');
     expect(restored?.hasMore).toBe(true);
   });
 
-  it('removes invalid or stale stored payloads', () => {
+  it('removes invalid, stale, or over-budget stored payloads', () => {
     const invalid = memoryStorage('{');
     expect(readStoredSpacePublicSnapshot(invalid, 5_000)).toBeNull();
     expect(invalid.removeItem).toHaveBeenCalledWith(SPACE_PUBLIC_SNAPSHOT_KEY);
@@ -81,6 +93,35 @@ describe('Space public snapshot storage', () => {
       readStoredSpacePublicSnapshot(stale, 24 * 60 * 60 * 1000 + 2)
     ).toBeNull();
     expect(stale.removeItem).toHaveBeenCalledWith(SPACE_PUBLIC_SNAPSHOT_KEY);
+
+    const oversized = memoryStorage(
+      'x'.repeat(SPACE_PUBLIC_SNAPSHOT_MAX_BYTES + 1)
+    );
+    expect(readStoredSpacePublicSnapshot(oversized, 5_000)).toBeNull();
+    expect(oversized.removeItem).toHaveBeenCalledWith(SPACE_PUBLIC_SNAPSHOT_KEY);
+  });
+
+  it('does not attempt a browser write when serialization exceeds the byte budget', () => {
+    const storage = memoryStorage();
+    const huge = item({
+      versions: [
+        {
+          label: 'main',
+          content: 'large',
+          contentHtml: 'x'.repeat(SPACE_PUBLIC_SNAPSHOT_MAX_BYTES),
+          code: null,
+          codeHtml: '',
+        },
+      ],
+    });
+
+    expect(
+      writeStoredSpacePublicSnapshot(storage, [huge], {
+        savedAt: 1_000,
+        hasMore: false,
+      })
+    ).toBe(false);
+    expect(storage.setItem).not.toHaveBeenCalled();
   });
 
   it('treats unavailable or quota-limited storage as a cache miss', () => {

--- a/lib/space-public-snapshot-storage.ts
+++ b/lib/space-public-snapshot-storage.ts
@@ -1,0 +1,54 @@
+import type { Item } from '@/app/lib/item-types';
+import {
+  SPACE_PUBLIC_SNAPSHOT_KEY,
+  createSpacePublicSnapshot,
+  parseSpacePublicSnapshot,
+  serializeSpacePublicSnapshot,
+  type RestoredSpacePublicSnapshot,
+} from './space-public-snapshot';
+
+export type SpaceSnapshotStorage = Pick<
+  Storage,
+  'getItem' | 'setItem' | 'removeItem'
+>;
+
+export function readStoredSpacePublicSnapshot(
+  storage: SpaceSnapshotStorage,
+  nowMs: number
+): RestoredSpacePublicSnapshot | null {
+  let raw: string | null;
+  try {
+    raw = storage.getItem(SPACE_PUBLIC_SNAPSHOT_KEY);
+  } catch {
+    return null;
+  }
+
+  const restored = parseSpacePublicSnapshot(raw, nowMs);
+  if (restored || raw === null) return restored;
+
+  try {
+    storage.removeItem(SPACE_PUBLIC_SNAPSHOT_KEY);
+  } catch {
+    // A failed cleanup should not turn continuity into a route failure.
+  }
+  return null;
+}
+
+export function writeStoredSpacePublicSnapshot(
+  storage: SpaceSnapshotStorage,
+  items: readonly Item[],
+  options: { savedAt: number; hasMore: boolean }
+) {
+  if (items.length === 0) return false;
+
+  const snapshot = createSpacePublicSnapshot(items, options);
+  try {
+    storage.setItem(
+      SPACE_PUBLIC_SNAPSHOT_KEY,
+      serializeSpacePublicSnapshot(snapshot)
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/lib/space-public-snapshot.test.ts
+++ b/lib/space-public-snapshot.test.ts
@@ -49,7 +49,7 @@ describe('Space public snapshot contract', () => {
     expect(serializeSpacePublicSnapshot(snapshot)).not.toContain('private');
   });
 
-  it('restores a fresh public snapshot with private fields explicitly null', () => {
+  it('restores a fresh public snapshot without private fields', () => {
     const raw = serializeSpacePublicSnapshot(
       createSpacePublicSnapshot([item()], {
         savedAt: 10_000,
@@ -68,9 +68,9 @@ describe('Space public snapshot contract', () => {
       id: 'item-1',
       slug: 'item-1',
       title: 'Item 1',
-      review: null,
-      userId: null,
     });
+    expect(restored?.items[0]).not.toHaveProperty('review');
+    expect(restored?.items[0]).not.toHaveProperty('userId');
   });
 
   it('rejects stale, far-future, wrong-version, and oversized snapshots', () => {

--- a/lib/space-public-snapshot.test.ts
+++ b/lib/space-public-snapshot.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import type { Item } from '@/app/lib/item-types';
+import {
+  SPACE_PUBLIC_SNAPSHOT_MAX_AGE_MS,
+  SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS,
+  SPACE_PUBLIC_SNAPSHOT_VERSION,
+  createSpacePublicSnapshot,
+  parseSpacePublicSnapshot,
+  serializeSpacePublicSnapshot,
+} from './space-public-snapshot';
+
+function item(index = 1, overrides: Partial<Item> = {}): Item {
+  return {
+    id: `item-${index}`,
+    slug: `item-${index}`,
+    title: `Item ${index}`,
+    category: 'notes',
+    tags: ['source:test', 'topic:continuity'],
+    url: `https://example.com/items/${index}`,
+    versions: [
+      {
+        label: 'main',
+        contentHtml: `<p>Item ${index}</p>`,
+      },
+    ],
+    defaultIndex: 0,
+    userId: 'private-user',
+    review: { private: true } as unknown as Item['review'],
+    ...overrides,
+  } as Item;
+}
+
+describe('Space public snapshot contract', () => {
+  it('caps the archive page and strips private/admin fields before serialization', () => {
+    const items = Array.from(
+      { length: SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS + 7 },
+      (_, index) => item(index + 1)
+    );
+    const snapshot = createSpacePublicSnapshot(items, {
+      savedAt: 1_000,
+      hasMore: true,
+    });
+
+    expect(snapshot.version).toBe(SPACE_PUBLIC_SNAPSHOT_VERSION);
+    expect(snapshot.items).toHaveLength(SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS);
+    expect(snapshot.items[0]).not.toHaveProperty('review');
+    expect(snapshot.items[0]).not.toHaveProperty('userId');
+    expect(serializeSpacePublicSnapshot(snapshot)).not.toContain('private-user');
+    expect(serializeSpacePublicSnapshot(snapshot)).not.toContain('private');
+  });
+
+  it('restores a fresh public snapshot with private fields explicitly null', () => {
+    const raw = serializeSpacePublicSnapshot(
+      createSpacePublicSnapshot([item()], {
+        savedAt: 10_000,
+        hasMore: false,
+      })
+    );
+
+    const restored = parseSpacePublicSnapshot(raw, 12_500);
+    expect(restored).toMatchObject({
+      savedAt: 10_000,
+      ageMs: 2_500,
+      hasMore: false,
+    });
+    expect(restored?.items).toHaveLength(1);
+    expect(restored?.items[0]).toMatchObject({
+      id: 'item-1',
+      slug: 'item-1',
+      title: 'Item 1',
+      review: null,
+      userId: null,
+    });
+  });
+
+  it('rejects stale, far-future, wrong-version, and oversized snapshots', () => {
+    const snapshot = createSpacePublicSnapshot([item()], {
+      savedAt: 5_000,
+      hasMore: false,
+    });
+
+    expect(
+      parseSpacePublicSnapshot(
+        serializeSpacePublicSnapshot(snapshot),
+        5_000 + SPACE_PUBLIC_SNAPSHOT_MAX_AGE_MS + 1
+      )
+    ).toBeNull();
+    expect(
+      parseSpacePublicSnapshot(
+        serializeSpacePublicSnapshot(snapshot),
+        snapshot.savedAt - 5 * 60 * 1000 - 1
+      )
+    ).toBeNull();
+
+    const wrongVersion = { ...snapshot, version: 99 };
+    expect(parseSpacePublicSnapshot(JSON.stringify(wrongVersion), 5_000)).toBeNull();
+
+    const oversized = {
+      ...snapshot,
+      items: Array.from(
+        { length: SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS + 1 },
+        () => snapshot.items[0]
+      ),
+    };
+    expect(parseSpacePublicSnapshot(JSON.stringify(oversized), 5_000)).toBeNull();
+  });
+
+  it('rejects malformed or private-field-injected browser data', () => {
+    const snapshot = createSpacePublicSnapshot([item()], {
+      savedAt: 5_000,
+      hasMore: false,
+    });
+
+    expect(parseSpacePublicSnapshot('{', 5_000)).toBeNull();
+    expect(parseSpacePublicSnapshot(null, 5_000)).toBeNull();
+
+    const privateInjection = {
+      ...snapshot,
+      items: [{ ...snapshot.items[0], userId: 'restored-private-user' }],
+    };
+    expect(
+      parseSpacePublicSnapshot(JSON.stringify(privateInjection), 5_000)
+    ).toBeNull();
+
+    const malformedVersion = {
+      ...snapshot,
+      items: [{ ...snapshot.items[0], versions: [{ label: 'main' }] }],
+    };
+    expect(
+      parseSpacePublicSnapshot(JSON.stringify(malformedVersion), 5_000)
+    ).toBeNull();
+  });
+});

--- a/lib/space-public-snapshot.test.ts
+++ b/lib/space-public-snapshot.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Item } from '@/app/lib/item-types';
 import {
   SPACE_PUBLIC_SNAPSHOT_MAX_AGE_MS,
+  SPACE_PUBLIC_SNAPSHOT_MAX_BYTES,
   SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS,
   SPACE_PUBLIC_SNAPSHOT_VERSION,
   createSpacePublicSnapshot,
@@ -20,33 +21,45 @@ function item(index = 1, overrides: Partial<Item> = {}): Item {
     versions: [
       {
         label: 'main',
+        content: `Item ${index}`,
         contentHtml: `<p>Item ${index}</p>`,
+        code: null,
+        codeHtml: '',
       },
     ],
     defaultIndex: 0,
+    createdAt: 100 + index,
+    updatedAt: 200 + index,
     userId: 'private-user',
     review: { private: true } as unknown as Item['review'],
     ...overrides,
-  } as Item;
+  };
 }
 
 describe('Space public snapshot contract', () => {
-  it('caps the archive page and strips private/admin fields before serialization', () => {
-    const items = Array.from(
-      { length: SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS + 7 },
-      (_, index) => item(index + 1)
-    );
+  it('caps the archive page and projects only explicit public fields', () => {
+    const first = item();
+    (first as Item & { futurePrivate?: string }).futurePrivate = 'future-secret';
+    const items = [
+      first,
+      ...Array.from(
+        { length: SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS + 6 },
+        (_, index) => item(index + 2)
+      ),
+    ];
     const snapshot = createSpacePublicSnapshot(items, {
       savedAt: 1_000,
       hasMore: true,
     });
+    const serialized = serializeSpacePublicSnapshot(snapshot);
 
     expect(snapshot.version).toBe(SPACE_PUBLIC_SNAPSHOT_VERSION);
     expect(snapshot.items).toHaveLength(SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS);
     expect(snapshot.items[0]).not.toHaveProperty('review');
     expect(snapshot.items[0]).not.toHaveProperty('userId');
-    expect(serializeSpacePublicSnapshot(snapshot)).not.toContain('private-user');
-    expect(serializeSpacePublicSnapshot(snapshot)).not.toContain('private');
+    expect(snapshot.items[0]).not.toHaveProperty('futurePrivate');
+    expect(serialized).not.toContain('private-user');
+    expect(serialized).not.toContain('future-secret');
   });
 
   it('restores a fresh public snapshot without private fields', () => {
@@ -68,12 +81,14 @@ describe('Space public snapshot contract', () => {
       id: 'item-1',
       slug: 'item-1',
       title: 'Item 1',
+      createdAt: 101,
+      updatedAt: 201,
     });
     expect(restored?.items[0]).not.toHaveProperty('review');
     expect(restored?.items[0]).not.toHaveProperty('userId');
   });
 
-  it('rejects stale, far-future, wrong-version, and oversized snapshots', () => {
+  it('rejects stale, far-future, wrong-version, oversized-count, and oversized-byte snapshots', () => {
     const snapshot = createSpacePublicSnapshot([item()], {
       savedAt: 5_000,
       hasMore: false,
@@ -95,17 +110,43 @@ describe('Space public snapshot contract', () => {
     const wrongVersion = { ...snapshot, version: 99 };
     expect(parseSpacePublicSnapshot(JSON.stringify(wrongVersion), 5_000)).toBeNull();
 
-    const oversized = {
+    const oversizedCount = {
       ...snapshot,
       items: Array.from(
         { length: SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS + 1 },
         () => snapshot.items[0]
       ),
     };
-    expect(parseSpacePublicSnapshot(JSON.stringify(oversized), 5_000)).toBeNull();
+    expect(
+      parseSpacePublicSnapshot(JSON.stringify(oversizedCount), 5_000)
+    ).toBeNull();
+
+    expect(
+      parseSpacePublicSnapshot('x'.repeat(SPACE_PUBLIC_SNAPSHOT_MAX_BYTES + 1), 5_000)
+    ).toBeNull();
+
+    const huge = createSpacePublicSnapshot(
+      [
+        item(1, {
+          versions: [
+            {
+              label: 'main',
+              content: 'large',
+              contentHtml: 'x'.repeat(SPACE_PUBLIC_SNAPSHOT_MAX_BYTES),
+              code: null,
+              codeHtml: '',
+            },
+          ],
+        }),
+      ],
+      { savedAt: 5_000, hasMore: false }
+    );
+    expect(() => serializeSpacePublicSnapshot(huge)).toThrow(
+      'browser cache byte budget'
+    );
   });
 
-  it('rejects malformed or private-field-injected browser data', () => {
+  it('rejects malformed, private-field-injected, and unknown-field browser data', () => {
     const snapshot = createSpacePublicSnapshot([item()], {
       savedAt: 5_000,
       hasMore: false,
@@ -120,6 +161,28 @@ describe('Space public snapshot contract', () => {
     };
     expect(
       parseSpacePublicSnapshot(JSON.stringify(privateInjection), 5_000)
+    ).toBeNull();
+
+    const unknownRoot = { ...snapshot, futurePrivate: 'secret' };
+    expect(parseSpacePublicSnapshot(JSON.stringify(unknownRoot), 5_000)).toBeNull();
+
+    const unknownItem = {
+      ...snapshot,
+      items: [{ ...snapshot.items[0], futurePrivate: 'secret' }],
+    };
+    expect(parseSpacePublicSnapshot(JSON.stringify(unknownItem), 5_000)).toBeNull();
+
+    const unknownVersion = {
+      ...snapshot,
+      items: [
+        {
+          ...snapshot.items[0],
+          versions: [{ ...snapshot.items[0].versions[0], futurePrivate: 'secret' }],
+        },
+      ],
+    };
+    expect(
+      parseSpacePublicSnapshot(JSON.stringify(unknownVersion), 5_000)
     ).toBeNull();
 
     const malformedVersion = {

--- a/lib/space-public-snapshot.ts
+++ b/lib/space-public-snapshot.ts
@@ -126,10 +126,6 @@ export function parseSpacePublicSnapshot(
     savedAt: parsed.savedAt,
     ageMs: Math.max(0, ageMs),
     hasMore: parsed.hasMore,
-    items: parsed.items.map(item => ({
-      ...item,
-      review: null,
-      userId: null,
-    })) as Item[],
+    items: parsed.items.map(item => ({ ...item })) as Item[],
   };
 }

--- a/lib/space-public-snapshot.ts
+++ b/lib/space-public-snapshot.ts
@@ -1,0 +1,135 @@
+import type { Item } from '@/app/lib/item-types';
+
+export const SPACE_PUBLIC_SNAPSHOT_KEY = 'scrapbook:space-public-snapshot:v1';
+export const SPACE_PUBLIC_SNAPSHOT_VERSION = 1;
+export const SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS = 100;
+export const SPACE_PUBLIC_SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+type PublicSnapshotItem = Omit<Item, 'review' | 'userId'>;
+
+export type SpacePublicSnapshot = {
+  version: typeof SPACE_PUBLIC_SNAPSHOT_VERSION;
+  savedAt: number;
+  hasMore: boolean;
+  items: PublicSnapshotItem[];
+};
+
+export type RestoredSpacePublicSnapshot = {
+  savedAt: number;
+  ageMs: number;
+  hasMore: boolean;
+  items: Item[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(entry => typeof entry === 'string');
+}
+
+function isPublicVersion(value: unknown) {
+  if (!isRecord(value)) return false;
+  if (typeof value.label !== 'string') return false;
+  if (typeof value.contentHtml !== 'string') return false;
+  if (value.code !== undefined && value.code !== null && typeof value.code !== 'string') {
+    return false;
+  }
+  if (
+    value.codeHtml !== undefined &&
+    value.codeHtml !== null &&
+    typeof value.codeHtml !== 'string'
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isPublicSnapshotItem(value: unknown): value is PublicSnapshotItem {
+  if (!isRecord(value)) return false;
+  if ('review' in value || 'userId' in value) return false;
+  if (typeof value.id !== 'string' || value.id.length === 0) return false;
+  if (typeof value.slug !== 'string' || value.slug.length === 0) return false;
+  if (typeof value.title !== 'string') return false;
+  if (typeof value.category !== 'string') return false;
+  if (!isStringArray(value.tags)) return false;
+  if (value.url !== null && value.url !== undefined && typeof value.url !== 'string') {
+    return false;
+  }
+  if (!Array.isArray(value.versions) || value.versions.length === 0) return false;
+  if (!value.versions.every(isPublicVersion)) return false;
+  if (!Number.isInteger(value.defaultIndex)) return false;
+  if (
+    (value.defaultIndex as number) < 0 ||
+    (value.defaultIndex as number) >= value.versions.length
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function toPublicSnapshotItem(item: Item): PublicSnapshotItem {
+  const { review: _review, userId: _userId, ...publicItem } = item;
+  return publicItem;
+}
+
+export function createSpacePublicSnapshot(
+  items: readonly Item[],
+  options: { savedAt: number; hasMore: boolean }
+): SpacePublicSnapshot {
+  return {
+    version: SPACE_PUBLIC_SNAPSHOT_VERSION,
+    savedAt: options.savedAt,
+    hasMore: options.hasMore,
+    items: items
+      .slice(0, SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS)
+      .map(toPublicSnapshotItem),
+  };
+}
+
+export function serializeSpacePublicSnapshot(snapshot: SpacePublicSnapshot) {
+  return JSON.stringify(snapshot);
+}
+
+export function parseSpacePublicSnapshot(
+  raw: string | null,
+  nowMs: number
+): RestoredSpacePublicSnapshot | null {
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) return null;
+  if (parsed.version !== SPACE_PUBLIC_SNAPSHOT_VERSION) return null;
+  if (typeof parsed.savedAt !== 'number' || !Number.isFinite(parsed.savedAt)) {
+    return null;
+  }
+  if (typeof parsed.hasMore !== 'boolean') return null;
+  if (!Array.isArray(parsed.items)) return null;
+  if (parsed.items.length > SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS) return null;
+  if (!parsed.items.every(isPublicSnapshotItem)) return null;
+
+  const ageMs = nowMs - parsed.savedAt;
+  if (ageMs < -MAX_CLOCK_SKEW_MS || ageMs > SPACE_PUBLIC_SNAPSHOT_MAX_AGE_MS) {
+    return null;
+  }
+
+  return {
+    savedAt: parsed.savedAt,
+    ageMs: Math.max(0, ageMs),
+    hasMore: parsed.hasMore,
+    items: parsed.items.map(item => ({
+      ...item,
+      review: null,
+      userId: null,
+    })) as Item[],
+  };
+}

--- a/lib/space-public-snapshot.ts
+++ b/lib/space-public-snapshot.ts
@@ -4,10 +4,31 @@ export const SPACE_PUBLIC_SNAPSHOT_KEY = 'scrapbook:space-public-snapshot:v1';
 export const SPACE_PUBLIC_SNAPSHOT_VERSION = 1;
 export const SPACE_PUBLIC_SNAPSHOT_MAX_ITEMS = 100;
 export const SPACE_PUBLIC_SNAPSHOT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+export const SPACE_PUBLIC_SNAPSHOT_MAX_BYTES = 2 * 1024 * 1024;
 
 const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
-type PublicSnapshotItem = Omit<Item, 'review' | 'userId'>;
+export type PublicSnapshotVersion = {
+  label: string;
+  content: string;
+  contentHtml: string;
+  code: string | null;
+  codeHtml: string;
+};
+
+export type PublicSnapshotItem = {
+  id: string;
+  title: string;
+  slug: string;
+  url: string | null;
+  defaultIndex: number;
+  versions: PublicSnapshotVersion[];
+  tags: string[];
+  category: string;
+  createdAt: number;
+  updatedAt: number;
+  score?: number;
+};
 
 export type SpacePublicSnapshot = {
   version: typeof SPACE_PUBLIC_SNAPSHOT_VERSION;
@@ -23,42 +44,67 @@ export type RestoredSpacePublicSnapshot = {
   items: Item[];
 };
 
+const SNAPSHOT_KEYS = new Set(['version', 'savedAt', 'hasMore', 'items']);
+const ITEM_KEYS = new Set([
+  'id',
+  'title',
+  'slug',
+  'url',
+  'defaultIndex',
+  'versions',
+  'tags',
+  'category',
+  'createdAt',
+  'updatedAt',
+  'score',
+]);
+const VERSION_KEYS = new Set([
+  'label',
+  'content',
+  'contentHtml',
+  'code',
+  'codeHtml',
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>) {
+  return Object.keys(value).every(key => allowed.has(key));
 }
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every(entry => typeof entry === 'string');
 }
 
-function isPublicVersion(value: unknown) {
-  if (!isRecord(value)) return false;
-  if (typeof value.label !== 'string') return false;
-  if (typeof value.contentHtml !== 'string') return false;
-  if (value.code !== undefined && value.code !== null && typeof value.code !== 'string') {
-    return false;
-  }
-  if (
-    value.codeHtml !== undefined &&
-    value.codeHtml !== null &&
-    typeof value.codeHtml !== 'string'
-  ) {
-    return false;
-  }
-  return true;
+function utf8ByteLength(value: string) {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function isPublicVersion(value: unknown): value is PublicSnapshotVersion {
+  if (!isRecord(value) || !hasOnlyKeys(value, VERSION_KEYS)) return false;
+  return (
+    typeof value.label === 'string' &&
+    typeof value.content === 'string' &&
+    typeof value.contentHtml === 'string' &&
+    (value.code === null || typeof value.code === 'string') &&
+    typeof value.codeHtml === 'string'
+  );
 }
 
 function isPublicSnapshotItem(value: unknown): value is PublicSnapshotItem {
-  if (!isRecord(value)) return false;
-  if ('review' in value || 'userId' in value) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, ITEM_KEYS)) return false;
   if (typeof value.id !== 'string' || value.id.length === 0) return false;
   if (typeof value.slug !== 'string' || value.slug.length === 0) return false;
   if (typeof value.title !== 'string') return false;
   if (typeof value.category !== 'string') return false;
   if (!isStringArray(value.tags)) return false;
-  if (value.url !== null && value.url !== undefined && typeof value.url !== 'string') {
+  if (value.url !== null && typeof value.url !== 'string') return false;
+  if (!Number.isFinite(value.createdAt) || !Number.isFinite(value.updatedAt)) {
     return false;
   }
+  if (value.score !== undefined && !Number.isFinite(value.score)) return false;
   if (!Array.isArray(value.versions) || value.versions.length === 0) return false;
   if (!value.versions.every(isPublicVersion)) return false;
   if (!Number.isInteger(value.defaultIndex)) return false;
@@ -71,9 +117,32 @@ function isPublicSnapshotItem(value: unknown): value is PublicSnapshotItem {
   return true;
 }
 
+function toPublicSnapshotVersion(
+  version: Item['versions'][number]
+): PublicSnapshotVersion {
+  return {
+    label: version.label,
+    content: version.content,
+    contentHtml: version.contentHtml,
+    code: version.code,
+    codeHtml: version.codeHtml,
+  };
+}
+
 function toPublicSnapshotItem(item: Item): PublicSnapshotItem {
-  const { review: _review, userId: _userId, ...publicItem } = item;
-  return publicItem;
+  return {
+    id: item.id,
+    title: item.title,
+    slug: item.slug,
+    url: item.url,
+    defaultIndex: item.defaultIndex,
+    versions: item.versions.map(toPublicSnapshotVersion),
+    tags: [...item.tags],
+    category: item.category,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    ...(item.score === undefined ? {} : { score: item.score }),
+  };
 }
 
 export function createSpacePublicSnapshot(
@@ -91,14 +160,18 @@ export function createSpacePublicSnapshot(
 }
 
 export function serializeSpacePublicSnapshot(snapshot: SpacePublicSnapshot) {
-  return JSON.stringify(snapshot);
+  const serialized = JSON.stringify(snapshot);
+  if (utf8ByteLength(serialized) > SPACE_PUBLIC_SNAPSHOT_MAX_BYTES) {
+    throw new Error('Space public snapshot exceeds the browser cache byte budget');
+  }
+  return serialized;
 }
 
 export function parseSpacePublicSnapshot(
   raw: string | null,
   nowMs: number
 ): RestoredSpacePublicSnapshot | null {
-  if (!raw) return null;
+  if (!raw || utf8ByteLength(raw) > SPACE_PUBLIC_SNAPSHOT_MAX_BYTES) return null;
 
   let parsed: unknown;
   try {
@@ -107,7 +180,7 @@ export function parseSpacePublicSnapshot(
     return null;
   }
 
-  if (!isRecord(parsed)) return null;
+  if (!isRecord(parsed) || !hasOnlyKeys(parsed, SNAPSHOT_KEYS)) return null;
   if (parsed.version !== SPACE_PUBLIC_SNAPSHOT_VERSION) return null;
   if (typeof parsed.savedAt !== 'number' || !Number.isFinite(parsed.savedAt)) {
     return null;
@@ -126,6 +199,10 @@ export function parseSpacePublicSnapshot(
     savedAt: parsed.savedAt,
     ageMs: Math.max(0, ageMs),
     hasMore: parsed.hasMore,
-    items: parsed.items.map(item => ({ ...item })) as Item[],
+    items: parsed.items.map(item => ({
+      ...item,
+      versions: item.versions.map(version => ({ ...version })),
+      tags: [...item.tags],
+    })),
   };
 }


### PR DESCRIPTION
## Why

Issue #553 calls for immediate, resumable Space navigation without making browser storage a second database or mixing public archive continuity with private review state. This draft proves the risky admission/serialization contracts independently before any provider reads localStorage or mutates browser history.

## Contract 1 — canonical browse state

- one stable encoder for ordinary `lane`, `tags`, and `item` state;
- deterministic `lane → tags → item` parameter ordering and normal URL escaping;
- empty values disappear;
- the same canonical serialization generates list/reader `viewKey`s for history restoration.

Trail/reading-sheet-only fields (`from`, `return`, `practice`, `stage`) stay outside this first codec until their existing route helpers are migrated deliberately.

## Contract 2 — bounded fail-closed public snapshot

- versioned key `scrapbook:space-public-snapshot:v1`;
- explicit public allowlists for snapshot, item, and version fields;
- future/unknown stored fields are rejected instead of silently entering the cache;
- `review`, `userId`, and any future non-allowlisted fields are absent from serialization;
- cap at the existing first-page size of 100 items;
- cap serialized data at 2 MiB UTF-8 before browser parse/write;
- 24-hour maximum age with a small forward-clock-skew tolerance;
- validate the full public version fields consumed by current Space (`label`, source content, rendered HTML, code, rendered code);
- validate item identity, URL, tags, indexes, timestamps, and optional score;
- reject malformed JSON, wrong versions, item-count/byte-budget overflow, stale snapshots, far-future timestamps, invalid version indexes, malformed versions, and unknown/private fields;
- restore cached items with private fields absent rather than manufacturing nullable sentinels;
- never write an empty archive snapshot;
- treat localStorage security/quota/read/write failures as ordinary cache misses;
- remove malformed/stale/oversized stored payloads when storage permits.

## Contract 3 — same-entry UI history

- namespace ephemeral list/reader UI under `__scrapbookSpaceUi` while preserving Next/router-owned fields in the same `history.state` object;
- bind restoration to an exact canonical `viewKey`, so list/reader/lane/filter states cannot consume one another's scroll snapshot;
- store only scroll position and bounded expanded-row IDs;
- clamp scroll positions and deduplicate/cap expanded IDs;
- reject malformed, wrong-version, cross-view, oversized, or out-of-range history payloads;
- keep durable learning/review state outside this namespace entirely.

## Integration contract

`docs/space-continuity.md` records the intended one-way admission sequence:

1. current server public data wins exactly as today;
2. successful non-empty public loads refresh the bounded browser snapshot;
3. a valid snapshot is admitted only when the server supplied no usable public items;
4. existing `reload()` background-revalidates that temporary fallback;
5. refresh failure preserves the visible list and existing bounded error UI;
6. private/admin review rows continue exclusively through their authenticated path.

The first runtime slice should not merge a partial server list with cached rows.

## Verification added

Focused unit tests cover:

- canonical parameter order, encoding, empty-value removal, and view-key parity;
- public item cap and explicit field projection;
- future field omission during serialization and unknown root/item/version rejection during parsing;
- fresh snapshot round-trip with private fields remaining absent;
- stale/future/wrong-version/item-count/byte-budget rejection;
- malformed JSON, private-field injection, and malformed-version rejection;
- localStorage round-trip, invalid-cache cleanup, empty-cache suppression, byte-budget enforcement, and quota/security failures;
- preservation of router-owned history fields;
- exact view-key restoration;
- bounded/deduplicated expanded-row IDs and scroll values;
- malformed/wrong-version/cross-view history rejection.

## Boundary

No browser storage is read or written by product code yet. No `history.state` is mutated by product code yet. No Space loading, routing, auth, review state, or UI behavior changes in this draft.

Once these pure contracts are green, integrate them in separate commits so cache admission and Back/Forward presentation restoration can be reviewed independently.

Part of #553