### PR TITLE
Reuse the public Space first page across warm requests

### DIFF
--- a/app/lib/space-cache.ts
+++ b/app/lib/space-cache.ts
@@ -1,0 +1,1 @@
+export const SPACE_PUBLIC_ITEMS_CACHE_TAG = 'space-public-items';

--- a/app/space/actions.test.ts
+++ b/app/space/actions.test.ts
@@ -8,6 +8,7 @@ const {
   parseMarkdown,
   highlightCode,
   revalidatePath,
+  updateTag,
 } = vi.hoisted(() => ({
   createClient: vi.fn(),
   requireSpaceAdmin: vi.fn(),
@@ -15,13 +16,15 @@ const {
   parseMarkdown: vi.fn(),
   highlightCode: vi.fn(),
   revalidatePath: vi.fn(),
+  updateTag: vi.fn(),
 }));
 
-vi.mock('next/cache', () => ({ revalidatePath }));
+vi.mock('next/cache', () => ({ revalidatePath, updateTag }));
 vi.mock('@/utils/supabase/server', () => ({ createClient }));
 vi.mock('./authorization', () => ({ requireSpaceAdmin }));
 vi.mock('@/app/lib/utils/markdown', () => ({ parseMarkdown, highlightCode }));
 
+import { SPACE_PUBLIC_ITEMS_CACHE_TAG } from '@/app/lib/space-cache';
 import {
   addItemAction,
   enrollItemForReviewAction,
@@ -56,6 +59,7 @@ describe('Space server actions', () => {
       await expect(action()).rejects.toThrow('not allowed');
       expect(requireSpaceAdmin).toHaveBeenCalledOnce();
       expect(from).not.toHaveBeenCalled();
+      expect(updateTag).not.toHaveBeenCalled();
     }
   );
 
@@ -65,9 +69,10 @@ describe('Space server actions', () => {
     ).rejects.toThrow();
     await expect(reviewItemAction('not-an-id', Rating.Good)).rejects.toThrow();
     expect(createClient).not.toHaveBeenCalled();
+    expect(updateTag).not.toHaveBeenCalled();
   });
 
-  it('authorizes before parsing or inserting an item and confirms the inserted row', async () => {
+  it('authorizes before parsing or inserting an item and invalidates the public cache after success', async () => {
     const single = vi
       .fn()
       .mockResolvedValue({ data: { id: itemId }, error: null });
@@ -83,13 +88,14 @@ describe('Space server actions', () => {
     expect(insert).toHaveBeenCalledWith(
       expect.objectContaining({ user_id: 'admin-id' })
     );
+    expect(updateTag).toHaveBeenCalledWith(SPACE_PUBLIC_ITEMS_CACHE_TAG);
     expect(revalidatePath).toHaveBeenCalledWith('/space');
     expect(requireSpaceAdmin.mock.invocationCallOrder[0]).toBeLessThan(
       parseMarkdown.mock.invocationCallOrder[0]
     );
   });
 
-  it('does not report a successful update when RLS or a stale ID matches no row', async () => {
+  it('does not invalidate public cache when an item update matched no row', async () => {
     const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
     const select = vi.fn().mockReturnValue({ maybeSingle });
     const eq = vi.fn().mockReturnValue({ select });
@@ -100,6 +106,7 @@ describe('Space server actions', () => {
     await expect(
       updateItemAction(itemId, { title: 'Changed' })
     ).rejects.toThrow('That Space item no longer exists or is not writable.');
+    expect(updateTag).not.toHaveBeenCalled();
     expect(revalidatePath).not.toHaveBeenCalled();
   });
 });

--- a/app/space/actions.ts
+++ b/app/space/actions.ts
@@ -1,10 +1,11 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, updateTag } from 'next/cache';
 import { Rating } from 'ts-fsrs';
 import { parseMarkdown, highlightCode } from '@/app/lib/utils/markdown';
 import { reviewOnce } from '@/app/lib/fsrs-adapter';
 import type { ReviewState } from '@/app/lib/review-types';
+import { SPACE_PUBLIC_ITEMS_CACHE_TAG } from '@/app/lib/space-cache';
 import { createClient } from '@/utils/supabase/server';
 import { requireSpaceAdmin } from './authorization';
 import {
@@ -61,6 +62,11 @@ function reviewWrite(userId: string, review: ReviewState) {
   };
 }
 
+function revalidatePublicSpaceItems() {
+  updateTag(SPACE_PUBLIC_ITEMS_CACHE_TAG);
+  revalidatePath('/space');
+}
+
 async function parseVersions(versions: AddItemInput['versions']) {
   return Promise.all(
     versions.map(async version => ({
@@ -97,7 +103,7 @@ export async function addItemAction(input: AddItemInput) {
 
   if (error || !data) throw new Error('Space could not save that item.');
 
-  revalidatePath('/space');
+  revalidatePublicSpaceItems();
 }
 
 export async function updateItemAction(
@@ -135,7 +141,7 @@ export async function updateItemAction(
   if (!data)
     throw new Error('That Space item no longer exists or is not writable.');
 
-  revalidatePath('/space');
+  revalidatePublicSpaceItems();
 }
 
 export async function enrollItemForReviewAction(

--- a/app/space/data.test.ts
+++ b/app/space/data.test.ts
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('server-only', () => ({}));
 
 const createClient = vi.hoisted(() => vi.fn());
+const loadPublicSpacePage = vi.hoisted(() => vi.fn());
 vi.mock('@/utils/supabase/server', () => ({ createClient }));
+vi.mock('./public-data', () => ({ loadPublicSpacePage }));
 
 import {
   loadInitialSpaceData,
@@ -15,6 +17,10 @@ describe('withSpaceTimeout', () => {
   beforeEach(() => {
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co');
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'test-key');
+    loadPublicSpacePage.mockResolvedValue({
+      databaseItems: [],
+      hasMore: false,
+    });
   });
 
   afterEach(() => {
@@ -47,9 +53,9 @@ describe('withSpaceTimeout', () => {
     expect(onTimeout).toHaveBeenCalledOnce();
   });
 
-  it('loads published learning items without requiring a sign-in', async () => {
-    const abortSignal = vi.fn().mockResolvedValue({
-      data: [
+  it('loads cached public learning items without using request-bound item access', async () => {
+    loadPublicSpacePage.mockResolvedValue({
+      databaseItems: [
         {
           id: 'item-1',
           title: 'A living lesson',
@@ -72,18 +78,9 @@ describe('withSpaceTimeout', () => {
           updated_at: '2026-08-09T00:00:00.000Z',
         },
       ],
-      error: null,
+      hasMore: false,
     });
-    const query = {
-      select: vi.fn(),
-      order: vi.fn(),
-      range: vi.fn(),
-      abortSignal,
-    };
-    query.select.mockReturnValue(query);
-    query.order.mockReturnValue(query);
-    query.range.mockReturnValue(query);
-    const from = vi.fn().mockReturnValue(query);
+    const from = vi.fn();
     createClient.mockResolvedValue({
       auth: {
         getUser: vi.fn().mockResolvedValue({
@@ -100,11 +97,11 @@ describe('withSpaceTimeout', () => {
     expect(result.items[0]?.title).toBe('A living lesson');
     expect(result.isAdmin).toBe(false);
     expect(result.error).toBeNull();
-    expect(from).toHaveBeenCalledWith('items');
-    expect(from).not.toHaveBeenCalledWith('reviews');
+    expect(loadPublicSpacePage).toHaveBeenCalledOnce();
+    expect(from).not.toHaveBeenCalled();
   });
 
-  it('starts the public archive request while identity is still loading', async () => {
+  it('starts the cached public archive request while identity is still loading', async () => {
     let resolveIdentity: (value: {
       data: { user: null };
       error: null;
@@ -114,28 +111,38 @@ describe('withSpaceTimeout', () => {
         resolveIdentity = resolve;
       }
     );
-    const abortSignal = vi.fn().mockResolvedValue({ data: [], error: null });
-    const query = {
-      select: vi.fn(),
-      order: vi.fn(),
-      range: vi.fn(),
-      abortSignal,
-    };
-    query.select.mockReturnValue(query);
-    query.order.mockReturnValue(query);
-    query.range.mockReturnValue(query);
     createClient.mockResolvedValue({
       auth: { getUser: vi.fn().mockReturnValue(identity) },
-      from: vi.fn().mockReturnValue(query),
+      from: vi.fn(),
     });
 
     const pending = loadInitialSpaceData();
-    await vi.waitFor(() => expect(abortSignal).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(loadPublicSpacePage).toHaveBeenCalledOnce());
     resolveIdentity({ data: { user: null }, error: null });
 
     await expect(pending).resolves.toMatchObject({
       items: [],
       isAdmin: false,
+    });
+  });
+
+  it('keeps identity context when the shared public archive cannot load', async () => {
+    loadPublicSpacePage.mockRejectedValue(new Error('archive offline'));
+    createClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+          error: null,
+        }),
+      },
+      from: vi.fn(),
+    });
+
+    await expect(loadInitialSpaceData()).resolves.toMatchObject({
+      items: [],
+      isAdmin: false,
+      user: null,
+      error: 'Space could not open the archive. Try again in a moment.',
     });
   });
 });

--- a/app/space/data.ts
+++ b/app/space/data.ts
@@ -2,13 +2,12 @@ import 'server-only';
 
 import type { User } from '@supabase/supabase-js';
 import { isAdminUser } from '@/app/lib/auth/admin';
-import type { DbItem, DbReview } from '@/app/lib/db/supabase';
+import type { DbReview } from '@/app/lib/db/supabase';
 import type { Item } from '@/app/lib/item-types';
-import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import { createClient } from '@/utils/supabase/server';
+import { loadPublicSpacePage } from './public-data';
 
-const INITIAL_LOAD_TIMEOUT_MS = 8_000;
 const AUTH_TIMEOUT_MS = 5_000;
 const REVIEW_LOAD_TIMEOUT_MS = 5_000;
 
@@ -90,6 +89,11 @@ export async function loadInitialSpaceData(): Promise<InitialSpaceData> {
     );
   }
 
+  const publicPagePromise = loadPublicSpacePage().then(
+    page => ({ page, error: null as unknown }),
+    error => ({ page: null, error })
+  );
+
   const supabase = await createClient();
   const userPromise: Promise<User | null> = withSpaceTimeout(
     supabase.auth.getUser(),
@@ -102,25 +106,9 @@ export async function loadInitialSpaceData(): Promise<InitialSpaceData> {
       return null;
     });
 
-  const itemsAbortController = new AbortController();
-  let itemsResult;
-  try {
-    [, itemsResult] = await Promise.all([
-      userPromise,
-      withSpaceTimeout(
-        supabase
-          .from('items')
-          .select(SPACE_ITEM_SELECT)
-          .order('created_at', { ascending: false })
-          .range(0, SPACE_PAGE_SIZE - 1)
-          .abortSignal(itemsAbortController.signal),
-        INITIAL_LOAD_TIMEOUT_MS,
-        'Space archive',
-        () => itemsAbortController.abort()
-      ),
-    ]);
-  } catch (itemsError) {
-    console.error('Space archive could not be loaded:', itemsError);
+  const publicResult = await publicPagePromise;
+  if (!publicResult.page) {
+    console.error('Space archive could not be loaded:', publicResult.error);
     const user = await userPromise;
     return {
       ...unavailableSpaceData(
@@ -133,19 +121,7 @@ export async function loadInitialSpaceData(): Promise<InitialSpaceData> {
 
   const user = await userPromise;
   const isAdmin = isAdminUser(user);
-
-  if (itemsResult.error) {
-    console.error('Space archive could not be loaded:', itemsResult.error);
-    return {
-      ...unavailableSpaceData(
-        'Space could not open the archive. Try again in a moment.'
-      ),
-      user,
-      isAdmin,
-    };
-  }
-
-  const databaseItems = (itemsResult.data ?? []) as unknown as DbItem[];
+  const { databaseItems, hasMore } = publicResult.page;
   let databaseReviews: DbReview[] = [];
   let error: string | null = null;
 
@@ -181,7 +157,7 @@ export async function loadInitialSpaceData(): Promise<InitialSpaceData> {
     isAdmin,
     user,
     nowMs: Date.now(),
-    hasMore: databaseItems.length === SPACE_PAGE_SIZE,
+    hasMore,
     error,
   };
 }

--- a/app/space/data.ts
+++ b/app/space/data.ts
@@ -6,7 +6,10 @@ import type { DbReview } from '@/app/lib/db/supabase';
 import type { Item } from '@/app/lib/item-types';
 import { mapDatabaseItemsToItems } from '@/app/lib/utils/database';
 import { createClient } from '@/utils/supabase/server';
-import { loadPublicSpacePage } from './public-data';
+import {
+  loadPublicSpacePage,
+  type PublicSpacePage,
+} from './public-data';
 
 const AUTH_TIMEOUT_MS = 5_000;
 const REVIEW_LOAD_TIMEOUT_MS = 5_000;
@@ -26,6 +29,10 @@ const REVIEW_SELECT = [
   'last_review',
   'suspended',
 ].join(',');
+
+type PublicPageResult =
+  | { page: PublicSpacePage; error: null }
+  | { page: null; error: unknown };
 
 export class SpaceLoadTimeoutError extends Error {
   constructor(label: string) {
@@ -89,8 +96,8 @@ export async function loadInitialSpaceData(): Promise<InitialSpaceData> {
     );
   }
 
-  const publicPagePromise = loadPublicSpacePage().then(
-    page => ({ page, error: null as unknown }),
+  const publicPagePromise: Promise<PublicPageResult> = loadPublicSpacePage().then(
+    page => ({ page, error: null }),
     error => ({ page: null, error })
   );
 

--- a/app/space/public-data.test.ts
+++ b/app/space/public-data.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const cacheLife = vi.hoisted(() => vi.fn());
+const cacheTag = vi.hoisted(() => vi.fn());
+const createPublicClient = vi.hoisted(() => vi.fn());
+vi.mock('next/cache', () => ({ cacheLife, cacheTag }));
+vi.mock('@/utils/supabase/public', () => ({ createPublicClient }));
+
+import { SPACE_PUBLIC_ITEMS_CACHE_TAG } from '@/app/lib/space-cache';
+import { loadPublicSpacePage } from './public-data';
+
+function publicRow(id = 'item-1') {
+  return {
+    id,
+    title: 'Cached public item',
+    slug: id,
+    url: null,
+    default_index: 0,
+    versions: [],
+    tags: ['topic:cache'],
+    category: 'notes',
+    score: null,
+    created_at: '2026-08-10T00:00:00.000Z',
+    updated_at: '2026-08-10T00:00:00.000Z',
+  };
+}
+
+function queryResult(result: unknown) {
+  const abortSignal = vi.fn().mockResolvedValue(result);
+  const query = {
+    select: vi.fn(),
+    order: vi.fn(),
+    range: vi.fn(),
+    abortSignal,
+  };
+  query.select.mockReturnValue(query);
+  query.order.mockReturnValue(query);
+  query.range.mockReturnValue(query);
+  return { query, abortSignal };
+}
+
+describe('loadPublicSpacePage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('uses the anonymous public projection with an explicit cache lifetime and tag', async () => {
+    const { query } = queryResult({ data: [publicRow()], error: null });
+    const from = vi.fn().mockReturnValue(query);
+    createPublicClient.mockReturnValue({ from });
+
+    const pending = loadPublicSpacePage();
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(cacheLife).toHaveBeenCalledWith({
+      stale: 60,
+      revalidate: 60,
+      expire: 86_400,
+    });
+    expect(cacheTag).toHaveBeenCalledWith(SPACE_PUBLIC_ITEMS_CACHE_TAG);
+    expect(from).toHaveBeenCalledWith('items');
+    expect(query.select).toHaveBeenCalledOnce();
+    expect(query.order).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(query.range).toHaveBeenCalledWith(0, 99);
+    expect(result.databaseItems).toHaveLength(1);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('marks a full first page as having more public archive rows', async () => {
+    const rows = Array.from({ length: 100 }, (_, index) =>
+      publicRow(`item-${index}`)
+    );
+    const { query } = queryResult({ data: rows, error: null });
+    createPublicClient.mockReturnValue({ from: vi.fn().mockReturnValue(query) });
+
+    const pending = loadPublicSpacePage();
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toMatchObject({ hasMore: true });
+  });
+
+  it('aborts a public archive request that exceeds the eight-second boundary', async () => {
+    const abortSignal = vi.fn(
+      () => new Promise<never>(() => undefined)
+    );
+    const query = {
+      select: vi.fn(),
+      order: vi.fn(),
+      range: vi.fn(),
+      abortSignal,
+    };
+    query.select.mockReturnValue(query);
+    query.order.mockReturnValue(query);
+    query.range.mockReturnValue(query);
+    createPublicClient.mockReturnValue({ from: vi.fn().mockReturnValue(query) });
+
+    const pending = loadPublicSpacePage();
+    const expectation = expect(pending).rejects.toThrow('Space archive timed out');
+    await vi.advanceTimersByTimeAsync(8_000);
+    await expectation;
+
+    const signal = abortSignal.mock.calls[0]?.[0] as AbortSignal;
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/app/space/public-data.test.ts
+++ b/app/space/public-data.test.ts
@@ -89,7 +89,14 @@ describe('loadPublicSpacePage', () => {
 
   it('aborts a public archive request that exceeds the eight-second boundary', async () => {
     const abortSignal = vi.fn(
-      () => new Promise<never>(() => undefined)
+      (signal: AbortSignal) =>
+        new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => reject(new Error('request aborted')),
+            { once: true }
+          );
+        })
     );
     const query = {
       select: vi.fn(),

--- a/app/space/public-data.ts
+++ b/app/space/public-data.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+
+import { cacheLife, cacheTag } from 'next/cache';
+import type { DbItem } from '@/app/lib/db/supabase';
+import { SPACE_ITEM_SELECT, SPACE_PAGE_SIZE } from '@/app/lib/space-data';
+import { SPACE_PUBLIC_ITEMS_CACHE_TAG } from '@/app/lib/space-cache';
+import { createPublicClient } from '@/utils/supabase/public';
+
+const PUBLIC_SPACE_LOAD_TIMEOUT_MS = 8_000;
+
+export type PublicSpacePage = {
+  databaseItems: DbItem[];
+  hasMore: boolean;
+};
+
+export async function loadPublicSpacePage(): Promise<PublicSpacePage> {
+  'use cache';
+  cacheLife({ stale: 60, revalidate: 60, expire: 86_400 });
+  cacheTag(SPACE_PUBLIC_ITEMS_CACHE_TAG);
+
+  const supabase = createPublicClient();
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, PUBLIC_SPACE_LOAD_TIMEOUT_MS);
+
+  try {
+    const result = await supabase
+      .from('items')
+      .select(SPACE_ITEM_SELECT)
+      .order('created_at', { ascending: false })
+      .range(0, SPACE_PAGE_SIZE - 1)
+      .abortSignal(controller.signal);
+
+    if (timedOut) throw new Error('Space archive timed out');
+    if (result.error) throw result.error;
+
+    const databaseItems = (result.data ?? []) as unknown as DbItem[];
+    return {
+      databaseItems,
+      hasMore: databaseItems.length === SPACE_PAGE_SIZE,
+    };
+  } catch (error) {
+    if (timedOut) throw new Error('Space archive timed out');
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/docs/space-continuity.md
+++ b/docs/space-continuity.md
@@ -1,6 +1,6 @@
 # Space continuity contracts
 
-Space should feel immediate on ordinary return navigation without making browser storage a second database. The continuity layer separates three short-lived concerns and leaves durable learning/review state elsewhere.
+Space should feel immediate on ordinary return navigation without making browser storage a second database. The continuity layer separates public data reuse, browser fallback, and ephemeral presentation state while leaving private review state request-bound.
 
 ## 1. Canonical browse URL state
 
@@ -14,7 +14,26 @@ The parameter order is always `lane`, `tags`, `item`. Empty values disappear. Th
 
 Reading-sheet and Trail-specific parameters remain outside this first codec until their current route helpers are migrated deliberately. Keep `from`, `return`, `practice`, and `stage` in their existing owner until one complete migration is ready.
 
-## 2. Bounded public archive snapshot
+## 2. Shared anonymous first-page cache
+
+`app/space/public-data.ts` owns the reusable server-side public first page. It is deliberately separate from request identity and review rows.
+
+Rules:
+
+- use a request-independent anonymous Supabase client with no cookie/session storage;
+- rely on the repository RLS policy that gives `anon` and `authenticated` the same public item projection while excluding `visibility:private` rows;
+- cache only the first 100 public item rows selected by `SPACE_ITEM_SELECT`;
+- use Next Cache Components with a 60-second stale/revalidate window and 24-hour hard expiry;
+- tag the entry as `space-public-items`;
+- keep the eight-second upstream timeout and abort boundary;
+- start the public page request independently of the request-bound identity lookup;
+- query private owner review rows only after identity resolves and outside the shared cache;
+- invalidate `space-public-items` after successful item add/edit writes;
+- leave review/enrollment actions out of the public cache invalidation path.
+
+The shared cache reduces repeated public database work on warm route navigation without putting cookies, owner identity, or review schedules into a cross-request cache. A cached public page remains subject to the same public RLS projection as a live anonymous read.
+
+## 3. Bounded public browser snapshot
 
 `lib/space-public-snapshot.ts` and `lib/space-public-snapshot-storage.ts` define the only browser-persistent archive fallback.
 
@@ -32,21 +51,21 @@ Rules:
 - treat localStorage read/write/quota/security failures as ordinary cache misses;
 - remove invalid, stale, or over-budget payloads when storage permits.
 
-### Current runtime admission sequence
+### Runtime admission sequence
 
-`ItemsProvider` now uses the snapshot as a stale-readable outage fallback:
+`ItemsProvider` uses the snapshot as a stale-readable outage fallback:
 
-1. Start with the server-provided public items.
-2. A successful non-empty first page wins and refreshes the bounded public snapshot.
+1. Start with the server-provided public items, which may themselves come from the shared anonymous server cache.
+2. A successful non-empty first page wins and refreshes the bounded browser snapshot.
 3. A successful live empty archive clears any older snapshot so removed material cannot reappear during a later outage.
-4. If the server explicitly failed and supplied zero usable public items, admit a valid recent snapshot after hydration.
+4. If the server explicitly failed and supplied zero usable public items, admit a valid recent browser snapshot after hydration.
 5. Revalidate an admitted snapshot immediately through the existing `reload()` path.
 6. A successful revalidation replaces the cache-backed list and refreshes the snapshot; a refresh failure preserves the visible list and bounded error UI.
 7. Private/admin review rows continue through their authenticated path and never enter browser storage.
 
-Do not merge cached public items with a partial server response. Either the server supplied a usable current public page or the cache is a temporary fallback. Warm successful navigation that renders cached public data before the server completes remains a separate #553/#333 follow-up.
+Do not merge cached browser items with a partial server response. Either the server supplied a usable current public page or the browser snapshot is a temporary fallback.
 
-## 3. Same-entry list UI history
+## 4. Same-entry list UI history
 
 `lib/space-history-ui.ts` owns ephemeral Back/Forward state that cannot be reconstructed from the URL. Version 2 stores:
 
@@ -79,7 +98,8 @@ Incidental hover, viewport observation, editor draft text, review state, and oth
 Evaluate continuity as separate journeys rather than one synthetic timing number:
 
 - cold load with healthy server data;
-- cold load with server archive failure + valid cached public snapshot;
+- warm navigation inside the 60-second shared public cache window;
+- cold load with server archive failure + valid cached browser snapshot;
 - warm in-app list ↔ reader return;
 - reading sheet ↔ prior list/Trail return;
 - Back/Forward restoration of filter, list page, scroll, and expanded rows.

--- a/utils/supabase/public.ts
+++ b/utils/supabase/public.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+
+import { createClient } from '@supabase/supabase-js';
+
+export function createPublicClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) throw new Error('Space archive is not configured.');
+
+  return createClient(url, anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+}


### PR DESCRIPTION
## Why

#580 made a recent browser snapshot available when the live archive fails, but a healthy warm `/space` navigation still repeats the same public first-page database read. The `items_public_read` RLS policy gives anonymous and authenticated readers the same public item projection while excluding `visibility:private`, so the public first page can be reused across requests without putting cookies, owner identity, or review rows into a shared cache.

## Change

- add a request-independent anonymous Supabase client with session persistence disabled;
- move the public first-page item query into `loadPublicSpacePage()` with Next Cache Components:
  - `'use cache'`;
  - 60-second stale/revalidate window;
  - 24-hour hard expiry;
  - cache tag `space-public-items`;
  - existing 100-row public projection and eight-second abort boundary;
- start that shared public request independently of request-bound identity lookup;
- keep owner identity and private review-row loading request-bound;
- add/edit item actions invalidate `space-public-items` and `/space` immediately;
- review/enrollment actions continue to revalidate owner UI without churning the public item cache;
- keep the existing browser localStorage snapshot as the later outage fallback rather than merging it with the server cache.

## Safety / privacy boundary

The shared client uses only `NEXT_PUBLIC_SUPABASE_URL` + anon key and no cookies. Repository RLS grants the current public item columns to both `anon` and `authenticated` through the same `items_public_read` policy, which excludes `visibility:private` tags. Private review rows remain in the request-bound authenticated query path.

Because this changes a shared-cache privacy boundary, it is intentionally ready for human review rather than self-merged under `AGENTS.md`.

## Verification

Exact head: `2b22517f6ccd3099aa41a0f10a51194e3eb0ba2c`.

Both CI jobs are green:

- lint;
- TypeScript typecheck;
- full unit suite;
- production build, including Next 16 `use cache` / `cacheLife` / `cacheTag` validation;
- complete hosted Chrome regression suite;
- homepage visual-review artifact upload.

Focused tests additionally prove:

- the cache lifetime/tag and exact first-page public query/order/range;
- `hasMore` and eight-second abort behavior;
- the shared public request starts while identity is still pending;
- visitor item loads never call request-bound `from('items')`;
- archive failure preserves identity/admin context;
- successful public item writes invalidate `space-public-items`;
- authorization failures and unmatched updates do not invalidate it.

## Boundary

No browser snapshot schema, private review cache, database/RLS migration, auth behavior, pagination cache, search cache, URL/history behavior, or model/ranking change. This reuses only the public first page for warm server requests.

Part of #553/#333 and #218.