### PR TITLE
Use the hosted Chrome channel without downloading bundled Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile --reporter=silent
-      - name: Install Chromium
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Install Chrome dependencies
+        run: pnpm exec playwright install-deps chromium
       - name: Chromium regressions
         run: pnpm exec playwright test --project=chromium > playwright.log 2>&1
       - name: Upload homepage visual review


### PR DESCRIPTION
## Why

Hosted Playwright already configures the Chromium project with `channel: 'chrome'`, so the suite launches the system Google Chrome installed on GitHub's Ubuntu runner. The CI job still ran `playwright install --with-deps chromium`, downloading Playwright's bundled Chromium/headless shell before launching a different browser channel.

This is the measured trial from #578.

## Change

- keep the hosted `channel: 'chrome'` project unchanged;
- replace `playwright install --with-deps chromium` with `playwright install-deps chromium`;
- keep the complete Chromium regression command and homepage visual artifact unchanged.

## Measured result

Baseline hosted logs downloaded approximately:

- 173.9 MiB bundled Chromium;
- 2.3 MiB FFMPEG;
- 104.3 MiB Chromium headless shell.

The trial was exercised on two hosted e2e runs. Both:

- launched the existing system Chrome channel;
- downloaded zero Playwright browser binaries;
- passed the complete Chromium regression suite;
- uploaded the homepage visual-review artifact.

Observed setup from browser-install step start to test-command start:

- bundled-browser baseline: about 24.3s;
- first `install-deps` trial: about 19.7s;
- second `install-deps` trial: about 12.5s.

Total browser-job time remains noisy because the full test suite varies by runner; the stable improvement is removing roughly 280 MiB of redundant browser downloads while preserving the same project, test selection, browser engine, and assertions.

The second trial still downloaded OS/font packages required by Playwright (~32 MiB combined apt archives), so this PR intentionally retains `install-deps` rather than assuming the runner image contains every visual/runtime dependency.

## Boundary

CI workflow only. No product runtime, Playwright project, browser engine, local setup, test selection, or pass/fail policy changes. Revert is one workflow line.

Tracks #578.