### PR TITLE
Use the saved public Space snapshot during archive outages

### DIFF
--- a/app/lib/contexts/item-context.tsx
+++ b/app/lib/contexts/item-context.tsx
@@ -17,6 +17,7 @@ import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
 import { createClient } from '@/utils/supabase/client';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import {
+  clearStoredSpacePublicSnapshot,
   readStoredSpacePublicSnapshot,
   writeStoredSpacePublicSnapshot,
 } from '@/lib/space-public-snapshot-storage';
@@ -40,6 +41,22 @@ const REVIEW_SELECT = [
 const SPACE_CLIENT_LOAD_TIMEOUT_MS = 10_000;
 const CACHED_SPACE_MESSAGE =
   'Showing the last saved public copy while live Space is unavailable.';
+
+function persistFirstSpacePage(
+  items: readonly Item[],
+  hasMore: boolean,
+  savedAt: number
+) {
+  if (items.length === 0) {
+    clearStoredSpacePublicSnapshot(window.localStorage);
+    return;
+  }
+
+  writeStoredSpacePublicSnapshot(window.localStorage, items, {
+    savedAt,
+    hasMore,
+  });
+}
 
 type ItemsContextType = {
   items: Item[];
@@ -106,10 +123,11 @@ export function ItemsProvider({
       setError(initialError);
       setUsingCachedSnapshot(false);
       lastRefreshAt.current = currentNow;
-      writeStoredSpacePublicSnapshot(window.localStorage, initialItems, {
-        savedAt: initialNowMs ?? currentNow,
-        hasMore: initialHasMore,
-      });
+      persistFirstSpacePage(
+        initialItems,
+        initialHasMore,
+        initialNowMs ?? currentNow
+      );
       return;
     }
 
@@ -134,6 +152,10 @@ export function ItemsProvider({
     setError(initialError);
     setUsingCachedSnapshot(false);
     lastRefreshAt.current = currentNow;
+
+    if (!initialError) {
+      persistFirstSpacePage(initialItems, initialHasMore, currentNow);
+    }
   }, [initialError, initialHasMore, initialItems, initialNowMs]);
 
   const fetchPage = useCallback(
@@ -209,10 +231,7 @@ export function ItemsProvider({
       setHasMore(page.hasMore);
       setUsingCachedSnapshot(false);
       lastRefreshAt.current = savedAt;
-      writeStoredSpacePublicSnapshot(window.localStorage, page.items, {
-        savedAt,
-        hasMore: page.hasMore,
-      });
+      persistFirstSpacePage(page.items, page.hasMore, savedAt);
     } catch (reloadError) {
       if (controller.signal.aborted) return;
       console.error('Error reloading items:', reloadError);

--- a/app/lib/contexts/item-context.tsx
+++ b/app/lib/contexts/item-context.tsx
@@ -16,6 +16,10 @@ import type { DbItem, DbReview } from '@/app/lib/db/supabase';
 import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
 import { createClient } from '@/utils/supabase/client';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
+import {
+  readStoredSpacePublicSnapshot,
+  writeStoredSpacePublicSnapshot,
+} from '@/lib/space-public-snapshot-storage';
 
 const REVIEW_SELECT = [
   'item_id',
@@ -34,6 +38,8 @@ const REVIEW_SELECT = [
 ].join(',');
 
 const SPACE_CLIENT_LOAD_TIMEOUT_MS = 10_000;
+const CACHED_SPACE_MESSAGE =
+  'Showing the last saved public copy while live Space is unavailable.';
 
 type ItemsContextType = {
   items: Item[];
@@ -83,19 +89,52 @@ export function ItemsProvider({
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [nowMs] = useState(() => initialNowMs ?? Date.now());
   const [editorOpen, setEditorOpen] = useState(false);
+  const [usingCachedSnapshot, setUsingCachedSnapshot] = useState(false);
   const activeReload = useRef<AbortController | null>(null);
   const activeLoadMore = useRef<AbortController | null>(null);
   const lastRefreshAt = useRef(initialNowMs ?? 0);
   const isAdmin = initialIsAdmin;
 
   useEffect(() => {
+    const currentNow = Date.now();
+
+    if (initialItems.length > 0) {
+      setItems(initialItems);
+      setHasMore(initialHasMore);
+      setLoading(false);
+      setRefreshing(false);
+      setError(initialError);
+      setUsingCachedSnapshot(false);
+      lastRefreshAt.current = currentNow;
+      writeStoredSpacePublicSnapshot(window.localStorage, initialItems, {
+        savedAt: initialNowMs ?? currentNow,
+        hasMore: initialHasMore,
+      });
+      return;
+    }
+
+    if (initialError) {
+      const cached = readStoredSpacePublicSnapshot(window.localStorage, currentNow);
+      if (cached) {
+        setItems(cached.items);
+        setHasMore(cached.hasMore);
+        setLoading(false);
+        setRefreshing(false);
+        setError(CACHED_SPACE_MESSAGE);
+        setUsingCachedSnapshot(true);
+        lastRefreshAt.current = currentNow;
+        return;
+      }
+    }
+
     setItems(initialItems);
     setHasMore(initialHasMore);
     setLoading(false);
     setRefreshing(false);
     setError(initialError);
-    lastRefreshAt.current = Date.now();
-  }, [initialError, initialHasMore, initialItems]);
+    setUsingCachedSnapshot(false);
+    lastRefreshAt.current = currentNow;
+  }, [initialError, initialHasMore, initialItems, initialNowMs]);
 
   const fetchPage = useCallback(
     async (offset: number, signal: AbortSignal) => {
@@ -165,9 +204,15 @@ export function ItemsProvider({
     try {
       const page = await fetchPage(0, controller.signal);
       if (controller.signal.aborted) return;
+      const savedAt = Date.now();
       setItems(page.items);
       setHasMore(page.hasMore);
-      lastRefreshAt.current = Date.now();
+      setUsingCachedSnapshot(false);
+      lastRefreshAt.current = savedAt;
+      writeStoredSpacePublicSnapshot(window.localStorage, page.items, {
+        savedAt,
+        hasMore: page.hasMore,
+      });
     } catch (reloadError) {
       if (controller.signal.aborted) return;
       console.error('Error reloading items:', reloadError);
@@ -184,6 +229,11 @@ export function ItemsProvider({
       }
     }
   }, [fetchPage, items.length]);
+
+  useEffect(() => {
+    if (!usingCachedSnapshot) return;
+    void reload();
+  }, [reload, usingCachedSnapshot]);
 
   const loadMore = useCallback(async () => {
     if (!hasMore || loadingMore) return;

--- a/lib/space-public-snapshot-storage.test.ts
+++ b/lib/space-public-snapshot-storage.test.ts
@@ -5,6 +5,7 @@ import {
   SPACE_PUBLIC_SNAPSHOT_MAX_BYTES,
 } from './space-public-snapshot';
 import {
+  clearStoredSpacePublicSnapshot,
   readStoredSpacePublicSnapshot,
   writeStoredSpacePublicSnapshot,
   type SpaceSnapshotStorage,
@@ -77,6 +78,22 @@ describe('Space public snapshot storage', () => {
     expect(restored?.items[0]).not.toHaveProperty('review');
     expect(restored?.items[0]).not.toHaveProperty('userId');
     expect(restored?.hasMore).toBe(true);
+  });
+
+  it('clears an obsolete snapshot without making storage failure fatal', () => {
+    const storage = memoryStorage('old');
+    expect(clearStoredSpacePublicSnapshot(storage)).toBe(true);
+    expect(storage.removeItem).toHaveBeenCalledWith(SPACE_PUBLIC_SNAPSHOT_KEY);
+    expect(storage.getItem(SPACE_PUBLIC_SNAPSHOT_KEY)).toBeNull();
+
+    const unavailable = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(() => {
+        throw new Error('SecurityError');
+      }),
+    } satisfies SpaceSnapshotStorage;
+    expect(clearStoredSpacePublicSnapshot(unavailable)).toBe(false);
   });
 
   it('removes invalid, stale, or over-budget stored payloads', () => {

--- a/lib/space-public-snapshot-storage.ts
+++ b/lib/space-public-snapshot-storage.ts
@@ -12,6 +12,15 @@ export type SpaceSnapshotStorage = Pick<
   'getItem' | 'setItem' | 'removeItem'
 >;
 
+export function clearStoredSpacePublicSnapshot(storage: SpaceSnapshotStorage) {
+  try {
+    storage.removeItem(SPACE_PUBLIC_SNAPSHOT_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function readStoredSpacePublicSnapshot(
   storage: SpaceSnapshotStorage,
   nowMs: number
@@ -26,11 +35,7 @@ export function readStoredSpacePublicSnapshot(
   const restored = parseSpacePublicSnapshot(raw, nowMs);
   if (restored || raw === null) return restored;
 
-  try {
-    storage.removeItem(SPACE_PUBLIC_SNAPSHOT_KEY);
-  } catch {
-    // A failed cleanup should not turn continuity into a route failure.
-  }
+  clearStoredSpacePublicSnapshot(storage);
   return null;
 }
 

--- a/tests/e2e/space-public-snapshot.spec.ts
+++ b/tests/e2e/space-public-snapshot.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+import type { Item } from '../../app/lib/item-types';
+import {
+  SPACE_PUBLIC_SNAPSHOT_KEY,
+  createSpacePublicSnapshot,
+  serializeSpacePublicSnapshot,
+} from '../../lib/space-public-snapshot';
+
+const cachedTitle = 'Cached continuity sentinel';
+
+function cachedItem(): Item {
+  return {
+    id: '00000000-0000-4000-8000-000000000553',
+    title: cachedTitle,
+    slug: 'cached-continuity-sentinel',
+    url: null,
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'notes',
+        content: 'A public snapshot used to verify stale-readable Space.',
+        contentHtml:
+          '<p>A public snapshot used to verify stale-readable Space.</p>',
+        code: null,
+        codeHtml: '',
+      },
+    ],
+    tags: ['topic:continuity', 'source:test'],
+    category: 'notes',
+    createdAt: Date.parse('2026-08-10T00:00:00.000Z'),
+    updatedAt: Date.parse('2026-08-10T00:00:00.000Z'),
+  };
+}
+
+test('uses a recent public snapshot only when the server returned no usable archive', async ({
+  page,
+}) => {
+  let response = await page.goto('/space');
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole('heading', { name: 'Space' })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const hadInitialError = await page.getByRole('alert').isVisible().catch(() => false);
+  const hadLiveReadingRows =
+    (await page.locator('a[href^="/space/read/"]').count()) > 0;
+  const serverReturnedFailedEmptyArchive = hadInitialError && !hadLiveReadingRows;
+
+  const raw = serializeSpacePublicSnapshot(
+    createSpacePublicSnapshot([cachedItem()], {
+      savedAt: Date.now(),
+      hasMore: false,
+    })
+  );
+  await page.evaluate(
+    ({ key, value }) => window.localStorage.setItem(key, value),
+    { key: SPACE_PUBLIC_SNAPSHOT_KEY, value: raw }
+  );
+
+  response = await page.reload();
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole('heading', { name: 'Space' })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  if (serverReturnedFailedEmptyArchive) {
+    await expect(page.getByRole('link', { name: cachedTitle })).toBeVisible({
+      timeout: 5_000,
+    });
+  } else {
+    await expect(page.getByRole('link', { name: cachedTitle })).toHaveCount(0);
+  }
+});


### PR DESCRIPTION
## Why

PR #577 landed the fail-closed browser-storage contracts for Space continuity without changing runtime behavior. This is the first runtime slice from #553: admit the saved public first page only when the server explicitly failed and supplied zero usable public items, then immediately revalidate through the existing reload path.

## Change

- after a successful server-provided first page, write the bounded public projection to localStorage;
- when the server returns zero items with an archive error, admit a valid recent public snapshot after hydration;
- immediately call the existing `reload()` path in the background after cache admission;
- successful revalidation replaces cached items and refreshes the snapshot;
- refresh failure preserves the visible cached list and uses the existing bounded error state;
- a successful live empty archive clears any older snapshot so removed material cannot reappear during a later outage;
- keep `loadMore()` out of snapshot persistence in this first slice;
- keep authenticated review rows out of browser storage through the #577 public projection contract.

## Browser contract

The focused Chromium test seeds one valid public snapshot, reloads Space, and adapts to the environment:

- hosted CI's failed/empty dummy archive must show the cached sentinel item;
- a usable live archive must keep the same seeded cached sentinel subordinate and invisible.

This proves fallback admission and server precedence without adding a fake Space data pipeline.

## Boundary

No cache/server row merging, service worker, offline mutation, review-state cache, canonical URL change, scroll/history restoration, or database/auth change. Browser storage remains a bounded public readability fallback only.

Part of #553.