### PR TITLE
Skip Chromium setup for proven non-runtime pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,27 +71,72 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Classify browser relevance
+        id: browser_changes
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
+            echo "run_browser=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Pushes to main always run the complete Chromium suite." >> "$GITHUB_OUTPUT"
+            {
+              echo "### Chromium classification: run"
+              echo
+              echo "Pushes to main always run the complete Chromium suite."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null && \
+             git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null && \
+             git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/scrapbook-changed-paths.txt; then
+            node scripts/ci-change-classifier-cli.mjs \
+              < /tmp/scrapbook-changed-paths.txt \
+              >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run_browser=true" >> "$GITHUB_OUTPUT"
+          echo "reason=Changed paths could not be resolved safely; run Chromium by default." >> "$GITHUB_OUTPUT"
+          {
+            echo "### Chromium classification: run"
+            echo
+            echo "Changed paths could not be resolved safely; run Chromium by default."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: pnpm/action-setup@v4
+        if: steps.browser_changes.outputs.run_browser == 'true'
         with:
           version: 10
       - uses: actions/setup-node@v4
+        if: steps.browser_changes.outputs.run_browser == 'true'
         with:
           node-version: 22
           cache: pnpm
-      - run: pnpm install --frozen-lockfile --reporter=silent
+      - name: Install dependencies
+        if: steps.browser_changes.outputs.run_browser == 'true'
+        run: pnpm install --frozen-lockfile --reporter=silent
       - name: Install Chrome dependencies
+        if: steps.browser_changes.outputs.run_browser == 'true'
         run: pnpm exec playwright install-deps chromium
       - name: Chromium regressions
+        if: steps.browser_changes.outputs.run_browser == 'true'
         run: pnpm exec playwright test --project=chromium > playwright.log 2>&1
       - name: Upload homepage visual review
-        if: always()
+        if: always() && steps.browser_changes.outputs.run_browser == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: homepage-visual-review
           path: test-results/homepage-density/after
           if-no-files-found: ignore
       - name: Upload browser failure diagnostics
-        if: failure()
+        if: failure() && steps.browser_changes.outputs.run_browser == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: chromium-failure-diagnostics

--- a/scripts/ci-change-classifier-cli.mjs
+++ b/scripts/ci-change-classifier-cli.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import { classifyCiPaths } from './ci-change-classifier.mjs';
+
+const input = fs.readFileSync(0, 'utf8');
+const paths = input.split(/\r?\n/).filter(Boolean);
+const result = classifyCiPaths(paths);
+
+process.stdout.write(`run_browser=${result.runBrowser ? 'true' : 'false'}\n`);
+process.stdout.write(`reason=${result.reason}\n`);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const browserLabel = result.runBrowser ? 'run' : 'skip';
+  const relevant = result.browserRelevantPaths.length
+    ? `\n\nBrowser-relevant paths:\n${result.browserRelevantPaths
+        .map(path => `- \`${path}\``)
+        .join('\n')}`
+    : '';
+  const independent = result.browserIndependentPaths.length
+    ? `\n\nAllowlisted browser-independent paths:\n${result.browserIndependentPaths
+        .map(path => `- \`${path}\``)
+        .join('\n')}`
+    : '';
+
+  fs.appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `### Chromium classification: ${browserLabel}\n\n${result.reason}${relevant}${independent}\n`
+  );
+}


### PR DESCRIPTION
## Why

#582 landed a tested conservative path classifier, and #579 reduced the cost of browser runs that genuinely need Chromium. The remaining avoidable cost is browser setup/tests on pull requests where every changed file is documentation or a colocated unit test.

This is the current-main transplant of the already-green #584 implementation after list-history work advanced `main`.

## Change

- add a tiny native-Node CLI wrapper around the tested classifier;
- let the e2e job classify pull-request base/head paths before installing pnpm, Node dependencies, Chrome dependencies, or running Playwright;
- preserve the complete Chromium suite for every push to `main` and for runtime/e2e/public/package/config/workflow/script/unknown changes;
- skip expensive browser setup only when every changed path is allowlisted as `docs/**`, root `README.md`, or a colocated `*.test.ts` / `*.test.tsx` unit-test file;
- fail safe to running Chromium if the PR base/head diff cannot be resolved;
- write the classification reason and path buckets into the GitHub job summary.

## Self-test property

This PR changes a workflow and a script, so its own e2e job must classify itself as browser-relevant and run the complete Chromium suite. The stale-base predecessor #584 already passed that self-test; this replacement repeats it against current main.

After merge, one useful docs-only PR and one focused TS unit-test-only PR will exercise the two positive skip paths before #576 closes.

## Boundary

`verify` remains unchanged for every PR. Pushes to main remain full-browser. No product runtime, browser project, test selection, assertion, or pass/fail policy changes for browser-relevant work.

Tracks #576.