### PR TITLE
Restore exact Space list state through browser Back

### DIFF
--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -5,7 +5,7 @@ import { Rating } from 'ts-fsrs';
 import type { Item } from '@/app/lib/item-types';
 import { readItemHref } from '@/lib/space-routes';
 import { formatInterval, formatDueRelative } from '@/app/lib/interval-format';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { MarkdownContent } from './markdown-content';
 import { useSearchParams } from 'next/navigation';
 import { CodeDisplay } from './code-display';
@@ -63,15 +63,18 @@ export function ResultsClient({
     setExpandedIds(expansionRecord(initialExpandedIds));
   }, [initialExpandedIds]);
 
-  const updateExpandedIds = (
-    updater: (previous: Record<string, boolean>) => Record<string, boolean>
-  ) => {
-    setExpandedIds(previous => {
-      const next = updater(previous);
-      onExpandedIdsChange?.(expandedIdsFromRecord(next));
-      return next;
-    });
-  };
+  const updateExpandedIds = useCallback(
+    (
+      updater: (previous: Record<string, boolean>) => Record<string, boolean>
+    ) => {
+      setExpandedIds(previous => {
+        const next = updater(previous);
+        onExpandedIdsChange?.(expandedIdsFromRecord(next));
+        return next;
+      });
+    },
+    [onExpandedIdsChange]
+  );
 
   const toggleHoveredShortcut = useMemo(
     () => ({
@@ -85,7 +88,7 @@ export function ResultsClient({
         }));
       },
     }),
-    [hoveredId]
+    [hoveredId, updateExpandedIds]
   );
   useSpaceShortcut('list.toggle-hovered', toggleHoveredShortcut);
 

--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -18,6 +18,8 @@ import {
 } from '@/components/cozy-flourishes';
 import { displaySpaceTags } from '@/lib/space-tags';
 
