### PR TITLE
Use canonical Space browse URLs in shared route helpers

### DIFF
--- a/lib/space-routes.test.ts
+++ b/lib/space-routes.test.ts
@@ -29,16 +29,16 @@ describe('reviewItemHref', () => {
     );
   });
 
-  it('preserves a real tag query without serializing an absent value', () => {
-    expect(reviewItemHref('item/id', ' topic:security ', ' fieldwork ')).toBe(
-      '/space/review?item=item%2Fid&tags=topic%3Asecurity&lane=fieldwork'
+  it('uses canonical lane, tags, item ordering and encoding', () => {
+    expect(reviewItemHref(' item/id ', ' topic:security ', ' fieldwork ')).toBe(
+      '/space/review?lane=fieldwork&tags=topic%3Asecurity&item=item%2Fid'
     );
     expect(() => reviewItemHref('   ')).toThrow('Review item id is required');
   });
 });
 
 describe('readItemHref', () => {
-  it('uses the public slug and keeps the originating Space view', () => {
+  it('uses the public slug and canonical originating Space context', () => {
     expect(
       readItemHref(
         'cache-files-are-published-atomically',
@@ -46,11 +46,14 @@ describe('readItemHref', () => {
         ' fieldwork '
       )
     ).toBe(
-      '/space/read/cache-files-are-published-atomically?tags=domain%3Areliability&lane=fieldwork'
+      '/space/read/cache-files-are-published-atomically?lane=fieldwork&tags=domain%3Areliability'
     );
   });
 
-  it('does not add an empty query string', () => {
+  it('encodes slugs and does not add an empty query string', () => {
+    expect(readItemHref(' concept / one ')).toBe(
+      '/space/read/concept%20%2F%20one'
+    );
     expect(readItemHref('a-living-lesson')).toBe('/space/read/a-living-lesson');
     expect(() => readItemHref('   ')).toThrow('Reading sheet slug is required');
   });

--- a/lib/space-routes.ts
+++ b/lib/space-routes.ts
@@ -1,3 +1,8 @@
+import {
+  createSpaceBrowseHref,
+  createSpaceBrowseParams,
+} from './space-browse-state';
+
 export function duplicateItemHref(itemId: string) {
   const normalizedId = itemId.trim();
   if (!normalizedId) throw new Error('Duplicate source item id is required');
@@ -10,20 +15,18 @@ export function reviewItemHref(itemId: string, tags?: string, lane?: string) {
   const normalizedId = itemId.trim();
   if (!normalizedId) throw new Error('Review item id is required');
 
-  const query = new URLSearchParams({ item: normalizedId });
-  if (tags?.trim()) query.set('tags', tags.trim());
-  if (lane?.trim()) query.set('lane', lane.trim());
-  return `/space/review?${query.toString()}`;
+  return createSpaceBrowseHref('/space/review', {
+    lane,
+    tags,
+    item: normalizedId,
+  });
 }
 
 export function readItemHref(slug: string, tags?: string, lane?: string) {
   const normalizedSlug = slug.trim();
   if (!normalizedSlug) throw new Error('Reading sheet slug is required');
 
-  const query = new URLSearchParams();
-  if (tags?.trim()) query.set('tags', tags.trim());
-  if (lane?.trim()) query.set('lane', lane.trim());
-
-  const suffix = query.size ? `?${query.toString()}` : '';
+  const query = createSpaceBrowseParams({ lane, tags }).toString();
+  const suffix = query ? `?${query}` : '';
   return `/space/read/${encodeURIComponent(normalizedSlug)}${suffix}`;
 }


### PR DESCRIPTION
## Why

PR #577 introduced one canonical encoder for Space browse state so route URLs and future history view keys share the same lane/tags/item ordering and escaping rules. `lib/space-routes.ts` still hand-built review and reading-sheet query strings with their own ordering.

## Change

- route `reviewItemHref()` through `createSpaceBrowseHref()`;
- route reading-sheet lane/tag context through `createSpaceBrowseParams()`;
- keep duplicate-item routing separate because `duplicate` is a workbench action rather than browse state;
- update the existing route-helper tests to pin canonical `lane → tags → item` ordering, trimming, and slug/query escaping.

## Boundary

Pure URL serialization refactor. No route destination, navigation method, browser history write, data load, cache, auth, or UI behavior changes beyond deterministic query parameter order.

Part of #553.