### PR TITLE
Pin RSS feed boundary requirements

### DIFF
--- a/lib/rss-feed.test.ts
+++ b/lib/rss-feed.test.ts
@@ -67,6 +67,16 @@ describe('createRssFeed', () => {
     ).toThrow('RSS feed date is invalid');
   });
 
+  it('requires a public item and a bounded positive maximum', () => {
+    expect(() => feed([])).toThrow('RSS feed requires at least one public item');
+    expect(() => feed([item()], 0)).toThrow(
+      'RSS feed maximumItems must be an integer between 1 and 200'
+    );
+    expect(() => feed([item()], 201)).toThrow(
+      'RSS feed maximumItems must be an integer between 1 and 200'
+    );
+  });
+
   it('rejects duplicate identities and bounds the item count', () => {
     expect(() => feed([item(), item()])).toThrow('item id is duplicated');
 


### PR DESCRIPTION
## Why

The RSS generator already enforces two useful input boundaries that were not directly pinned together: the feed must contain at least one public item, and `maximumItems` must stay within 1–200. This current-main transplant adds focused regression coverage and repeats the positive TS unit-test-only proof for the CI browser classifier after the docs proof advanced `main`.

## Change

Add one unit test covering:

- empty public item list rejection;
- `maximumItems=0` rejection;
- `maximumItems=201` rejection.

## Expected CI evidence

Because this PR changes only `lib/rss-feed.test.ts`:

- `verify` must still run lint, typecheck, full unit tests, and production build;
- the e2e job must run checkout + path classification;
- pnpm setup, Node setup, dependency install, Chrome dependencies, Playwright, and browser artifacts must all be skipped.

The superseded stale-base #589 already produced that skip pattern; this replacement repeats it against current main.

## Boundary

Test only. No RSS runtime, feed XML, publication state, route, caching, or CI classifier behavior changes.

Proof for #576; also advances #312 input-boundary coverage.