### PR TITLE
Keep the Space reader URL on the visible item

### DIFF
--- a/components/space/review-gallery.tsx
+++ b/components/space/review-gallery.tsx
@@ -3,7 +3,7 @@
 
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { parseQuery } from '@/app/lib/searchlang';
 import { searchItems } from '@/app/lib/item-search';
@@ -72,14 +72,17 @@ export function ReviewGallery() {
     tags: tagsParam,
   });
 
-  const replaceReaderItem = (index: number) => {
-    const nextItem = items[index];
-    if (!nextItem) return;
-    router.replace(
-      reviewItemHref(nextItem.id, tagsParam, laneParam ?? undefined),
-      { scroll: false }
-    );
-  };
+  const replaceReaderItem = useCallback(
+    (index: number) => {
+      const nextItem = items[index];
+      if (!nextItem) return;
+      router.replace(
+        reviewItemHref(nextItem.id, tagsParam, laneParam ?? undefined),
+        { scroll: false }
+      );
+    },
+    [items, laneParam, router, tagsParam]
+  );
 
   useEffect(() => {
     if (!hasMore || loadingMore) return;
@@ -106,7 +109,7 @@ export function ReviewGallery() {
 
   useEffect(() => {
     if (!itemParam && current) replaceReaderItem(currentIndex);
-  }, [current, currentIndex, itemParam]);
+  }, [current, currentIndex, itemParam, replaceReaderItem]);
 
   const nextShortcut = useMemo(
     () => ({
@@ -122,7 +125,7 @@ export function ReviewGallery() {
         replaceReaderItem(nextIndex);
       },
     }),
-    [current, currentIndex, items, laneParam, router, tagsParam]
+    [current, currentIndex, items.length, replaceReaderItem]
   );
   const previousShortcut = useMemo(
     () => ({
@@ -138,7 +141,7 @@ export function ReviewGallery() {
         replaceReaderItem(previousIndex);
       },
     }),
-    [current, currentIndex, items, laneParam, router, tagsParam]
+    [current, currentIndex, replaceReaderItem]
   );
   const toggleContentShortcut = useMemo(
     () => ({

--- a/components/space/review-gallery.tsx
+++ b/components/space/review-gallery.tsx
@@ -15,7 +15,8 @@ import { reviewOnce } from '@/app/lib/fsrs-adapter';
 import type { ReviewState } from '@/app/lib/review-types';
 import { rollbackFailedReview } from '@/app/lib/review-overrides';
 import { reviewItemAction } from '@/app/space/actions';
-import { duplicateItemHref } from '@/lib/space-routes';
+import { duplicateItemHref, reviewItemHref } from '@/lib/space-routes';
+import { createSpaceBrowseHref } from '@/lib/space-browse-state';
 import { SpaceHeader } from './space-header';
 import { CodeDisplay } from './code-display';
 import { useSpaceShortcut } from './space-shortcut-provider';
@@ -66,11 +67,19 @@ export function ReviewGallery() {
 
   const current = items[currentIndex];
   const active = current?.versions[activeIdx];
-  const exitParams = new URLSearchParams();
-  if (tagsParam) exitParams.set('tags', tagsParam);
-  if (laneParam) exitParams.set('lane', laneParam);
-  const exitSearch = exitParams.toString();
-  const exitHref = `/space${exitSearch ? `?${exitSearch}` : ''}`;
+  const exitHref = createSpaceBrowseHref('/space', {
+    lane: laneParam,
+    tags: tagsParam,
+  });
+
+  const replaceReaderItem = (index: number) => {
+    const nextItem = items[index];
+    if (!nextItem) return;
+    router.replace(
+      reviewItemHref(nextItem.id, tagsParam, laneParam ?? undefined),
+      { scroll: false }
+    );
+  };
 
   useEffect(() => {
     if (!hasMore || loadingMore) return;
@@ -95,6 +104,10 @@ export function ReviewGallery() {
     }
   }, [itemParam, items]);
 
+  useEffect(() => {
+    if (!itemParam && current) replaceReaderItem(currentIndex);
+  }, [current, currentIndex, itemParam]);
+
   const nextShortcut = useMemo(
     () => ({
       enabled: Boolean(current) && currentIndex < items.length - 1,
@@ -102,11 +115,14 @@ export function ReviewGallery() {
         ? 'Already at the last reader item'
         : 'No reader item is available',
       run: () => {
-        setCurrentIndex(index => Math.min(index + 1, items.length - 1));
+        const nextIndex = Math.min(currentIndex + 1, items.length - 1);
+        if (nextIndex === currentIndex) return;
+        setCurrentIndex(nextIndex);
         setShowContent(true);
+        replaceReaderItem(nextIndex);
       },
     }),
-    [current, currentIndex, items.length]
+    [current, currentIndex, items, laneParam, router, tagsParam]
   );
   const previousShortcut = useMemo(
     () => ({
@@ -115,11 +131,14 @@ export function ReviewGallery() {
         ? 'Already at the first reader item'
         : 'No reader item is available',
       run: () => {
-        setCurrentIndex(index => Math.max(index - 1, 0));
+        const previousIndex = Math.max(currentIndex - 1, 0);
+        if (previousIndex === currentIndex) return;
+        setCurrentIndex(previousIndex);
         setShowContent(true);
+        replaceReaderItem(previousIndex);
       },
     }),
-    [current, currentIndex]
+    [current, currentIndex, items, laneParam, router, tagsParam]
   );
   const toggleContentShortcut = useMemo(
     () => ({
@@ -167,8 +186,10 @@ export function ReviewGallery() {
     }
 
     if (currentIndex < items.length - 1) {
-      setCurrentIndex(index => index + 1);
+      const nextIndex = currentIndex + 1;
+      setCurrentIndex(nextIndex);
       setShowContent(true);
+      replaceReaderItem(nextIndex);
     }
   };
 

--- a/tests/e2e/space-reader-url-sync.spec.ts
+++ b/tests/e2e/space-reader-url-sync.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test';
+import type { Item } from '../../app/lib/item-types';
+import {
+  SPACE_PUBLIC_SNAPSHOT_KEY,
+  createSpacePublicSnapshot,
+  serializeSpacePublicSnapshot,
+} from '../../lib/space-public-snapshot';
+
+function readerItem(index: number): Item {
+  return {
+    id: `reader-sync-${index}`,
+    title: `Reader sync ${index}`,
+    slug: `reader-sync-${index}`,
+    url: null,
+    defaultIndex: 0,
+    versions: [
+      {
+        label: 'notes',
+        content: `Reader selection ${index}`,
+        contentHtml: `<p>Reader selection ${index}</p>`,
+        code: null,
+        codeHtml: '',
+      },
+    ],
+    tags: ['topic:continuity', 'source:test'],
+    category: 'notes',
+    createdAt: Date.parse('2026-08-10T00:00:00.000Z') + index,
+    updatedAt: Date.parse('2026-08-10T00:00:00.000Z') + index,
+  };
+}
+
+test('reader URL follows intentional item navigation and reload restores that item', async ({
+  page,
+}) => {
+  const raw = serializeSpacePublicSnapshot(
+    createSpacePublicSnapshot([readerItem(1), readerItem(2)], {
+      savedAt: Date.now(),
+      hasMore: false,
+    })
+  );
+
+  await page.addInitScript(
+    ({ key, value }) => window.localStorage.setItem(key, value),
+    { key: SPACE_PUBLIC_SNAPSHOT_KEY, value: raw }
+  );
+
+  const response = await page.goto('/space/review');
+  expect(response?.ok()).toBe(true);
+
+  const firstHeading = page.getByRole('heading', { name: 'Reader sync 1' });
+  const fallbackWasAdmitted = await firstHeading
+    .isVisible({ timeout: 5_000 })
+    .catch(() => false);
+  test.skip(
+    !fallbackWasAdmitted,
+    'This regression uses the failed/empty hosted archive so the saved public snapshot supplies deterministic reader rows.'
+  );
+
+  await expect(page).toHaveURL(/\/space\/review\?item=reader-sync-1$/);
+
+  await page.keyboard.press('ArrowRight');
+  await expect(page.getByRole('heading', { name: 'Reader sync 2' })).toBeVisible();
+  await expect(page).toHaveURL(/\/space\/review\?item=reader-sync-2$/);
+
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Reader sync 2' })).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page).toHaveURL(/\/space\/review\?item=reader-sync-2$/);
+
+  await page.keyboard.press('ArrowLeft');
+  await expect(page.getByRole('heading', { name: 'Reader sync 1' })).toBeVisible();
+  await expect(page).toHaveURL(/\/space\/review\?item=reader-sync-1$/);
+});

--- a/tests/e2e/space-reader-url-sync.spec.ts
+++ b/tests/e2e/space-reader-url-sync.spec.ts
@@ -48,13 +48,7 @@ test('reader URL follows intentional item navigation and reload restores that it
   expect(response?.ok()).toBe(true);
 
   const firstHeading = page.getByRole('heading', { name: 'Reader sync 1' });
-  const fallbackWasAdmitted = await firstHeading
-    .isVisible({ timeout: 5_000 })
-    .catch(() => false);
-  test.skip(
-    !fallbackWasAdmitted,
-    'This regression uses the failed/empty hosted archive so the saved public snapshot supplies deterministic reader rows.'
-  );
+  await expect(firstHeading).toBeVisible({ timeout: 15_000 });
 
   await expect(page).toHaveURL(/\/space\/review\?item=reader-sync-1$/);
 


### PR DESCRIPTION
## Why

#344's exact list-return half is solved, but the Reader still had the original URL-selection bug: keyboard/review navigation changed the visible item while `?item=` continued to point at the previous landing target. Reloading or sharing the URL could therefore open a different item from the one on screen.

## Change

- when `/space/review` opens without an `item`, replace the URL with the first visible Reader item;
- on intentional next/previous keyboard movement, replace `?item=` with the newly visible item;
- after a successful review automatically advances the Reader, replace `?item=` with that next item too;
- keep initial explicit deep-link resolution unchanged;
- use `router.replace(..., { scroll: false })` so movement stays addressable without creating a Back entry for every arrow press;
- canonicalize the Reader exit URL through the shared lane/tag serializer;
- keep the URL replacement callback stable so the synchronization effects and shortcut registrations have complete dependencies.

## Browser contract

The deterministic regression proves:

1. an untargeted Reader canonicalizes to item 1;
2. ArrowRight shows item 2 and updates `?item=reader-sync-2`;
3. reload restores item 2 from that URL;
4. ArrowLeft returns to item 1 and updates the URL again.

The earlier timing-based conditional skip was removed. The contract must now actually observe the fallback rows and complete the journey.

## Validation

- `pnpm ci:local --skip-install` — 6/6 stages passed
- Chromium — 131 passed, 7 live-archive contracts skipped by design
- focused browse/route unit tests — 9/9 passed
- focused Reader URL test — passed hermetically
- exact rebased diff checked against current `main`

## Boundary

Reader selection identity only. No new history entries, list-history state, cache model, auth/review persistence, ranking, or Trail behavior.

Completes the remaining URL-selection half of #344 and advances #553.