+const EMPTY_EXPANDED_IDS: readonly string[] = [];
+
 function expansionRecord(ids: readonly string[]) {
   return Object.fromEntries(ids.map(id => [id, true])) as Record<
     string,
@@ -38,7 +40,7 @@ export function ResultsClient({
   nowMs,
   isAdmin,
   lane,
-  initialExpandedIds = [],
+  initialExpandedIds = EMPTY_EXPANDED_IDS,
   onExpandedIdsChange,
   emptyTitle = 'No items',
   emptyDescription = 'No published items match this view.',
@@ -63,17 +65,17 @@ export function ResultsClient({
     setExpandedIds(expansionRecord(initialExpandedIds));
   }, [initialExpandedIds]);
 
+  useEffect(() => {
+    onExpandedIdsChange?.(expandedIdsFromRecord(expandedIds));
+  }, [expandedIds, onExpandedIdsChange]);
+
   const updateExpandedIds = useCallback(
     (
       updater: (previous: Record<string, boolean>) => Record<string, boolean>
     ) => {
-      setExpandedIds(previous => {
-        const next = updater(previous);
-        onExpandedIdsChange?.(expandedIdsFromRecord(next));
-        return next;
-      });
+      setExpandedIds(updater);
     },
-    [onExpandedIdsChange]
+    []
   );
 
   const toggleHoveredShortcut = useMemo(
@@ -193,6 +195,7 @@ function Row({
       <div
         className="cursor-pointer px-4 py-3.5 pl-5 transition-colors hover:bg-white/20 dark:hover:bg-black/5"
         onClick={onToggle}
+        data-space-list-toggle
       >
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">

--- a/components/space/space-results-client.tsx
+++ b/components/space/space-results-client.tsx
@@ -5,7 +5,7 @@ import { Rating } from 'ts-fsrs';
 import type { Item } from '@/app/lib/item-types';
 import { readItemHref } from '@/lib/space-routes';
 import { formatInterval, formatDueRelative } from '@/app/lib/interval-format';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { MarkdownContent } from './markdown-content';
 import { useSearchParams } from 'next/navigation';
 import { CodeDisplay } from './code-display';
@@ -18,6 +18,19 @@ import {
 } from '@/components/cozy-flourishes';
 import { displaySpaceTags } from '@/lib/space-tags';
 
+function expansionRecord(ids: readonly string[]) {
+  return Object.fromEntries(ids.map(id => [id, true])) as Record<
+    string,
+    boolean
+  >;
+}
+
+function expandedIdsFromRecord(record: Record<string, boolean>) {
+  return Object.entries(record)
+    .filter(([, expanded]) => expanded)
+    .map(([id]) => id);
+}
+
 export function ResultsClient({
   items,
   onReview,
@@ -25,6 +38,8 @@ export function ResultsClient({
   nowMs,
   isAdmin,
   lane,
+  initialExpandedIds = [],
+  onExpandedIdsChange,
   emptyTitle = 'No items',
   emptyDescription = 'No published items match this view.',
 }: {
@@ -34,11 +49,29 @@ export function ResultsClient({
   nowMs: number;
   isAdmin: boolean;
   lane?: string;
+  initialExpandedIds?: readonly string[];
+  onExpandedIdsChange?: (ids: string[]) => void;
   emptyTitle?: string;
   emptyDescription?: string;
 }) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
-  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
+  const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>(() =>
+    expansionRecord(initialExpandedIds)
+  );
+
+  useEffect(() => {
+    setExpandedIds(expansionRecord(initialExpandedIds));
+  }, [initialExpandedIds]);
+
+  const updateExpandedIds = (
+    updater: (previous: Record<string, boolean>) => Record<string, boolean>
+  ) => {
+    setExpandedIds(previous => {
+      const next = updater(previous);
+      onExpandedIdsChange?.(expandedIdsFromRecord(next));
+      return next;
+    });
+  };
 
   const toggleHoveredShortcut = useMemo(
     () => ({
@@ -46,7 +79,7 @@ export function ResultsClient({
       disabledReason: hoveredId ? undefined : 'Hover an item first',
       run: () => {
         if (!hoveredId) return;
-        setExpandedIds(previous => ({
+        updateExpandedIds(previous => ({
           ...previous,
           [hoveredId]: !previous[hoveredId],
         }));
@@ -81,7 +114,7 @@ export function ResultsClient({
       {items.map(item => {
         const expanded = Boolean(expandedIds[item.id]);
         const onToggle = () =>
-          setExpandedIds(previous => ({
+          updateExpandedIds(previous => ({
             ...previous,
             [item.id]: !previous[item.id],
           }));
@@ -142,6 +175,8 @@ function Row({
       className="material-paper group relative overflow-hidden rounded-xl border transition-[transform,box-shadow,border-color] duration-150 hover:-rotate-[0.08deg] hover:border-[hsl(var(--material-paper-edge))] hover:shadow-[0_12px_26px_rgba(45,40,32,0.13)]"
       onMouseEnter={() => onHoverChange(true)}
       onMouseLeave={() => onHoverChange(false)}
+      data-space-list-item={item.id}
+      data-expanded={expanded ? 'true' : 'false'}
     >
       <span
         aria-hidden="true"

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -55,6 +55,7 @@ export function SpaceView() {
     nowMs: initialNowMs,
     editorOpen,
     setEditorOpen,
+    loading,
     hasMore,
     loadMore,
     loadingMore,
@@ -72,6 +73,7 @@ export function SpaceView() {
   const scrollRef = useRef<HTMLElement>(null);
   const expandedIdsRef = useRef<string[]>([]);
   const restoredViewKeyRef = useRef<string | null>(null);
+  const restoringViewKeyRef = useRef<string | null>(null);
   const scrollFrameRef = useRef<number | null>(null);
 
   const historyViewKey = useMemo(
@@ -82,28 +84,6 @@ export function SpaceView() {
       }),
     [activeLane, tagsParam]
   );
-
-  useLayoutEffect(() => {
-    restoredViewKeyRef.current = null;
-    const snapshot = readSpaceHistoryUiState(
-      window.history.state,
-      historyViewKey
-    );
-    const nextExpandedIds = snapshot?.expandedIds ?? [];
-
-    expandedIdsRef.current = nextExpandedIds;
-    setRestoredExpandedIds(nextExpandedIds);
-    setPage(snapshot?.page ?? 1);
-
-    const frame = window.requestAnimationFrame(() => {
-      if (scrollRef.current) {
-        scrollRef.current.scrollTop = snapshot?.scrollTop ?? 0;
-      }
-      restoredViewKeyRef.current = historyViewKey;
-    });
-
-    return () => window.cancelAnimationFrame(frame);
-  }, [historyViewKey]);
 
   const itemsWithMutations = useMemo<Item[]>(() => {
     return allItems.map(item => {
@@ -124,9 +104,42 @@ export function SpaceView() {
 
   const totalPages = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
 
+  useLayoutEffect(() => {
+    if (loading) return;
+    if (restoredViewKeyRef.current === historyViewKey) return;
+    if (restoringViewKeyRef.current === historyViewKey) return;
+
+    restoringViewKeyRef.current = historyViewKey;
+    const snapshot = readSpaceHistoryUiState(
+      window.history.state,
+      historyViewKey
+    );
+    const nextExpandedIds = snapshot?.expandedIds ?? [];
+
+    expandedIdsRef.current = nextExpandedIds;
+    setRestoredExpandedIds(nextExpandedIds);
+    setPage(Math.min(snapshot?.page ?? 1, totalPages));
+
+    const frame = window.requestAnimationFrame(() => {
+      if (scrollRef.current) {
+        scrollRef.current.scrollTop = snapshot?.scrollTop ?? 0;
+      }
+      restoredViewKeyRef.current = historyViewKey;
+      restoringViewKeyRef.current = null;
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      if (restoringViewKeyRef.current === historyViewKey) {
+        restoringViewKeyRef.current = null;
+      }
+    };
+  }, [historyViewKey, loading, totalPages]);
+
   useEffect(() => {
+    if (loading) return;
     if (page > totalPages) setPage(totalPages);
-  }, [page, totalPages]);
+  }, [loading, page, totalPages]);
 
   const paginatedItems = useMemo(() => {
     const start = (page - 1) * ITEMS_PER_PAGE;
@@ -411,7 +424,10 @@ export function SpaceView() {
               >
                 Previous
               </Button>
-              <span className="rounded-full border border-border/60 bg-background/65 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground">
+              <span
+                data-space-page-indicator
+                className="rounded-full border border-border/60 bg-background/65 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.1em] text-muted-foreground"
+              >
                 {page} of {totalPages}
               </span>
               <Button

--- a/components/space/space-view.tsx
+++ b/components/space/space-view.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { parseQuery } from '@/app/lib/searchlang';
@@ -19,6 +26,12 @@ import {
 } from '@/app/space/actions';
 import { SpaceHeader } from './space-header';
 import { Button } from '@/components/ui/button';
+import { createSpaceBrowseViewKey } from '@/lib/space-browse-state';
+import {
+  createSpaceHistoryUiSnapshot,
+  mergeSpaceHistoryUiState,
+  readSpaceHistoryUiState,
+} from '@/lib/space-history-ui';
 import {
   countItemsBySpaceLane,
   filterItemsBySpaceLane,
@@ -55,13 +68,42 @@ export function SpaceView() {
   const [mutations, setMutations] = useState<Record<string, ReviewState>>({});
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
+  const [restoredExpandedIds, setRestoredExpandedIds] = useState<string[]>([]);
+  const scrollRef = useRef<HTMLElement>(null);
+  const expandedIdsRef = useRef<string[]>([]);
+  const restoredViewKeyRef = useRef<string | null>(null);
+  const scrollFrameRef = useRef<number | null>(null);
 
-  const viewKey = `${activeLane}:${tagsParam ?? ''}`;
-  const [previousViewKey, setPreviousViewKey] = useState(viewKey);
-  if (previousViewKey !== viewKey) {
-    setPreviousViewKey(viewKey);
-    setPage(1);
-  }
+  const historyViewKey = useMemo(
+    () =>
+      createSpaceBrowseViewKey('list', {
+        lane: activeLane,
+        tags: tagsParam,
+      }),
+    [activeLane, tagsParam]
+  );
+
+  useLayoutEffect(() => {
+    restoredViewKeyRef.current = null;
+    const snapshot = readSpaceHistoryUiState(
+      window.history.state,
+      historyViewKey
+    );
+    const nextExpandedIds = snapshot?.expandedIds ?? [];
+
+    expandedIdsRef.current = nextExpandedIds;
+    setRestoredExpandedIds(nextExpandedIds);
+    setPage(snapshot?.page ?? 1);
+
+    const frame = window.requestAnimationFrame(() => {
+      if (scrollRef.current) {
+        scrollRef.current.scrollTop = snapshot?.scrollTop ?? 0;
+      }
+      restoredViewKeyRef.current = historyViewKey;
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [historyViewKey]);
 
   const itemsWithMutations = useMemo<Item[]>(() => {
     return allItems.map(item => {
@@ -80,12 +122,17 @@ export function SpaceView() {
     return searchItems(laneItems, query, nowMs);
   }, [activeLane, itemsWithMutations, query, nowMs]);
 
+  const totalPages = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
+
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
   const paginatedItems = useMemo(() => {
     const start = (page - 1) * ITEMS_PER_PAGE;
     return items.slice(start, start + ITEMS_PER_PAGE);
   }, [items, page]);
 
-  const totalPages = Math.max(1, Math.ceil(items.length / ITEMS_PER_PAGE));
   const itemCount = `${items.length}${hasMore ? '+' : ''}`;
   const headerStatus = tagsParam
     ? `${itemCount} · ${tagsParam}`
@@ -106,6 +153,56 @@ export function SpaceView() {
       void loadMore();
     }
   }, [hasMore, items.length, loadMore, loadingMore, page, totalPages]);
+
+  const persistHistoryState = useCallback(
+    (expandedIds = expandedIdsRef.current) => {
+      if (restoredViewKeyRef.current !== historyViewKey) return;
+
+      const snapshot = createSpaceHistoryUiSnapshot({
+        viewKey: historyViewKey,
+        page,
+        scrollTop: scrollRef.current?.scrollTop ?? 0,
+        expandedIds,
+      });
+      window.history.replaceState(
+        mergeSpaceHistoryUiState(window.history.state, snapshot),
+        '',
+        window.location.href
+      );
+    },
+    [historyViewKey, page]
+  );
+
+  useEffect(() => {
+    persistHistoryState();
+  }, [page, persistHistoryState]);
+
+  useEffect(
+    () => () => {
+      if (scrollFrameRef.current !== null) {
+        window.cancelAnimationFrame(scrollFrameRef.current);
+      }
+    },
+    []
+  );
+
+  const onScroll = useCallback(() => {
+    if (restoredViewKeyRef.current !== historyViewKey) return;
+    if (scrollFrameRef.current !== null) return;
+
+    scrollFrameRef.current = window.requestAnimationFrame(() => {
+      scrollFrameRef.current = null;
+      persistHistoryState();
+    });
+  }, [historyViewKey, persistHistoryState]);
+
+  const onExpandedIdsChange = useCallback(
+    (expandedIds: string[]) => {
+      expandedIdsRef.current = expandedIds;
+      persistHistoryState(expandedIds);
+    },
+    [persistHistoryState]
+  );
 
   const onEnroll = useCallback(async (id: string) => {
     const initialReview: ReviewState = {
@@ -170,7 +267,12 @@ export function SpaceView() {
         onEditorToggle={() => setEditorOpen(!editorOpen)}
         isEditorOpen={editorOpen}
       />
-      <main className="relative min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:p-5">
+      <main
+        ref={scrollRef}
+        onScroll={onScroll}
+        data-space-list-scroll
+        className="relative min-h-0 flex-1 overflow-y-auto px-3 py-4 sm:p-5"
+      >
         <div
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 opacity-45 dark:opacity-20"
@@ -269,12 +371,15 @@ export function SpaceView() {
           ) : null}
 
           <ResultsClient
+            key={historyViewKey}
             items={paginatedItems}
             onReview={onReview}
             onEnroll={onEnroll}
             nowMs={nowMs}
             isAdmin={isAdmin}
             lane={activeLane}
+            initialExpandedIds={restoredExpandedIds}
+            onExpandedIdsChange={onExpandedIdsChange}
             emptyTitle={
               loadingMore
                 ? `Loading ${activeLaneDefinition.label}…`

--- a/docs/space-continuity.md
+++ b/docs/space-continuity.md
@@ -1,18 +1,18 @@
 # Space continuity contracts
 
-Space should feel immediate on ordinary return navigation without making browser storage a second database. The continuity layer therefore separates three short-lived concerns and leaves durable learning/review state elsewhere.
+Space should feel immediate on ordinary return navigation without making browser storage a second database. The continuity layer separates three short-lived concerns and leaves durable learning/review state elsewhere.
 
 ## 1. Canonical browse URL state
 
-`lib/space-browse-state.ts` owns the stable serialization for the ordinary list/reader state:
+`lib/space-browse-state.ts` owns the stable serialization for ordinary list/reader state:
 
 - `lane`;
 - `tags`;
 - `item`.
 
-The parameter order is always `lane`, `tags`, `item`. Empty values disappear. The same serialization produces the per-view `viewKey` used by ephemeral history restoration.
+The parameter order is always `lane`, `tags`, `item`. Empty values disappear. The same serialization produces the per-view `viewKey` used by ephemeral history restoration. Shared review and reading-sheet route helpers consume this serializer; remaining component-local URL assembly should migrate onto it rather than inventing another ordering convention.
 
-Reading-sheet and Trail-specific parameters remain outside this first codec until their current route helpers are migrated deliberately; do not duplicate `from`, `return`, `practice`, or `stage` in a second half-migrated helper.
+Reading-sheet and Trail-specific parameters remain outside this first codec until their current route helpers are migrated deliberately. Keep `from`, `return`, `practice`, and `stage` in their existing owner until one complete migration is ready.
 
 ## 2. Bounded public archive snapshot
 
@@ -21,48 +21,56 @@ Reading-sheet and Trail-specific parameters remain outside this first codec unti
 Rules:
 
 - versioned key: `scrapbook:space-public-snapshot:v1`;
+- explicit public field allowlists at snapshot, item, and version boundaries;
 - maximum 100 items, matching the current first public page;
+- maximum serialized size 2 MiB UTF-8 before parse/write;
 - maximum age 24 hours;
 - tolerate at most five minutes of forward clock skew;
-- strip `review` and `userId` before serialization;
-- reject cached payloads that contain those fields;
-- restore cached items with `review: null` and `userId: null`;
-- do not write empty snapshots;
-- treat localStorage read/write/quota/security failures as cache misses;
-- remove invalid/stale payloads when storage permits.
+- exclude `review`, `userId`, and future non-allowlisted fields from serialization;
+- reject unknown/private stored fields rather than inheriting future `Item` fields automatically;
+- restore cached public items with private fields absent;
+- treat localStorage read/write/quota/security failures as ordinary cache misses;
+- remove invalid, stale, or over-budget payloads when storage permits.
 
-### Admission sequence
+### Current runtime admission sequence
 
-The eventual `ItemsProvider` integration should stay one-way and conservative:
+`ItemsProvider` now uses the snapshot as a stale-readable outage fallback:
 
-1. Start with the server-provided public items exactly as today.
-2. After hydration, if the server supplied usable public items, keep them and write/update the bounded public snapshot.
-3. If the server supplied no usable public items and a valid cached public snapshot exists, admit the cached items immediately and mark the visible state as stale/cached.
-4. Revalidate through the existing `reload()` path; a successful public response replaces the cache-backed list and refreshes the snapshot.
-5. A refresh failure preserves the admitted list and surfaces the existing bounded error state.
-6. Private/admin review rows continue through their existing authenticated path and never enter the public snapshot.
+1. Start with the server-provided public items.
+2. A successful non-empty first page wins and refreshes the bounded public snapshot.
+3. A successful live empty archive clears any older snapshot so removed material cannot reappear during a later outage.
+4. If the server explicitly failed and supplied zero usable public items, admit a valid recent snapshot after hydration.
+5. Revalidate an admitted snapshot immediately through the existing `reload()` path.
+6. A successful revalidation replaces the cache-backed list and refreshes the snapshot; a refresh failure preserves the visible list and bounded error UI.
+7. Private/admin review rows continue through their authenticated path and never enter browser storage.
 
-Do not merge cached public items with a partial server response in this first slice. Either the server supplied a usable current public page or the cache is a temporary fallback.
+Do not merge cached public items with a partial server response. Either the server supplied a usable current public page or the cache is a temporary fallback. Warm successful navigation that renders cached public data before the server completes remains a separate #553/#333 follow-up.
 
-## 3. Same-entry UI history
+## 3. Same-entry list UI history
 
-`lib/space-history-ui.ts` owns ephemeral Back/Forward state that cannot be reconstructed from the URL:
+`lib/space-history-ui.ts` owns ephemeral Back/Forward state that cannot be reconstructed from the URL. Version 2 stores:
 
+- the current 20-item list page;
 - scroll position;
 - expanded row IDs.
 
 Rules:
 
 - namespace under `__scrapbookSpaceUi` while preserving Next/router-owned history fields;
-- bind every snapshot to the exact canonical `viewKey`;
-- cap expanded IDs at 24 and deduplicate them;
-- clamp scroll positions to a finite non-negative bound;
-- reject wrong-version, cross-view, malformed, oversized, or out-of-range payloads;
+- bind every snapshot to the exact canonical list `viewKey`;
+- page is bounded to a finite positive range;
+- expanded IDs are deduplicated and capped at 24;
+- scroll position is clamped to a finite non-negative bound;
+- reject legacy/wrong-version, cross-view, malformed, oversized, or out-of-range payloads;
 - never store review schedules, reactions, practice answers, learned state, or other durable learning data here.
+
+`SpaceView` owns list restoration because it already owns pagination and the scroll container. `ResultsClient` keeps the expansion map local and reports only the bounded expanded IDs upward. Restoration waits until live/cached Space data is ready so an empty hydration frame cannot clamp a retained page or consume a scroll snapshot against zero-height content.
 
 ## Browser-history ownership
 
-Use ordinary canonical URLs for durable navigation identity. Use same-entry `history.state` only for ephemeral presentation restoration. Temporary modal state may use its own explicit same-document marker when that marker has independent Back/Forward semantics; it should disappear on close and must not become a durable learning identifier.
+Use ordinary canonical URLs for durable navigation identity. Use same-entry `history.state` only for ephemeral presentation restoration on the current canonical entry. The mobile editor remains history-neutral; its dismiss/reopen continuity comes from retaining one Monaco instance, while navigation Back/Forward belongs to the Space continuity lane.
+
+Incidental hover, viewport observation, editor draft text, review state, and other high-frequency/private state do not receive history entries.
 
 ## Measurement
 
@@ -72,6 +80,6 @@ Evaluate continuity as separate journeys rather than one synthetic timing number
 - cold load with server archive failure + valid cached public snapshot;
 - warm in-app list ↔ reader return;
 - reading sheet ↔ prior list/Trail return;
-- Back/Forward restoration of filter, target, scroll, and expanded rows.
+- Back/Forward restoration of filter, list page, scroll, and expanded rows.
 
-Record the exact route, data condition, viewport, and cache state with each measurement. The useful result is immediate usable content and restored context, not merely a lower aggregate load number.
+Record the exact route, data condition, viewport, and cache state with each measurement. The useful result is immediate usable content and restored context, rather than only a lower aggregate load number.

--- a/docs/space-continuity.md
+++ b/docs/space-continuity.md
@@ -66,6 +66,8 @@ Rules:
 
 `SpaceView` owns list restoration because it already owns pagination and the scroll container. `ResultsClient` keeps the expansion map local and reports only the bounded expanded IDs upward. Restoration waits until live/cached Space data is ready so an empty hydration frame cannot clamp a retained page or consume a scroll snapshot against zero-height content.
 
+The focused browser regression seeds 25 deterministic public fallback rows, moves to list page 2, expands one row, scrolls the actual Space list container, and verifies those values are present on the current history entry before navigating to Trail. Browser Back must restore page 2, the same expanded row, and the recorded scroll position. When a usable live archive wins over the seeded fallback, that fixture-specific regression skips rather than overriding live data.
+
 ## Browser-history ownership
 
 Use ordinary canonical URLs for durable navigation identity. Use same-entry `history.state` only for ephemeral presentation restoration on the current canonical entry. The mobile editor remains history-neutral; its dismiss/reopen continuity comes from retaining one Monaco instance, while navigation Back/Forward belongs to the Space continuity lane.

--- a/lib/space-history-ui.test.ts
+++ b/lib/space-history-ui.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   SPACE_HISTORY_MAX_EXPANDED_IDS,
+  SPACE_HISTORY_MAX_PAGE,
   SPACE_HISTORY_MAX_SCROLL_PX,
   SPACE_HISTORY_UI_KEY,
+  SPACE_HISTORY_UI_VERSION,
   createSpaceHistoryUiSnapshot,
   mergeSpaceHistoryUiState,
   readSpaceHistoryUiState,
@@ -12,6 +14,7 @@ describe('Space history UI state', () => {
   it('preserves router-owned history fields while namespacing Space UI state', () => {
     const snapshot = createSpaceHistoryUiSnapshot({
       viewKey: 'list:open:',
+      page: 3,
       scrollTop: 412.4,
       expandedIds: ['item-1', 'item-2'],
     });
@@ -24,16 +27,19 @@ describe('Space history UI state', () => {
       __NA: true,
       tree: ['space'],
       [SPACE_HISTORY_UI_KEY]: {
+        version: SPACE_HISTORY_UI_VERSION,
         viewKey: 'list:open:',
+        page: 3,
         scrollTop: 412,
         expandedIds: ['item-1', 'item-2'],
       },
     });
   });
 
-  it('bounds scroll and deduplicates/caps expanded row IDs', () => {
+  it('bounds page, scroll, and deduplicates/caps expanded row IDs', () => {
     const snapshot = createSpaceHistoryUiSnapshot({
       viewKey: 'list:archive:tag',
+      page: Number.POSITIVE_INFINITY,
       scrollTop: Number.POSITIVE_INFINITY,
       expandedIds: [
         '',
@@ -46,6 +52,7 @@ describe('Space history UI state', () => {
       ],
     });
 
+    expect(snapshot.page).toBe(1);
     expect(snapshot.scrollTop).toBe(0);
     expect(snapshot.expandedIds).toHaveLength(SPACE_HISTORY_MAX_EXPANDED_IDS);
     expect(snapshot.expandedIds[0]).toBe('item-1');
@@ -53,8 +60,10 @@ describe('Space history UI state', () => {
 
     const clamped = createSpaceHistoryUiSnapshot({
       viewKey: 'list:open:',
+      page: SPACE_HISTORY_MAX_PAGE + 500,
       scrollTop: SPACE_HISTORY_MAX_SCROLL_PX + 500,
     });
+    expect(clamped.page).toBe(SPACE_HISTORY_MAX_PAGE);
     expect(clamped.scrollTop).toBe(SPACE_HISTORY_MAX_SCROLL_PX);
   });
 
@@ -63,25 +72,35 @@ describe('Space history UI state', () => {
       null,
       createSpaceHistoryUiSnapshot({
         viewKey: 'reader:open:tag',
+        page: 2,
         scrollTop: 88,
         expandedIds: ['item-3'],
       })
     );
 
     expect(readSpaceHistoryUiState(state, 'reader:open:tag')).toEqual({
-      version: 1,
+      version: SPACE_HISTORY_UI_VERSION,
       viewKey: 'reader:open:tag',
+      page: 2,
       scrollTop: 88,
       expandedIds: ['item-3'],
     });
     expect(readSpaceHistoryUiState(state, 'list:open:tag')).toBeNull();
   });
 
-  it('rejects malformed, oversized, wrong-version, and out-of-range payloads', () => {
+  it('rejects legacy, malformed, oversized, cross-view, and out-of-range payloads', () => {
     expect(readSpaceHistoryUiState(null, 'list:open:')).toBeNull();
     expect(
       readSpaceHistoryUiState(
-        { [SPACE_HISTORY_UI_KEY]: { version: 99 } },
+        {
+          [SPACE_HISTORY_UI_KEY]: {
+            version: 1,
+            viewKey: 'list:open:',
+            page: 1,
+            scrollTop: 0,
+            expandedIds: [],
+          },
+        },
         'list:open:'
       )
     ).toBeNull();
@@ -89,8 +108,9 @@ describe('Space history UI state', () => {
       readSpaceHistoryUiState(
         {
           [SPACE_HISTORY_UI_KEY]: {
-            version: 1,
+            version: SPACE_HISTORY_UI_VERSION,
             viewKey: 'list:open:',
+            page: 0,
             scrollTop: -1,
             expandedIds: [],
           },
@@ -102,8 +122,9 @@ describe('Space history UI state', () => {
       readSpaceHistoryUiState(
         {
           [SPACE_HISTORY_UI_KEY]: {
-            version: 1,
+            version: SPACE_HISTORY_UI_VERSION,
             viewKey: 'list:open:',
+            page: 1,
             scrollTop: 1,
             expandedIds: Array.from(
               { length: SPACE_HISTORY_MAX_EXPANDED_IDS + 1 },
@@ -112,6 +133,20 @@ describe('Space history UI state', () => {
           },
         },
         'list:open:'
+      )
+    ).toBeNull();
+    expect(
+      readSpaceHistoryUiState(
+        {
+          [SPACE_HISTORY_UI_KEY]: {
+            version: SPACE_HISTORY_UI_VERSION,
+            viewKey: 'list:open:',
+            page: 1,
+            scrollTop: 1,
+            expandedIds: [],
+          },
+        },
+        'list:archive:'
       )
     ).toBeNull();
   });

--- a/lib/space-history-ui.ts
+++ b/lib/space-history-ui.ts
@@ -1,11 +1,13 @@
 export const SPACE_HISTORY_UI_KEY = '__scrapbookSpaceUi';
-export const SPACE_HISTORY_UI_VERSION = 1;
+export const SPACE_HISTORY_UI_VERSION = 2;
 export const SPACE_HISTORY_MAX_EXPANDED_IDS = 24;
 export const SPACE_HISTORY_MAX_SCROLL_PX = 10_000_000;
+export const SPACE_HISTORY_MAX_PAGE = 10_000;
 
 export type SpaceHistoryUiSnapshot = {
   version: typeof SPACE_HISTORY_UI_VERSION;
   viewKey: string;
+  page: number;
   scrollTop: number;
   expandedIds: string[];
 };
@@ -17,6 +19,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function clampScrollTop(value: number) {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(Math.round(value), SPACE_HISTORY_MAX_SCROLL_PX));
+}
+
+function clampPage(value: number) {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(Math.round(value), SPACE_HISTORY_MAX_PAGE));
 }
 
 function normaliseExpandedIds(ids: readonly string[]) {
@@ -36,12 +43,14 @@ function normaliseExpandedIds(ids: readonly string[]) {
 
 export function createSpaceHistoryUiSnapshot(options: {
   viewKey: string;
+  page?: number;
   scrollTop: number;
   expandedIds?: readonly string[];
 }): SpaceHistoryUiSnapshot {
   return {
     version: SPACE_HISTORY_UI_VERSION,
     viewKey: options.viewKey,
+    page: clampPage(options.page ?? 1),
     scrollTop: clampScrollTop(options.scrollTop),
     expandedIds: normaliseExpandedIds(options.expandedIds ?? []),
   };
@@ -70,6 +79,14 @@ export function readSpaceHistoryUiState(
     return null;
   }
   if (
+    typeof candidate.page !== 'number' ||
+    !Number.isInteger(candidate.page) ||
+    candidate.page < 1 ||
+    candidate.page > SPACE_HISTORY_MAX_PAGE
+  ) {
+    return null;
+  }
+  if (
     typeof candidate.scrollTop !== 'number' ||
     !Number.isFinite(candidate.scrollTop) ||
     candidate.scrollTop < 0 ||
@@ -90,6 +107,7 @@ export function readSpaceHistoryUiState(
   return {
     version: SPACE_HISTORY_UI_VERSION,
     viewKey: candidate.viewKey,
+    page: candidate.page,
     scrollTop: candidate.scrollTop,
     expandedIds: [...candidate.expandedIds],
   };

--- a/tests/e2e/space-list-history-resume.spec.ts
+++ b/tests/e2e/space-list-history-resume.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import type { Item } from '../../app/lib/item-types';
+import {
+  SPACE_PUBLIC_SNAPSHOT_KEY,
+  createSpacePublicSnapshot,
+  serializeSpacePublicSnapshot,
+} from '../../lib/space-public-snapshot';
+
+const RESTORED_ITEM_ID = 'resume-item-21';
+
+function cachedItem(index: number): Item {
+  const id = `resume-item-${String(index).padStart(2, '0')}`;
+  const longParagraph = `Continuity detail ${index}. ${'Return to the same reading place. '.repeat(
+    180
+  )}`;
+
+  return {
+    id,
+    title: `Resume item ${String(index).padStart(2, '0')}`,
+    slug: id,
+    url: null,
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'notes',
+        content: longParagraph,
+        contentHtml: `<p>${longParagraph}</p>`,
+        code: null,
+        codeHtml: '',
+      },
+    ],
+    tags: ['topic:continuity', 'source:test'],
+    category: 'notes',
+    createdAt: Date.parse('2026-08-10T00:00:00.000Z') + index,
+    updatedAt: Date.parse('2026-08-10T00:00:00.000Z') + index,
+  };
+}
+
+test('browser Back restores Space list page, expansion, and scroll for the same view', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const raw = serializeSpacePublicSnapshot(
+    createSpacePublicSnapshot(
+      Array.from({ length: 25 }, (_, index) => cachedItem(index + 1)),
+      {
+        savedAt: Date.now(),
+        hasMore: false,
+      }
+    )
+  );
+
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, value),
+    { key: SPACE_PUBLIC_SNAPSHOT_KEY, value: raw }
+  );
+
+  const response = await page.goto('/space');
+  expect(response?.ok()).toBe(true);
+  await expect(page.getByRole('heading', { name: 'Space' })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const cachedSentinel = page.getByRole('link', { name: 'Resume item 01' });
+  const cacheWasAdmitted = await cachedSentinel
+    .isVisible({ timeout: 5_000 })
+    .catch(() => false);
+  test.skip(
+    !cacheWasAdmitted,
+    'This regression uses the failed/empty hosted archive so the saved public snapshot supplies deterministic rows.'
+  );
+
+  const pageIndicator = page.locator('[data-space-page-indicator]');
+  await expect(pageIndicator).toHaveText('1 of 2');
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(pageIndicator).toHaveText('2 of 2');
+
+  const restoredRow = page.locator(
+    `[data-space-list-item="${RESTORED_ITEM_ID}"]`
+  );
+  await expect(restoredRow).toBeVisible();
+  await restoredRow.locator('[data-space-list-toggle]').click();
+  await expect(restoredRow).toHaveAttribute('data-expanded', 'true');
+
+  const scroll = page.locator('[data-space-list-scroll]');
+  const savedScrollTop = await scroll.evaluate(element => {
+    const maximum = element.scrollHeight - element.clientHeight;
+    element.scrollTop = Math.min(260, maximum);
+    element.dispatchEvent(new Event('scroll'));
+    return element.scrollTop;
+  });
+  expect(savedScrollTop).toBeGreaterThan(0);
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        ({ itemId, expectedScrollTop }) => {
+          const snapshot = history.state?.__scrapbookSpaceUi;
+          return {
+            page: snapshot?.page,
+            expanded: snapshot?.expandedIds?.includes(itemId) ?? false,
+            scrollDelta:
+              typeof snapshot?.scrollTop === 'number'
+                ? Math.abs(snapshot.scrollTop - expectedScrollTop)
+                : Number.POSITIVE_INFINITY,
+          };
+        },
+        { itemId: RESTORED_ITEM_ID, expectedScrollTop: savedScrollTop }
+      )
+    )
+    .toEqual({ page: 2, expanded: true, scrollDelta: 0 });
+
+  await page.getByRole('link', { name: 'Open reading trail' }).click();
+  await expect(page).toHaveURL(/\/space\/trail/);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/\/space$/);
+  await expect(pageIndicator).toHaveText('2 of 2');
+  await expect(restoredRow).toHaveAttribute('data-expanded', 'true');
+  await expect
+    .poll(() =>
+      scroll.evaluate((element, expected) =>
+        Math.abs(element.scrollTop - Number(expected))
+      , savedScrollTop)
+    )
+    .toBeLessThanOrEqual(2);
+});


### PR DESCRIPTION
## Why

#553 calls for returning to the exact prior Space context instead of resetting to the first list page or collapsed rows. The continuity contracts are already on main; this slice wires them into the ordinary list view only.

## Change

- version the ephemeral `__scrapbookSpaceUi` payload to v2 and include the current 20-item list page alongside scroll position and expanded row IDs;
- keep Next/router-owned history fields intact while replacing only the namespaced Space UI payload on the current entry;
- key restoration by the canonical list `viewKey` derived from lane + filter state;
- restore only after live/cached Space data is ready so an empty hydration frame cannot clamp page 2 back to page 1 or consume scroll against zero-height content;
- throttle scroll persistence to one animation frame;
- persist page and expansion changes immediately without creating extra history entries;
- keep expansion state local to `ResultsClient`, reporting only expanded IDs upward;
- keep state updaters pure and report expansion changes from an effect;
- keep Trail, reader-local state, review data, hover state, and editor state outside this list history payload.

## Browser contract

Hosted Chromium seeds a deterministic 25-item public snapshot, then:

1. opens Space and moves to page 2;
2. expands one row;
3. scrolls the actual Space list container;
4. verifies the current history entry contains page/expansion/scroll;
5. navigates to Trail;
6. uses browser Back;
7. verifies page 2, the expanded row, and exact scroll position return.

The test skips when a usable live archive wins over the seeded fallback, so it does not replace live data with a fake test pipeline.

## Verification

Exact head: `df8dabc3741939ecf50ca02fc9f97077d82e4764`.

Both jobs are green:

- lint;
- TypeScript typecheck;
- full unit suite, including v2 page/scroll/expansion history validation;
- production build;
- complete Chromium regression suite;
- exact list page/expanded-row/scroll Back round-trip;
- homepage visual-review artifact upload.

## Docs

Refresh `docs/space-continuity.md` to describe the already-landed public cache runtime accurately, record the v2 list-history payload and its browser regression, and keep mobile editor/navigation ownership boundaries explicit.

## Boundary

List presentation continuity only. No new URL parameter, new history entry, cache model, database/auth/review-state persistence, Trail history, reader history, or editor history behavior.

Part of #553 and directly advances #344.