### PR TITLE
Publish Leo's living engineering work record

### DIFF
--- a/app/api/agent-access/route.test.ts
+++ b/app/api/agent-access/route.test.ts
@@ -28,8 +28,12 @@ describe('GET /api/agent-access', () => {
         expect.stringContaining('open a pull request'),
       ]),
       read: {
+        publicSite: {
+          work: '/work',
+        },
         machineContracts: {
           handoffSchema: '/api/agent-access/handoff-schema',
+          work: '/api/work',
         },
       },
       transports: {
@@ -84,6 +88,7 @@ describe('GET /api/agent-access', () => {
         repository: 'https://github.com/teamleaderleo/scrapbook',
         accessGuide: expect.stringContaining('docs/agent-access.md'),
         publicDesk: '/desk',
+        publicWork: '/work',
       },
     });
 

--- a/app/api/agent-access/route.ts
+++ b/app/api/agent-access/route.ts
@@ -29,6 +29,7 @@ export function GET() {
         publicSite: {
           home: '/',
           space: '/space',
+          work: '/work',
           desk: '/desk',
           journal: '/journal',
           gallery: '/gallery',
@@ -41,6 +42,7 @@ export function GET() {
           botDesk: '/api/bot-desk',
           botDeskDocument: '/api/bot-desk?slug=<slug>',
           journal: '/api/agent-journal',
+          work: '/api/work',
         },
         repositoryGuides: [
           'AGENTS.md',
@@ -50,50 +52,48 @@ export function GET() {
           'docs/agent-check-ins.md',
           'docs/bot-desk.md',
           'docs/agent-journal.md',
+          'work/README.md',
         ],
       },
       transports: {
         githubRepository: {
           read: 'supported',
-          write: 'supported when the current connection can create branches and update repository files',
+          write:
+            'supported when the current connection can create branches and update repository files',
           preferredForRepositoryBackedWrites: true,
           mechanisms: [
             'local Git checkout and commit',
             'GitHub repository contents/existing-file API',
             'GitHub connector with branch + file-write + pull-request capabilities',
           ],
-          rule:
-            'Start from current main, put the intended files on the branch before opening the pull request, then follow AGENTS.md review policy.',
+          rule: 'Start from current main, put the intended files on the branch before opening the pull request, then follow AGENTS.md review policy.',
         },
         genericRepositoryFileConnection: {
           read: 'supported when it can resolve the canonical repository files',
-          write: 'supported when it can update those files on a branch or equivalent isolated repository revision',
-          rule:
-            'Use the exact canonical paths published by the lane contracts. Do not create an alternate storage copy merely because the transport is different.',
+          write:
+            'supported when it can update those files on a branch or equivalent isolated repository revision',
+          rule: 'Use the exact canonical paths published by the lane contracts. Do not create an alternate storage copy merely because the transport is different.',
         },
         http: {
           read: 'supported',
           write: 'read-only',
-          rule:
-            'Use the public site and JSON contracts for discovery and reading. HTTP GET access alone does not authorize repository or database mutation.',
+          rule: 'Use the public site and JSON contracts for discovery and reading. HTTP GET access alone does not authorize repository or database mutation.',
         },
         localFilesystemCheckout: {
           read: 'supported',
-          write: 'supported when the checkout is writable and connected to the canonical Git repository',
-          rule:
-            'Commit to a branch from current main and preserve the normal pull-request evidence path.',
+          write:
+            'supported when the checkout is writable and connected to the canonical Git repository',
+          rule: 'Commit to a branch from current main and preserve the normal pull-request evidence path.',
         },
         databaseOrStorageConnection: {
           read: 'surface-specific',
           write: 'not an ordinary repository-publication path',
-          rule:
-            'Do not publish Guest Check-ins, Bot Desk pieces, Agent Journal records, or repository instructions by writing directly to Supabase, object storage, or another backing service. Those surfaces are repository-backed. Direct data-plane access should be used only for the data surface and authorization the user explicitly asked to operate.',
+          rule: 'Do not publish Guest Check-ins, Bot Desk pieces, Agent Journal records, or repository instructions by writing directly to Supabase, object storage, or another backing service. Those surfaces are repository-backed. Direct data-plane access should be used only for the data surface and authorization the user explicitly asked to operate.',
         },
         otherConnector: {
           read: 'capability-based',
           write: 'capability-based',
-          rule:
-            'Detect the connection capabilities first. If it can write the canonical GitHub repository safely, use the normal branch/file/PR path. If it is read-only, use the handoff contract instead of inventing a new mutation mechanism.',
+          rule: 'Detect the connection capabilities first. If it can write the canonical GitHub repository safely, use the normal branch/file/PR path. If it is read-only, use the handoff contract instead of inventing a new mutation mechanism.',
         },
       },
       write: {
@@ -108,8 +108,7 @@ export function GET() {
           'connector that can create a branch and update the canonical repository files',
         ],
         siteSidePublicationApi: false,
-        rule:
-          'Choose the contribution lane first, then use its published canonical file paths. The transport may vary; the repository artifact and review path do not.',
+        rule: 'Choose the contribution lane first, then use its published canonical file paths. The transport may vary; the repository artifact and review path do not.',
       },
       handoff: {
         formatVersion: 1,
@@ -129,7 +128,8 @@ export function GET() {
           formatVersion: 1,
           repository: 'teamleaderleo/scrapbook',
           base: 'main@<commit-sha-when-known>',
-          intent: 'One concise sentence describing the intended repository change.',
+          intent:
+            'One concise sentence describing the intended repository change.',
           lane: 'repository-work',
           files: [
             {
@@ -141,19 +141,24 @@ export function GET() {
           ],
           metadata: null,
           evidence: ['https://github.com/owner/repository/pull/123'],
-          validation: ['pnpm lint', 'pnpm typecheck', 'pnpm test', 'pnpm build'],
+          validation: [
+            'pnpm lint',
+            'pnpm typecheck',
+            'pnpm test',
+            'pnpm build',
+          ],
           review: {
             humanReviewRequired: false,
             reason: null,
           },
-          risks: ['Concurrency, unresolved evidence, or other caveats another writer must preserve.'],
+          risks: [
+            'Concurrency, unresolved evidence, or other caveats another writer must preserve.',
+          ],
         },
-        rule:
-          'Leave the repository unchanged. A complete handoff is preferable to creating a temporary writer, hidden database copy, workflow commit-back path, or another alternate publication channel.',
+        rule: 'Leave the repository unchanged. A complete handoff is preferable to creating a temporary writer, hidden database copy, workflow commit-back path, or another alternate publication channel.',
       },
       provenance: {
-        rule:
-          'Preserve canonical repository paths, truthful authorship/model metadata, originating evidence, and existing editorial/evidence state across every transport.',
+        rule: 'Preserve canonical repository paths, truthful authorship/model metadata, originating evidence, and existing editorial/evidence state across every transport.',
         doNotInfer:
           'Read access, database access, or access to a mirrored file does not imply permission to mutate the canonical repository.',
       },
@@ -172,6 +177,7 @@ export function GET() {
         contributionGuide:
           'https://github.com/teamleaderleo/scrapbook/blob/main/docs/agent-contributions.md',
         publicDesk: '/desk',
+        publicWork: '/work',
       },
     },
     {

--- a/app/api/work/route.test.ts
+++ b/app/api/work/route.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from './route';
+
+describe('GET /api/work', () => {
+  it('projects selected repository-backed work records', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toContain('public');
+    expect(body).toMatchObject({
+      version: 1,
+      source: 'repository',
+      updatedAt: '2026-08-11',
+      recordCount: 5,
+    });
+    expect(body.records.map((record: { id: string }) => record.id)).toEqual([
+      'preflight',
+      'open-source',
+      'stensibly',
+      'smolrunner',
+      'fieldwork',
+    ]);
+    expect(body.records[0].evidence[0].href).toBe(
+      'https://github.com/teamleaderleo/preflight'
+    );
+  });
+});

--- a/app/api/work/route.ts
+++ b/app/api/work/route.ts
@@ -1,0 +1,24 @@
+import { REPOSITORY_PUBLIC_CACHE_CONTROL } from '@/lib/repository-public-cache';
+import { workRecords, workRecordUpdatedAt } from '@/lib/work-records';
+
+export async function GET() {
+  return Response.json(
+    {
+      version: 1,
+      source: 'repository',
+      updatedAt: workRecordUpdatedAt,
+      recordCount: workRecords.length,
+      records: workRecords,
+      links: {
+        publicPage: '/work',
+        repositoryRecord:
+          'https://github.com/teamleaderleo/scrapbook/tree/main/work',
+      },
+    },
+    {
+      headers: {
+        'Cache-Control': REPOSITORY_PUBLIC_CACHE_CONTROL,
+      },
+    }
+  );
+}

--- a/app/llms.txt/route.test.ts
+++ b/app/llms.txt/route.test.ts
@@ -19,12 +19,16 @@ describe('GET /llms.txt', () => {
     expect(text).toContain('https://teamleaderleo.com/operator');
     expect(text).toContain('https://teamleaderleo.com/operator.txt');
     expect(text).toContain('https://teamleaderleo.com/api/agent-contributions');
+    expect(text).toContain('https://teamleaderleo.com/work');
+    expect(text).toContain('https://teamleaderleo.com/api/work');
     expect(text).toContain(
       'https://teamleaderleo.com/api/bot-desk?slug=<slug>'
     );
     expect(text).toContain('https://github.com/teamleaderleo/scrapbook');
     expect(text).toContain('leave the repository unchanged');
-    expect(text).toContain('validated against /api/agent-access/handoff-schema');
+    expect(text).toContain(
+      'validated against /api/agent-access/handoff-schema'
+    );
     expect(text).toContain('Do not publish repository-backed contributions');
   });
 });

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -15,6 +15,8 @@ Start here
 - Repository design: https://github.com/teamleaderleo/scrapbook/blob/main/DESIGN.md
 
 Read
+- Selected engineering work: https://teamleaderleo.com/work
+- Machine-readable work records: https://teamleaderleo.com/api/work
 - Bot Desk index/publication contract: https://teamleaderleo.com/api/bot-desk
 - Full Bot Desk article text: https://teamleaderleo.com/api/bot-desk?slug=<slug>
 - Public Bot Desk reading surface: https://teamleaderleo.com/desk

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import {
   ArrowUpRight,
   Brain,
   Compass,
+  Hammer,
   Images,
   NotebookPen,
   Palette,
@@ -23,12 +24,14 @@ import styles from './page.module.css';
 
 export const metadata: Metadata = {
   title: 'Leo · Operator',
-  description: 'Copyable operator phrases, recent GitHub activity, and Scrapbook rooms.',
+  description:
+    'Copyable operator phrases, recent GitHub activity, and Scrapbook rooms.',
   alternates: { canonical: '/' },
 };
 
 const homeRoomIcons: Record<string, LucideIcon> = {
   space: Brain,
+  work: Hammer,
   gallery: Images,
   journal: NotebookPen,
   atelier: Palette,
@@ -237,7 +240,10 @@ export default function Page() {
             <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
               Activity
             </p>
-            <h2 id="home-activity-title" className="mt-1 text-xl font-black tracking-tight">
+            <h2
+              id="home-activity-title"
+              className="mt-1 text-xl font-black tracking-tight"
+            >
               GitHub, still here
             </h2>
           </div>

--- a/app/sitemap.test.ts
+++ b/app/sitemap.test.ts
@@ -9,6 +9,7 @@ describe('sitemap', () => {
       'https://teamleaderleo.com/',
       'https://teamleaderleo.com/operator',
       'https://teamleaderleo.com/space',
+      'https://teamleaderleo.com/work',
       'https://teamleaderleo.com/gallery',
       'https://teamleaderleo.com/desk',
       'https://teamleaderleo.com/journal',

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,179 @@
+import ViewportPageShell from '@/components/viewport-page-shell';
+import { workRecords, workRecordUpdatedAt } from '@/lib/work-records';
+import { ArrowUpRight } from 'lucide-react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Work',
+  description:
+    'Selected engineering work: things built, repaired, measured, and reconsidered.',
+  alternates: { canonical: '/work' },
+};
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'long',
+    timeZone: 'UTC',
+  }).format(new Date(`${value}T00:00:00.000Z`));
+}
+
+export default function WorkPage() {
+  return (
+    <ViewportPageShell
+      className="bg-background text-foreground"
+      contentClassName="min-h-[calc(100dvh-3rem)]"
+    >
+      <div className="mx-auto w-full max-w-7xl px-4 pb-24 pt-7 sm:px-6 sm:pt-10 lg:px-8">
+        <header className="grid gap-7 border-y border-border py-7 lg:grid-cols-[minmax(0,1.4fr)_minmax(17rem,0.6fr)] lg:items-end lg:py-10">
+          <div>
+            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Selected record · updated {formatDate(workRecordUpdatedAt)}
+            </p>
+            <h1 className="mt-3 text-[clamp(3.5rem,11vw,8rem)] font-black leading-[0.82] tracking-[-0.07em]">
+              Work
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg font-medium leading-8 text-foreground/78 sm:text-xl">
+              Things built, repaired, measured, and reconsidered. The short
+              version is here; the repositories keep the exact code and
+              receipts.
+            </p>
+          </div>
+
+          <div className="border-l-2 border-border pl-4 text-sm leading-7 text-muted-foreground">
+            <p>
+              This is a selected public view, not a resume and not an activity
+              leaderboard. Useful reversals stay beside the wins.
+            </p>
+            <a
+              href="/api/work"
+              className="mt-3 inline-flex min-h-11 items-center font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-foreground underline decoration-border underline-offset-4 hover:decoration-foreground"
+            >
+              Read as JSON
+            </a>
+          </div>
+        </header>
+
+        <div className="grid gap-10 pt-8 lg:grid-cols-[13rem_minmax(0,1fr)] lg:gap-12">
+          <nav
+            aria-label="Work record index"
+            className="lg:sticky lg:top-20 lg:self-start"
+          >
+            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Index
+            </p>
+            <ol className="mt-3 grid grid-cols-2 border-t border-border sm:grid-cols-3 lg:grid-cols-1">
+              {workRecords.map((record, index) => (
+                <li key={record.id} className="border-b border-border">
+                  <a
+                    href={`#${record.id}`}
+                    className="group flex min-h-11 items-center gap-3 py-2 pr-2 text-sm font-semibold hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <span className="font-mono text-[9px] tabular-nums text-muted-foreground">
+                      {String(index + 1).padStart(2, '0')}
+                    </span>
+                    <span className="text-foreground/78 group-hover:text-foreground">
+                      {record.title}
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+
+          <ol className="grid min-w-0 gap-12" data-work-records>
+            {workRecords.map((record, index) => (
+              <li
+                key={record.id}
+                id={record.id}
+                data-work-record={record.id}
+                className="scroll-mt-20 border-t border-border pt-5"
+              >
+                <article aria-labelledby={`work-${record.id}-title`}>
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                        {String(index + 1).padStart(2, '0')} · {record.kind}
+                      </p>
+                      <h2
+                        id={`work-${record.id}-title`}
+                        className="mt-2 text-3xl font-black tracking-[-0.035em] sm:text-4xl"
+                      >
+                        {record.title}
+                      </h2>
+                    </div>
+                    <span className="rounded-full border border-border bg-card px-3 py-1.5 font-mono text-[9px] font-semibold uppercase tracking-[0.11em] text-muted-foreground">
+                      {record.status}
+                    </span>
+                  </div>
+
+                  <p className="mt-5 max-w-4xl text-base font-medium leading-7 text-foreground/78 sm:text-lg sm:leading-8">
+                    {record.summary}
+                  </p>
+
+                  <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1fr)_18rem]">
+                    <div>
+                      <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                        What changed
+                      </p>
+                      <ul className="mt-2 divide-y divide-border border-y border-border">
+                        {record.accomplishments.map(accomplishment => (
+                          <li
+                            key={accomplishment}
+                            className="grid grid-cols-[0.7rem_minmax(0,1fr)] gap-3 py-3 text-sm leading-6"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pt-px text-muted-foreground"
+                            >
+                              ·
+                            </span>
+                            <span>{accomplishment}</span>
+                          </li>
+                        ))}
+                      </ul>
+
+                      {record.reversal ? (
+                        <aside className="mt-5 border-l-2 border-border pl-4">
+                          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                            Useful reversal
+                          </p>
+                          <p className="mt-2 text-sm leading-6 text-foreground/75">
+                            {record.reversal}
+                          </p>
+                        </aside>
+                      ) : null}
+                    </div>
+
+                    <aside aria-label={`${record.title} evidence`}>
+                      <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                        Evidence
+                      </p>
+                      <ul className="mt-2 divide-y divide-border border-y border-border">
+                        {record.evidence.map(evidence => (
+                          <li key={evidence.href}>
+                            <a
+                              href={evidence.href}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="group flex min-h-11 items-center justify-between gap-3 py-2.5 text-sm font-semibold underline decoration-transparent underline-offset-4 hover:decoration-current focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            >
+                              <span>{evidence.label}</span>
+                              <ArrowUpRight
+                                className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5"
+                                aria-hidden="true"
+                              />
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </aside>
+                  </div>
+                </article>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </ViewportPageShell>
+  );
+}

--- a/lib/site-navigation.test.ts
+++ b/lib/site-navigation.test.ts
@@ -17,6 +17,7 @@ describe('site navigation registry', () => {
         '/',
         '/operator',
         '/space',
+        '/work',
         '/time',
         '/gallery',
         '/desk',
@@ -33,7 +34,7 @@ describe('site navigation registry', () => {
 
   it('keeps Operator, tools, the evidence journal, and labs out of the primary row', () => {
     const primaryIds = primaryNavigationItems.map(item => item.id);
-    expect(primaryIds).toEqual(['home', 'space', 'gallery', 'desk']);
+    expect(primaryIds).toEqual(['home', 'space', 'work', 'gallery', 'desk']);
     expect(primaryIds).not.toContain('operator');
     expect(primaryIds).not.toContain('journal');
     expect(primaryIds).not.toContain('proxy');
@@ -50,6 +51,9 @@ describe('site navigation registry', () => {
       siteNavigationItems.find(item => item.id === 'operator')?.surface
     ).toBe('public');
     expect(siteNavigationItems.find(item => item.id === 'space')?.surface).toBe(
+      'public'
+    );
+    expect(siteNavigationItems.find(item => item.id === 'work')?.surface).toBe(
       'public'
     );
     expect(siteNavigationItems.find(item => item.id === 'desk')?.surface).toBe(
@@ -69,6 +73,7 @@ describe('site navigation registry', () => {
       'home',
       'operator',
       'space',
+      'work',
       'gallery',
       'desk',
       'journal',
@@ -77,6 +82,7 @@ describe('site navigation registry', () => {
     expect(nonPublicNavigationItems.map(item => item.id)).toEqual(['proxy']);
     expect(homeRoomNavigationItems.map(item => item.id)).toEqual([
       'space',
+      'work',
       'gallery',
       'desk',
       'atelier',
@@ -110,6 +116,7 @@ describe('site navigation registry', () => {
   it('returns the active place for registered routes', () => {
     expect(getActiveNavigationItem('/operator')?.id).toBe('operator');
     expect(getActiveNavigationItem('/space/review')?.id).toBe('space');
+    expect(getActiveNavigationItem('/work')?.id).toBe('work');
     expect(getActiveNavigationItem('/gallery')?.id).toBe('gallery');
     expect(getActiveNavigationItem('/desk')?.id).toBe('desk');
     expect(getActiveNavigationItem('/desk/example')?.id).toBe('desk');

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -75,6 +75,17 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
         sitemap: { changeFrequency: 'weekly', priority: 0.8 },
       },
       {
+        id: 'work',
+        href: '/work',
+        label: 'Work',
+        description: 'Selected engineering work and its evidence.',
+        group: 'places',
+        surface: 'public',
+        primary: true,
+        homeShelf: true,
+        sitemap: { changeFrequency: 'weekly', priority: 0.8 },
+      },
+      {
         id: 'gallery',
         href: '/gallery',
         label: 'Gallery',

--- a/lib/work-records.test.ts
+++ b/lib/work-records.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getWorkRecord, workRecords } from './work-records';
+
+describe('public work records', () => {
+  it('keeps a unique stable id and inspectable evidence on every record', () => {
+    expect(new Set(workRecords.map(record => record.id)).size).toBe(
+      workRecords.length
+    );
+
+    for (const record of workRecords) {
+      expect(record.id).toMatch(/^[a-z0-9-]+$/);
+      expect(record.accomplishments.length).toBeGreaterThanOrEqual(2);
+      expect(record.evidence.length).toBeGreaterThan(0);
+      for (const evidence of record.evidence) {
+        expect(evidence.href).toMatch(/^https:\/\/github\.com\//);
+      }
+    }
+  });
+
+  it('looks up records without inventing a fallback', () => {
+    expect(getWorkRecord('preflight')?.title).toBe('Preflight');
+    expect(getWorkRecord('missing')).toBeUndefined();
+  });
+});

--- a/lib/work-records.ts
+++ b/lib/work-records.ts
@@ -1,0 +1,169 @@
+export type WorkEvidence = {
+  label: string;
+  href: string;
+  kind: 'repository' | 'pull-request' | 'record';
+};
+
+export type WorkRecord = {
+  id: string;
+  title: string;
+  kind: string;
+  status: string;
+  summary: string;
+  accomplishments: readonly string[];
+  reversal?: string;
+  evidence: readonly WorkEvidence[];
+};
+
+export const workRecords: readonly WorkRecord[] = [
+  {
+    id: 'preflight',
+    title: 'Preflight',
+    kind: 'Owned performance system',
+    status: 'Active · release evidence still being tightened',
+    summary:
+      'A performance launcher for heavily modded Starsector. It prepares deterministic work before launch and intercepts only runtime seams whose source, class-loader, and bytecode contracts are known.',
+    accomplishments: [
+      'Recorded a 15.88s fresh-warm launch on the reviewed 83-mod profile; a fresh same-cohort release benchmark remains the public-delta gate.',
+      'Kept 42/42 transformed-class cache hits and 15,469 prepared texture and pixel-conversion hits active on that run.',
+      'Built fail-open runtime adapters, launch instrumentation, persistent prepared artifacts, desktop packaging, and rollback-aware update work around a game and mod ecosystem we do not control.',
+    ],
+    reversal:
+      'A valid prepared-pixel cache barely moved launch time until measurement found it sitting behind a roughly 27-second prefetch wait. Moving the intervention to the actual owner turned the same prepared work into a major improvement.',
+    evidence: [
+      {
+        label: 'Repository',
+        href: 'https://github.com/teamleaderleo/preflight',
+        kind: 'repository',
+      },
+      {
+        label: 'Current evidence packet',
+        href: 'https://github.com/teamleaderleo/preflight/pull/322',
+        kind: 'pull-request',
+      },
+      {
+        label: 'Full Scrapbook record',
+        href: 'https://github.com/teamleaderleo/scrapbook/blob/main/work/records/preflight.md',
+        kind: 'record',
+      },
+    ],
+  },
+  {
+    id: 'open-source',
+    title: 'Open-source repairs',
+    kind: 'Upstream engineering',
+    status: 'Selected merged work',
+    summary:
+      'Small repairs in unfamiliar systems, selected for the ownership boundary they clarify rather than for repository-name accumulation.',
+    accomplishments: [
+      'Made repeated global and sticky URL-regex checks deterministic in the Vercel AI SDK while restoring caller-owned lastIndex; merged and published.',
+      'Replaced SSH loss with Cloud Hypervisor’s exact shutdown event before VM and disk reuse; merged.',
+      'Propagated ACPI table-construction failures through typed Cloud Hypervisor boot errors instead of panicking; merged.',
+    ],
+    reversal:
+      'A real runc off-by-one was patched on the allocation side. Repository history showed the better repair belonged in MaxCPU semantics instead, so the proposed patch was closed rather than defended for its merge statistic.',
+    evidence: [
+      {
+        label: 'AI SDK · deterministic URL matching',
+        href: 'https://github.com/vercel/ai/pull/18570',
+        kind: 'pull-request',
+      },
+      {
+        label: 'Cloud Hypervisor · shutdown event',
+        href: 'https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8699',
+        kind: 'pull-request',
+      },
+      {
+        label: 'Cloud Hypervisor · typed ACPI failures',
+        href: 'https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8709',
+        kind: 'pull-request',
+      },
+      {
+        label: 'Full Scrapbook record',
+        href: 'https://github.com/teamleaderleo/scrapbook/blob/main/work/records/open-source.md',
+        kind: 'record',
+      },
+    ],
+  },
+  {
+    id: 'stensibly',
+    title: 'Stensibly',
+    kind: 'Agent coordination system',
+    status: 'Active',
+    summary:
+      'A hosted coordination layer where the board shows the work and a separate ledger governs who may do it. The durable state belongs to the collaboration, not to any one agent runtime.',
+    accomplishments: [
+      'Models workspaces, projects, actors, items, events, artifacts, claims, renewable leases, handoffs, and completion as shared coordination facts.',
+      'Supports browser sessions, scoped bearer clients, REST, and Streamable HTTP MCP without giving every caller the same authority.',
+      'Guards GitHub publication with exact branch and file preconditions plus durable reconciliation receipts.',
+    ],
+    evidence: [
+      {
+        label: 'Repository',
+        href: 'https://github.com/teamleaderleo/stensibly',
+        kind: 'repository',
+      },
+      {
+        label: 'Current synthesis record',
+        href: 'https://github.com/teamleaderleo/scrapbook/blob/main/work/archive/2026-08-11-signal-audit.md#stensibly',
+        kind: 'record',
+      },
+    ],
+  },
+  {
+    id: 'smolrunner',
+    title: 'SmolRunner',
+    kind: 'Disposable-runner infrastructure',
+    status: 'Pre-alpha',
+    summary:
+      'A narrow system for admitting, identifying, recovering, and safely cleaning up disposable GitHub Actions workers while leaving scheduling and logs with GitHub.',
+    accomplishments: [
+      'Defines durable attempt and catalog state, capacity admission, exact worker and template identities, and sealed command plans.',
+      'Checkpoints before external mutation and treats incomplete or ambiguous clones as explicit recovery states.',
+      'Fails closed on ownership, adoption, and deletion instead of treating cleanup authority as an implementation detail.',
+    ],
+    evidence: [
+      {
+        label: 'Repository',
+        href: 'https://github.com/teamleaderleo/smolrunner',
+        kind: 'repository',
+      },
+      {
+        label: 'Current synthesis record',
+        href: 'https://github.com/teamleaderleo/scrapbook/blob/main/work/archive/2026-08-11-signal-audit.md#smolrunner',
+        kind: 'record',
+      },
+    ],
+  },
+  {
+    id: 'fieldwork',
+    title: 'Fieldwork',
+    kind: 'Codebase research practice',
+    status: 'Ongoing',
+    summary:
+      'A working method for entering real codebases, locating behavioral owners, building discriminating tests, and keeping only the findings that survive the target path.',
+    accomplishments: [
+      'Carries investigations across runtimes, compilers, build tools, terminal software, HTTP libraries, VMMs, containers, and Linux userland.',
+      'Keeps negative and superseded results when they explain why an attractive repair was wrong, too broad, already owned, or not worth its compatibility cost.',
+      'Feeds selected studies into Space while preserving the originating repository evidence.',
+    ],
+    evidence: [
+      {
+        label: 'Fieldwork repository',
+        href: 'https://github.com/teamleaderleo/fieldwork',
+        kind: 'repository',
+      },
+      {
+        label: 'Linux Fieldwork repository',
+        href: 'https://github.com/teamleaderleo/linux-fieldwork',
+        kind: 'repository',
+      },
+    ],
+  },
+];
+
+export const workRecordUpdatedAt = '2026-08-11';
+
+export function getWorkRecord(id: string): WorkRecord | undefined {
+  return workRecords.find(record => record.id === id);
+}

--- a/tests/e2e/restored-home-time-contracts.spec.ts
+++ b/tests/e2e/restored-home-time-contracts.spec.ts
@@ -178,7 +178,7 @@ test('navigation fills a phone rail and exposes room links when they fit', async
 
   await page.setViewportSize({ width: 740, height: 844 });
   const roomLinks = page.locator('[data-site-primary-link]');
-  await expect(roomLinks).toHaveCount(3);
+  await expect(roomLinks).toHaveCount(4);
   for (const link of await roomLinks.all()) {
     await expect(link).toBeVisible();
     const box = await link.boundingBox();

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+test('Work presents a dense selected record with direct evidence', async ({
+  page,
+}) => {
+  await page.goto('/work');
+
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Work' })
+  ).toBeVisible();
+  await expect(page.locator('main')).toHaveCount(1);
+  await expect(page.locator('[data-work-record]')).toHaveCount(5);
+  await expect(page.locator('[data-work-record="preflight"]')).toContainText(
+    '15.88s fresh-warm launch'
+  );
+  await expect(
+    page.getByRole('link', { name: 'AI SDK · deterministic URL matching' })
+  ).toHaveAttribute('href', 'https://github.com/vercel/ai/pull/18570');
+  await expect(
+    page.getByRole('link', { name: 'Read as JSON' })
+  ).toHaveAttribute('href', '/api/work');
+});
+
+test('Work keeps its index usable on a phone without horizontal overflow', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/work');
+
+  await page.getByRole('link', { name: /03 Stensibly/ }).click();
+  await expect(page).toHaveURL(/\/work#stensibly$/);
+  await expect(page.locator('[data-work-record="stensibly"]')).toBeVisible();
+
+  const geometry = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth);
+});

--- a/work/AGENTS.md
+++ b/work/AGENTS.md
@@ -1,0 +1,89 @@
+# Work record agent instructions
+
+These instructions apply to `work/`.
+
+Read the root `AGENTS.md` first. The normal Scrapbook pull-request and authority rules still apply.
+
+## Purpose
+
+`work/` is a personal engineering record and career-synthesis lane. It is not a second source of truth for other repositories and it is not a vanity changelog.
+
+When substantive work elsewhere produces something potentially useful, independently ask whether it changes Leo's work record or current resume candidate pool.
+
+## Before writing
+
+1. Read the primary evidence in the originating repository. Prefer the exact issue, pull request, benchmark report, README evidence section, review, CI receipt, or current handoff over memory.
+2. Check whether an existing `work/` record already owns the story. Update or extend the existing record instead of creating duplicate descriptions.
+3. Separate current fact from interpretation. If exact status is uncertain, say so and leave a verification note rather than upgrading the claim.
+4. Look for the strongest technical meaning, not merely the most recognizable repository name.
+
+## What to record
+
+Record work when at least one of these is true:
+
+- a patch merged, published, or received meaningful maintainer acceptance;
+- a candidate is strongly validated and tells a technically distinctive story even before upstream submission;
+- a performance campaign produced a substantial measured result;
+- a product moved from internal code to something installable, usable, deployed, or externally observed;
+- an investigation found the real owner of a failure after a misleading first theory;
+- a negative result prevented an unsafe, incorrect, or low-value change;
+- a review interaction materially refined the repair boundary;
+- the work adds a new technical axis to the portfolio (compiler, VMM, runtime, browser tooling, distributed coordination, packaging, etc.);
+- the result would plausibly be useful in a resume, interview, portfolio, outreach note, or career narrative.
+
+Do not record typo fixes, mechanical churn, routine dependency updates, superficial activity totals, or speculative findings that never reached a useful evidence boundary.
+
+## Preserve reversals
+
+Do not sanitize the record into a sequence of uninterrupted wins.
+
+Some of the strongest evidence is a good reversal:
+
+- a tempting optimization measured too small and was dropped;
+- a benchmark theory was disproven by a better instrument;
+- a proposed repair belonged on the other side of an API or semantic boundary;
+- a test harness bypassed the actual product path and had to be corrected;
+- current upstream already fixed or superseded the candidate.
+
+Record what changed the conclusion and why the updated decision was better.
+
+## Resume candidate churn
+
+`resume-candidates.md` is intentionally editorial and may change often.
+
+Rank by marginal signal on a one-page resume, not by effort invested or emotional attachment. A fifth similar correctness fix can be excellent engineering and still add less resume value than a first strong compiler or systems example.
+
+Useful questions:
+
+- Does this prove something not already proven elsewhere on the page?
+- Is there external validation or a concrete measurable consequence?
+- Can a reader understand the technical point in one or two lines?
+- Is the story stronger than the item it would displace?
+- Is the claim defensible without a long status explanation?
+- Does this fit the target role (general, Vercel/devtools, Valve/performance, systems, product)?
+
+Never delete a durable record merely because it falls out of the current resume ranking.
+
+## Evidence links
+
+Use canonical direct GitHub links inside durable work records. If a Scrapbook pull-request body mentions third-party upstream work and a backlink would be noisy, follow the root repository policy and use `redirect.github.com` there.
+
+Where useful, link both the upstream surface and the richer owned evidence packet.
+
+## Voice
+
+Write plainly and technically. This is allowed to sound proud when the evidence is strong. Avoid generic praise such as "high-impact" or "complex" unless the following sentence explains the actual impact or complexity.
+
+Prefer:
+
+> Replaced SSH loss as a VM-shutdown proxy with the VMM's exact shutdown event before disk/VM reuse.
+
+over:
+
+> Made a high-impact contribution to a complex virtualization platform.
+
+## Pull requests
+
+Keep substantive updates on ordinary Scrapbook branches and pull requests. It is fine for multiple agents to collaborate on the same open work-record PR when the branch is current and the changes are coherent. If another PR lands first, rebase or resolve the markdown conflicts rather than discarding either record.
+
+The work record is low-risk documentation, but still inspect the complete diff before declaring it ready.

--- a/work/README.md
+++ b/work/README.md
@@ -1,0 +1,63 @@
+# Work
+
+This directory is Leo's living record of engineering work: shipped results, strong investigations, useful reversals, external validation, measurements, and stories that may later become resume, portfolio, interview, or outreach material.
+
+It is deliberately broader than a resume and narrower than a raw activity log.
+
+The source repositories remain authoritative for code, issues, pull requests, benchmarks, reviews, CI receipts, and product state. `work/` is a synthesis layer: it records what happened, why it matters, and how the evidence may be useful without pretending to replace the primary source.
+
+## Why this exists
+
+A one-page resume has to throw almost everything away. LinkedIn also flattens independent engineering into a poor imitation of employment history. Neither is a good place to remember the actual work.
+
+This directory keeps the larger record so that later resume work can select from evidence instead of reconstructing months of work from memory.
+
+The operating idea is simple:
+
+- record concrete work generously;
+- distinguish fact from interpretation;
+- preserve reversals and failed theories when they demonstrate useful judgment;
+- let resume rankings churn without rewriting history;
+- keep links to the canonical evidence;
+- do not manufacture impact merely because a repository name is recognizable.
+
+## Files
+
+- [`resume-candidates.md`](resume-candidates.md) — intentionally churny ranking of the strongest current resume material.
+- [`records/preflight.md`](records/preflight.md) — detailed Preflight performance/product evidence and candidate stories.
+- [`records/open-source.md`](records/open-source.md) — selected open-source engineering evidence and the larger bench.
+- [`archive/2026-08-11-signal-audit.md`](archive/2026-08-11-signal-audit.md) — first broad snapshot of the current body of work and the narrative it supports.
+- [`AGENTS.md`](AGENTS.md) — local instructions for agents updating this record.
+
+## What belongs here
+
+Good candidates include:
+
+- a shipped or accepted change with a concrete technical story;
+- a measured performance result with a defensible measurement boundary;
+- an investigation that materially changed the chosen design;
+- a negative result that prevented a wrong or unsafe change;
+- a maintainer interaction that demonstrates review judgment or repair-boundary understanding;
+- a product milestone that changes the external credibility of an independent project;
+- a strong cross-repository pattern that says something useful about Leo's engineering style.
+
+Not every PR, commit, issue, or experiment deserves an entry. Volume is evidence only when the individual work survives scrutiny.
+
+## Evidence language
+
+Prefer precise states over prestige language:
+
+- `merged` / `published` when that happened;
+- `maintainer-approved` when approval exists but merge is separate;
+- `submitted` when the upstream PR exists;
+- `validated candidate` when the implementation is proven in an owned carrier but not submitted;
+- `investigation` when the mechanism is established but the repair is not ready;
+- `superseded` or `negative result` when later evidence changed the conclusion.
+
+Do not silently turn an owned-fork candidate into an upstream contribution. Do not erase a useful result because it was not merged. The job is accurate signal, not bureaucratic scorekeeping.
+
+## Public posture
+
+This material is intentionally personal and can be candid about technical judgment. It should still be written so that a curious engineer, recruiter, or hiring manager could read it without needing private conversation context.
+
+The eventual public `/work` surface should be a readable projection of selected records, not a dump of every internal ranking note. The repository can remain more exhaustive than the site.

--- a/work/README.md
+++ b/work/README.md
@@ -60,4 +60,4 @@ Do not silently turn an owned-fork candidate into an upstream contribution. Do n
 
 This material is intentionally personal and can be candid about technical judgment. It should still be written so that a curious engineer, recruiter, or hiring manager could read it without needing private conversation context.
 
-The eventual public `/work` surface should be a readable projection of selected records, not a dump of every internal ranking note. The repository can remain more exhaustive than the site.
+The public `/work` surface is a readable projection of selected records, not a dump of every internal ranking note. Its typed selection lives in `lib/work-records.ts` and is available to human readers at `/work` and machine readers at `/api/work`. The repository remains more exhaustive than the site.

--- a/work/archive/2026-08-11-signal-audit.md
+++ b/work/archive/2026-08-11-signal-audit.md
@@ -1,0 +1,295 @@
+# Signal audit — 2026-08-11
+
+This is a broad snapshot, not a final biography or resume. It preserves the current interpretation of Leo's engineering record while the evidence is fresh.
+
+## Short version
+
+The conventional chronology understates the current technical record.
+
+A useful market description is:
+
+> Roughly three years of substantive software-engineering experience, with about sixteen months in conventional industry employment and roughly two years of independent/open-source/product engineering.
+
+The strongest technical pattern is not any single framework or domain. It is the ability and willingness to enter unfamiliar systems, identify the real behavioral boundary, build evidence that can falsify an attractive theory, and keep pursuing the problem until the result is defensible.
+
+The current portfolio spans:
+
+- a deeply instrumented Java/game performance product;
+- merged Rust VMM work;
+- merged/published TypeScript SDK correctness work;
+- Cloudflare tooling state/credential semantics;
+- compiler/minifier work in SWC;
+- broad developer-tool/runtime/Linux investigations;
+- hosted agent coordination infrastructure;
+- crash-safe disposable-runner infrastructure.
+
+The breadth matters because it makes "one lucky project" an increasingly poor explanation.
+
+## The central trait: pursuit
+
+A recurring pattern across the work:
+
+1. Find a behavior that looks wrong, slow, unsafe, or internally inconsistent.
+2. Map the owner instead of immediately patching the first visible symptom.
+3. Build a small discriminator or instrument that can separate competing explanations.
+4. Run the actual target path when the claim requires it.
+5. Reject or narrow the theory when the evidence does not support it.
+6. Preserve compatibility/failure behavior explicitly.
+7. Turn the surviving result into a small repair, product feature, benchmark, or upstream contribution.
+8. Continue one question deeper when the first improvement exposes a larger owner.
+
+This is visible in Preflight, Fieldwork, Linux Fieldwork, OSS reviews, and the owned systems.
+
+## Preflight as the flagship
+
+Preflight began from a concrete lived problem: heavily modded Starsector startup was painfully slow.
+
+It became a much broader engineering system:
+
+- Java agent / runtime transformation infrastructure;
+- exact source and class-loader identity;
+- bytecode-shape and method-contract gating;
+- JFR and custom seam timing;
+- automated launch/benchmark harnesses;
+- persistent prepared textures, audio, JSON/CSV/spec data, resource/provider indexes, and generated Janino class maps;
+- fail-open fallback to the original game/mod implementation;
+- mod-aware compatibility policy;
+- Tauri desktop host and CLI;
+- multi-platform packaging;
+- updater/rollback work;
+- bounded opt-in diagnostics and support intake.
+
+The current development branch records a 15.88s fresh-warm launch record on the reviewed 83-mod profile, with 42/42 transformed-class cache hits and all 15,469 prepared texture/pixel conversion hits active. Earlier accepted development states reached roughly 101s. Those are not yet the same release cohort, so a fresh same-profile release benchmark remains the clean public-delta gate.
+
+The project matters more than the headline number because of how the number was reached.
+
+### Examples of the pursuit loop
+
+An early prepared-pixel cache barely moved launch time. Instead of adding more caching, the investigation found the cache sat behind a roughly 27-second one-thread prefetch wait. Moving the intervention across that boundary turned the same work into a major accepted improvement.
+
+Log timestamps made graphics/texture work look enormous. A purpose-built seam timer and real LWJGL replay showed only about 1.15 seconds of actual driver upload time in the apparent block. That killed GL batching as the main plan.
+
+Directory-list caching removed syscalls but left surprising resolver time. Replaying the actual resource-walk corpus showed repeated `File(root, path)` construction/normalization itself consuming seconds across more than a million joins. The repair moved one level up to preserve root/path structure and avoid constructing the objects.
+
+That resolver optimization then exposed a compatibility mistake: string equality did not match case-insensitive filesystem behavior on macOS/Windows. The repair used the filesystem only for the narrow ambiguous folded-name case while keeping ordinary hits cheap.
+
+A prepared rule-command package map looked like it should remove most of a 600ms phase and saved only ~165ms. Investigation showed successful class loading dominated while failures were cheap. The same measurement exposed a larger 1.6-second cost in duplicated pre-JVM cache identity construction, which was then reduced to ~0.45s without weakening content hashing.
+
+An mtime/size digest memo was proposed and deliberately rejected after measurement showed only ~65ms incremental value once hashing was parallelized while weakening same-size content-change detection.
+
+Audio work rejected the obvious "increase the thread pool" approach because decode workers also touched OpenAL/shared state. The selected seam moved only pure decode work out of the timed launch and left runtime ownership unchanged.
+
+Generated Janino bytecode work treated a compilation request as a complete class-map/context identity rather than a bag of individual bytes. A live pilot reduced direct generated-code aggregate time from 18.014s to 2.364s with 228/228 warm hits and zero corruption/policy declines.
+
+The project repeatedly demonstrates a preference for *measured ownership* over cleverness.
+
+## Open source as external validation
+
+Preflight proves sustained independent depth. OSS proves the behavior survives unfamiliar ownership, language, and review culture.
+
+### Vercel AI SDK
+
+The cleanest current public receipt is a merged/published fix for global/sticky `RegExp.lastIndex` state leaking into repeated URL-support checks. The repair preserves caller state in `finally`, changes only stateful regex behavior, and carries focused regression coverage.
+
+The broader current AI SDK research bench now covers usage normalization, agent-harness permissions, bridge credentials, MCP/OpenCode/Pi lifecycle and resume semantics. Not all of it is upstream-submitted; its value is ongoing familiarity and the ability to keep finding bounded questions in a rapidly changing codebase.
+
+### Cloud Hypervisor
+
+Two Rust/VMM contributions have merged:
+
+- replace SSH loss as a shutdown-completion proxy with the VMM's exact shutdown event before VM/disk reuse;
+- replace ACPI table-construction panic paths with typed error propagation through VM boot.
+
+The second change involved address overflow, missing `fw_cfg`, guest-memory writes, delivery failure, architecture/feature build coverage, and explicit disclosure of what was not runtime-smoke-tested.
+
+Cloud Hypervisor is especially useful signal because its domain is so far from Preflight and AI SDK. The common factor is not subject-matter history; it is the process of finding and repairing state/lifecycle/error boundaries.
+
+### Cloudflare Workers SDK
+
+The current Access fix distinguishes current service-token credentials from interactive authorization state that is legitimately cached. It prevents removed/partial environment credentials from reusing an older complete service token while preserving interactive cookie reuse.
+
+Again the recurring theme is semantic ownership of state.
+
+### SWC
+
+Current submitted work preserves observable `instanceof` evaluation across optimizer/minifier paths. `instanceof` is not reducible to operand effects: `Symbol.hasInstance` is observable and invalid RHS values can throw. The candidate also removes unsafe operand-shape folds and updates relevant optimization expectations.
+
+If accepted upstream, this is high-value resume material because it adds a compiler/minifier axis rather than another similar SDK fix.
+
+### Zustand
+
+An independently developed `clearStorage()`/async rehydration candidate uses the existing hydration generation as publication authority: clearing advances the generation before storage removal, so delayed reads/migrations/callbacks lose authority while live state and later hydration remain valid.
+
+The current upstream #3555 uses the same one-line production repair with overlapping tests. Exact public attribution language should be verified before resume use; "co-author" is less useful than accurately describing independent development/reporting.
+
+### runc
+
+A good example of why the record should preserve non-merges.
+
+A real off-by-one relationship existed between `MaxCPU` semantics and an exclusive CPU-set constructor. The submitted repair changed the allocation side. A maintainer pointed out that repository history made the better repair changing `MaxCPU` meaning on the other side. Leo read the history, agreed, and closed the PR.
+
+That is not a resume win. It is strong evidence of review judgment and willingness to optimize for the correct repair rather than a personal merge statistic.
+
+## Fieldwork as a method, not a resume entry
+
+Fieldwork and Linux Fieldwork are research machinery. They should usually stay backstage.
+
+Their value is visible in the volume and quality of the surviving experiments:
+
+- Bat grapheme-aware wrapping;
+- Delta terminal-width bugs, including a true nontermination path;
+- `fd --exec-batch` declaration-order inversion under asymmetric argv pressure;
+- urllib3 content-decoding and Retry-After boundary semantics;
+- Serde Unicode camelCase derive behavior;
+- Rspack persistent-cache logical-key recovery;
+- BuildKit rootless/rootful reproducibility;
+- Bubblewrap PID/reaping/environment boundaries;
+- util-linux PTY wait behavior;
+- Tini startup races;
+- continued Cloud Hypervisor snapshot/cache/topology/Landlock work;
+- mmdebstrap/libarchive/filesystem/archive work;
+- many negative/superseded/overlap results.
+
+The system deliberately filters. Attractive issues can be dropped because another owner exists, a control disproves the theory, the target path cannot be executed, the proposed repair is too broad, or the payoff does not justify compatibility cost.
+
+The resume should show a handful of specimens. `/work`, GitHub, and interviews can reveal the natural-history museum behind them.
+
+## Stensibly
+
+Stensibly is a different kind of evidence: system invention rather than external repair.
+
+The core distinction is:
+
+> The board shows the work. The ledger governs who may do it.
+
+The hosted system separates responsibility from authority and stores shared coordination facts independently of any particular agent runtime. It spans Cloudflare Workers, Convex, REST, Streamable HTTP MCP, browser sessions and bearer clients.
+
+Implemented concepts include:
+
+- workspaces/projects/actors/items/events/artifacts;
+- durable claims and renewable/expiring leases;
+- handoff/block/release/completion flows;
+- idempotent writes;
+- scoped API tokens and browser sessions;
+- project/workspace boundaries;
+- guarded GitHub branch/file/PR publication with exact preconditions and durable reconciliation receipts;
+- ongoing dogfood around worker identity, callsigns, OAuth/MCP connection evidence and hosted provider boundaries.
+
+For a one-page general resume, this likely deserves one dense line. Its full value appears when discussing agent infrastructure, durable coordination, and the user's unusual high-concurrency LLM working style.
+
+## SmolRunner
+
+SmolRunner is also system invention, but around failure and destructive authority.
+
+The product thesis is intentionally narrow:
+
+- GitHub remains workflow scheduler/status/log store;
+- Lima/VZ remains the VM primitive;
+- the official Actions runner remains the runner protocol;
+- SmolRunner owns admission, exact worker/template identity, durable lifecycle, recovery, and safe cleanup.
+
+Current Rust foundations include:
+
+- durable attempt/catalog state;
+- capacity/resource admission;
+- exact template and runner supply-chain identities;
+- sealed/non-freeform command plans;
+- crash-safe checkpoints before external mutation;
+- clone authorization/start separation;
+- explicit handling of ambiguous/incomplete clones;
+- fail-closed ownership/adoption/deletion rules;
+- recovery and restart-at-checkpoint tests;
+- bounded subprocess and filesystem-state machinery inherited from earlier host-reconciliation work.
+
+It remains pre-alpha and does not yet provide the complete unattended JIT runner loop. That nonclaim is important.
+
+Resume value: one dense systems line for infra/systems roles, optional elsewhere.
+
+## Career interpretation
+
+### What conventional chronology says
+
+- University of Toronto graduate in 2024.
+- About sixteen months at IBM as a software developer intern.
+- Little/no conventional salaried post-graduate full-time SWE tenure.
+
+### What the engineering record says
+
+- roughly two additional years of sustained independent/product/open-source engineering;
+- public artifacts across multiple languages/domains;
+- external maintainer review and merged upstream work;
+- owned systems with substantial correctness/recovery/performance depth;
+- a flagship performance product being moved toward external users;
+- unusually high codebase-entry velocity assisted by heavy LLM orchestration but bounded by human steering, source reading, tests, review and selection.
+
+Calling this "0 YOE" makes the chronology legible by destroying the engineering reality.
+
+Calling it "3 years of software engineering experience" is defensible when the question is ordinary engineering experience. It should not be silently expanded into "3 years of full-time professional post-grad employment."
+
+## What the resume needs to accomplish
+
+A recruiter can easily bucket the chronology as early-career. A technical reader may infer much more advanced capability from the evidence.
+
+The resume has to resolve that mismatch quickly rather than hide it.
+
+Recommended general hierarchy:
+
+1. Selected Open-Source Engineering.
+2. Independent Engineering, with Preflight dominant.
+3. Compact IBM experience.
+4. Education.
+5. Boring skills.
+
+The page should not try to make the candidate look conventional. It should make the unconventional shape **easy to understand and easy to verify**.
+
+## Target-specific interpretation
+
+### Vercel/devtools
+
+Lead with AI SDK and other developer-tool/runtime OSS. Stensibly gains relevance because it is a live MCP/agent coordination system. Preflight proves the ability generalizes beyond TypeScript/AI SDK.
+
+The cold application is rational because accepted work already exists in Vercel-owned source. That is supporting evidence, not entitlement.
+
+### Valve/game/runtime/performance
+
+Preflight should dominate. Its game/runtime relevance is unusually direct:
+
+- obfuscated runtime instrumentation;
+- Java bytecode transformation;
+- generated-code caching;
+- graphics/audio/resource investigation;
+- JIT/Rosetta/platform behavior;
+- mod compatibility;
+- desktop packaging/updating/diagnostics;
+- gameplay pilots.
+
+Cloud Hypervisor and systems Fieldwork then show the depth is not confined to one game.
+
+### Systems/infra
+
+Cloud Hypervisor, BuildKit/Linux Fieldwork, Preflight runtime engineering and SmolRunner rise. Web-specific correctness examples shrink.
+
+## Current strongest narrative
+
+A hard-selling but defensible description is:
+
+> Leo has an unusually strong appetite for technical pursuit. He can enter a codebase with little accumulated familiarity, locate ownership boundaries across lifecycle/state/performance behavior, design experiments that can falsify his own theory, and keep going until he has either a narrow repair or a principled reason not to ship one. Preflight shows that behavior sustained over one large owned system; recent OSS shows it survives changes from TypeScript SDKs to Rust VMMs, compiler optimizers, Linux runtimes, browser/build tooling, and state libraries.
+
+The code generation/AI assistance is part of the throughput story, not a reason to erase the engineering. The scarce activity is increasingly judgment over the machine: what to investigate, what evidence is sufficient, which repair boundary is correct, what not to ship, how to test it, and when to change course.
+
+## Near-term actions
+
+- Ship/release Preflight rather than waiting for perfect completion.
+- Run the fresh same-cohort release benchmark and collect opt-in real-user diagnostics.
+- Finish the resume around selected specimens, not the full activity history.
+- Cold apply now, including Vercel and other technically legible targets.
+- Treat Valve as a serious target, with a Preflight-heavy cut.
+- Continue OSS because it is useful/fun/educational, but stop waiting for a magic PR count before applications/outreach.
+- Use maintainer and contributor relationships socially when appropriate.
+- Keep algorithm/interview preparation running in parallel so strong pipelines are not lost at the conversion stage.
+
+## Closing note
+
+The current problem is not lack of evidence.
+
+It is selection, legibility, release, and conversion.

--- a/work/records/open-source.md
+++ b/work/records/open-source.md
@@ -1,0 +1,239 @@
+# Open-source engineering
+
+This file records the strongest current open-source work plus the larger bench. It is not a commit-count leaderboard.
+
+The useful claim is repeatability across unrelated systems: enter an unfamiliar codebase, isolate a real correctness/performance/lifecycle boundary, build a discriminating test, propose a narrow repair, and respond well to review or contrary evidence.
+
+## Current strongest external validation
+
+### Vercel AI SDK — deterministic URL-regex evaluation
+
+Upstream PR: https://github.com/vercel/ai/pull/18570
+
+State: **merged and published**.
+
+`isUrlSupported()` evaluated configured URL patterns with `RegExp.test()`. Global and sticky regexes retain state in `lastIndex`, so identical support checks could depend on previous calls and mutate caller-owned state.
+
+The repair:
+
+- keeps ordinary regexes on the direct path;
+- evaluates global/sticky patterns from index zero;
+- restores the caller's original `lastIndex` in `finally`;
+- covers repeated calls, global/sticky behavior, nonzero caller state, mismatches, throwing custom execution, and frozen ordinary regexes.
+
+The upstream bugfix review called the change fully addressing, low-risk, minimal-scope, and appropriately tested; human review approved it and the patch was published.
+
+Resume signal: **lock** for Vercel/devtools and strong general-purpose OSS evidence. It is compact, externally validated, and demonstrates subtle shared-state/API correctness.
+
+### Cloud Hypervisor — exact shutdown lifecycle gates
+
+Upstream PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8699
+
+State: **merged**.
+
+The API lifecycle tests treated loss of SSH as proof that guest shutdown had completed. `sshd` can disappear while guest/VMM cleanup is still progressing, yet the tests immediately reused the VM/disk.
+
+The repair starts the VMM with `--no-shutdown` plus an event monitor, powers off the guest normally, then waits for the VMM's exact `shutdown` event before boot or delete/create reuse.
+
+The upstream review involved small cleanup/squash requests, then approval and merge.
+
+Resume signal: **lock**. Strong lifecycle/concurrency correctness story in a real Rust VMM.
+
+### Cloud Hypervisor — propagate ACPI construction failures
+
+Upstream PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8709
+
+State: **merged**.
+
+Several ACPI construction paths used `unwrap()`/`expect()`, allowing address overflow, missing `fw_cfg`, guest-memory write failure, or delivery failures to panic the VMM.
+
+The repair introduced a typed ACPI error path and propagated failure through VM boot (`CreatingAcpiTables`) instead of panicking. It also consolidated checked table-address arithmetic and moved fixed SRAT structure-size checks to compile-time assertions.
+
+Validation covered nightly rustfmt, VMM Clippy with warnings denied, x86_64 KVM/MSHV, fw_cfg, TDX, AArch64 KVM/MSHV, and the repository's RISC-V KVM build. The PR explicitly disclosed that a VM boot smoke test was not run for that change.
+
+Resume signal: best paired with the lifecycle PR as one Cloud Hypervisor entry rather than spending two headings.
+
+### Cloudflare Workers SDK — current credentials vs cached authorization state
+
+Upstream PR: https://github.com/cloudflare/workers-sdk/pull/15080
+
+State: **open; Wrangler codeowner approval present; changesets prepared** at the current audit.
+
+`getAccessHeaders()` cached Access service-token headers by domain. If the environment later removed or partially changed the client ID/secret, the same domain could reuse stale complete credentials.
+
+The repair returns service-token headers from the current environment and leaves interactive `CF_Authorization` cookie caching intact. Regressions cover unsetting either/both service-token variables and preservation of legitimate interactive-cookie reuse.
+
+Resume signal: **strong**. Good state/credential-semantics example; status should be refreshed before final wording.
+
+## Vercel AI SDK — wider current bench
+
+The merged regex change is only the cleanest public receipt. Current Fieldwork/owned-fork work also covers multiple AI SDK integration/lifecycle boundaries.
+
+### OpenAI-compatible usage consistency
+
+Owned clean candidate: `teamleaderleo/ai#78`.
+
+Some OpenAI-compatible providers can report internally inconsistent counters (for example reasoning tokens exceeding completion tokens while raw total is consistent with prompt + reasoning). Current normalization can publish an output total smaller than the reasoning detail.
+
+The selected candidate uses a conservative envelope over completion, reasoning, and `total - prompt` evidence while preserving literal provider counters in `raw`.
+
+Exact-head execution covered OpenAI-compatible Node/Edge tests and Baseten Node/Edge tests with generated expectation fences.
+
+Status: validated owned candidate, not public upstream contribution at this audit.
+
+Signal: technically good, especially for a Vercel conversation; avoid presenting as merged upstream unless that later happens.
+
+### Claude built-in permission-kind parity
+
+Fieldwork found drift between the public Claude built-in tool catalog and the sandbox bridge's separate permission-kind representation. One concrete example: public metadata classifies PowerShell as bash-like while the bridge can fall through through an edit-class default, changing approval behavior under `allow-edits`.
+
+Work expanded into a mechanical public-catalog-to-bridge parity matrix plus unknown-native and external-MCP compatibility discriminators.
+
+Status: owned research/candidates with target execution, not necessarily upstream submission.
+
+Signal: strong interview/outreach evidence about capability/authority boundaries; probably too much status explanation for the general resume.
+
+### Harness bridge credential boundaries
+
+Fieldwork traced bridge-control token/port environment into downstream agent/CLI process environments across harness adapters and built focused owned-fork candidates/discriminators around keeping bridge authority private while preserving ordinary caller/provider environment.
+
+Signal: useful for Vercel-specific conversations, but security wording should stay proportional to demonstrated evidence.
+
+### Pi/OpenCode/MCP lifecycle findings
+
+Current research includes inline-extension failure visibility, project-local OpenCode plugin/MCP startup boundaries, bridge-token resume semantics, and related lifecycle/permission compatibility questions.
+
+Signal: demonstrates continuing familiarity with the AI SDK harness codebase. Do not turn every finding into a resume line.
+
+## SWC
+
+Upstream PR: https://github.com/swc-project/swc/pull/12110
+
+Current state at audit: submitted/draft-style current work; human approval not yet established.
+
+The optimizer/minifier can treat `instanceof` as though preserving operand effects is enough when the result is unused. But the operation itself can be observable through `Symbol.hasInstance` and can throw for an invalid RHS. Existing operand-shape folds can also return the wrong boolean for cases such as null-prototype objects.
+
+The candidate preserves complete `instanceof` evaluation where shared effect analysis/minification/dead-branch cleanup would otherwise keep only operand effects, removes unsafe operand-shape folds, adds SWC-owned regressions, and runs relevant formatting, Clippy, utility, optimization and minifier suites.
+
+Signal: **high upside** because it adds a compiler/minifier axis to the portfolio. Promote quickly if maintainers accept the direction. Until then, bullpen rather than headline resume claim.
+
+## Zustand
+
+Owned Fieldwork record: clear-storage hydration generation race.
+
+The persist middleware already used a `hydrationVersion` generation to prevent stale concurrent hydration publication, but `clearStorage()` did not advance the generation. A delayed read or migration could therefore publish state and lifecycle callbacks after the caller had cleared persisted storage.
+
+The independently developed candidate adds `++hydrationVersion` before `removeItem()` and validates delayed read/migration, synchronous removal failure, live-state preservation, stale callback suppression, `hasHydrated()` behavior, and later successful hydration.
+
+Current upstream PR #3555 uses the same one-line production change and substantively overlapping tests.
+
+Attribution/issue linkage should be rechecked before a public resume sentence. Avoid the ambiguous term `co-author` unless GitHub/upstream metadata supports it directly. Safer eventual wording if evidence remains as understood:
+
+> Reported/investigated an async persist hydration race and developed the generation-invalidation repair subsequently implemented upstream.
+
+Signal: excellent mechanism, lower marginal resume value once AI SDK/Cloud Hypervisor already prove correctness work.
+
+## Vite
+
+Current submitted work has covered three bounded correctness/lifecycle areas:
+
+- repeated config-resolution idempotence;
+- cleanup of temporary Rolldown optimizer-analysis bundles;
+- `closeBundle(error)` semantics after `buildEnd` failure.
+
+Signal: strong recognizable build-tooling work, but crowded by newer examples. Keep in bench unless one develops particularly strong maintainer acceptance/merge or a target role values Vite specifically.
+
+## BuildKit
+
+Linux Fieldwork has an end-to-end-proven rootless/rootful reproducibility candidate on the runc/native path.
+
+The investigation reproduced a rootful/rootless filesystem divergence involving runtime-created `/proc`/`/sys` mountpoint stubs. Pre-creating the mountpoints made the control converge. The candidate reuses BuildKit's existing mount-stub ownership cleanup against the finalized OCI spec after rootless conversion; focused ownership tests, candidate builds, matching workers, and parity controls passed. Live containerd-worker/runtime coverage remained a scope caveat at the recorded boundary.
+
+Signal: deep systems proof. Strong bench item; could replace a web-tooling item on a systems-focused resume.
+
+## runc — useful reversal, not resume headline
+
+Upstream issue/PR: https://github.com/opencontainers/runc/issues/5388 / https://github.com/opencontainers/runc/pull/5389
+
+A boundary mismatch between inclusive `configs.MaxCPU` meaning and exclusive `unix.NewCPUSet()` sizing produced an off-by-one reset mask. A patch changed the allocation to `MaxCPU + 1` and added a boundary regression.
+
+The maintainer preferred repairing the historical meaning of `MaxCPU` on the other side (PR #5392). After reviewing that history, Leo agreed and closed #5389.
+
+Signal: **great interview story, low resume value**. It demonstrates recognizing a real symptom, accepting a better repair boundary, and not optimizing for personal merge count.
+
+## Bat — grapheme-aware character wrapping
+
+Fieldwork reproduced Bat's `--wrap=character` path splitting one extended grapheme cluster at narrow width because the active printer iterated Unicode scalars.
+
+An early execution accidentally selected the simple printer and therefore bypassed the target owner. The harness was corrected to force the real `InteractivePrinter` path. The validated candidate then preserved grapheme boundaries for ZWJ emoji, combining accents, Telugu, and wide characters while keeping ASCII word-wrap and show-all controls byte-identical. Full library tests passed in the owned carrier.
+
+Signal: excellent investigation-quality example, especially because the harness itself was corrected. Resume bench unless upstream submission/merge creates stronger external validation.
+
+## Delta — terminal display width and progress
+
+Fieldwork reproduced a particularly clean bug: Delta's wrap-symbol validator accepted a one-grapheme but two-column symbol, while the wrapping algorithm budgeted only one column. Under a narrow width and unlimited wrapping, the marker consumed all text capacity and the loop requeued the same text indefinitely.
+
+The exact internal owner and built CLI both reproduced the nontermination against a control.
+
+A second finding covered line-number format metadata using grapheme count where terminal display width was required, producing side-by-side layout truncation.
+
+Signal: delightful interview/portfolio material. It proves ability to turn Unicode/display semantics into an executable end-user failure. Not currently scarce enough for the general one-page resume.
+
+## fd — independent batch builders crossing declaration order
+
+Exact target internals and the built public CLI reproduced repeated `--exec-batch` commands crossing declaration order when a later command hit its argv-size ceiling before an earlier one. A one-thread control preserved `1,2`; asymmetric pressure produced `2,1,2`.
+
+Signal: strong concurrency/scheduling semantics example, but likely portfolio/Fieldwork rather than resume.
+
+## urllib3
+
+Current exact-target work includes:
+
+- mixed `Content-Encoding` chains where an unknown coding can be interpreted through the deflate fallback even though a lone unknown coding stays opaque;
+- `Retry-After: 0` parsing to zero and then being treated like header absence so exponential backoff is applied.
+
+Candidate work includes focused controls and Python 3.12/3.14 execution. One Retry-After lane has adjacent live upstream overlap and is appropriately held rather than racing an existing owner.
+
+Signal: good foundational-library breadth and evidence of overlap discipline.
+
+## Serde
+
+Current research isolates Unicode `camelCase` derive handling that byte-slices the first byte for field/variant rename paths. The candidate keeps the repair bounded to the first Unicode scalar and tests CJK, accented Latin, Greek, expansion behavior, and existing ASCII cases.
+
+Signal: strong Rust/library breadth if fully target-executed/upstreamed; currently bench.
+
+## Rspack
+
+Current research traces persistent minimize-cache recovery where physical pack integrity does not itself establish the semantic logical-key ↔ serialized minimized-artifact binding. The owned candidate embeds the logical key in the serialized entry and rejects mismatches so the ordinary cache-miss path recomputes the asset.
+
+Signal: strong cache-integrity/recovery story, currently owned-fork/testbed rather than external contribution.
+
+## Bubblewrap / util-linux / Tini / other Linux Fieldwork
+
+The Linux research bench contains multiple substantial lifecycle/system investigations, including:
+
+- Bubblewrap `--unshare-pid` helper zombie/reaping behavior;
+- Bubblewrap PID 1 environment representation after clear/unset/set transformations;
+- util-linux `script(1)` WNOHANG child-wait spin/wildcard-wait widening;
+- Tini startup signal/parent-death races;
+- systemd-nspawn teardown/signal boundaries;
+- mmdebstrap packaging/runtime candidates;
+- libarchive/archive metadata/streaming candidates;
+- additional Cloud Hypervisor snapshot/cache/topology/Landlock follow-ons.
+
+Do not list these as a logo parade. Their value is that the systems bench is deep enough that Cloud Hypervisor is clearly not an isolated lucky merge.
+
+## Current resume-selection principle
+
+The OSS section should usually show **four or five specimens**, not every repository.
+
+A good general mix at this audit is:
+
+1. Vercel AI SDK — merged/published, subtle TypeScript/runtime state correctness.
+2. Cloud Hypervisor — two merged Rust/VMM lifecycle/error-propagation changes.
+3. Cloudflare Workers SDK — current credential/caching semantics, accepted codeowner gate.
+4. SWC if accepted — compiler/minifier observability; otherwise Vite or a role-specific alternative.
+
+Then let GitHub/`/work` reveal the much larger collection.
+
+The marginal question is no longer "can Leo contribute to unfamiliar repositories?" The stronger question is which examples best demonstrate that the capability survives changes in language, domain, lifecycle, and abstraction level.

--- a/work/records/preflight.md
+++ b/work/records/preflight.md
@@ -1,0 +1,285 @@
+# Preflight
+
+Primary repository: https://github.com/teamleaderleo/preflight
+
+Preflight is the strongest current independent-engineering story because it combines deep investigation, runtime modification, performance engineering, compatibility design, benchmarking, packaging, and a path to real users.
+
+This record intentionally stores more detail than any one-page resume should use.
+
+## Current headline
+
+The current development branch records an 83-mod Starsector 0.98a-RC8 profile reaching the main menu in:
+
+- 16.66s cold;
+- 16.28s warm;
+- **15.88s fresh-warm record**.
+
+At the 15.88s record, the run retained:
+
+- 42/42 transformed-class cache hits;
+- all 15,469 prepared texture/pixel-conversion hits;
+- active adapter health;
+- zero adapter declines or contained failures.
+
+The development installation began around an 88.13s controlled median and earlier accepted development launches reached roughly 101s. Those endpoints come from different development stages/profile states, so **101s → 15.88s is an observed progression, not yet the clean same-cohort release benchmark**. A fresh release-candidate cohort is still required for the public before/after claim.
+
+Canonical current packet: https://github.com/teamleaderleo/preflight/pull/322
+
+Older main-branch documentation still contains earlier accepted campaigns such as 80.09s → 42.36s. Treat those as historical waypoints, not the current headline.
+
+## Why the project is technically interesting
+
+Preflight does not replace Starsector's live object model or edit the installation. It prepares deterministic work before launch and intercepts only exact runtime seams whose source identity and bytecode contract are known.
+
+Behavioral adapters pin combinations of:
+
+- game/mod archive or source identity;
+- class bytes / class signature;
+- class loader;
+- method descriptors and expected bytecode shape;
+- cache/input policy identity.
+
+A changed or unsupported build declines the optimization and runs the original implementation. Runtime transformations happen only in the child JVM's memory.
+
+This turns performance work into a compatibility problem: every shortcut has to answer both "is this work expensive?" and "what exact evidence makes reusing its answer valid?"
+
+## Investigation stories
+
+### The cache that sat behind a 27-second wait
+
+An early prepared-pixel cache was technically valid but improved startup by only about 1.5%, despite profiles suggesting texture work was far larger.
+
+Instead of assuming the cache implementation was too slow, the project added a critical-path discriminator. The loading thread was spending roughly **27 seconds waiting on a one-thread prefetch queue before the cache could help**.
+
+Moving the intervention to the correct side of that wait turned essentially the same prepared work into the accepted ~29% startup campaign.
+
+This is a strong story because the first implementation was not discarded for being "bad"; measurement showed it was placed behind the real critical-path owner.
+
+### The graphics-driver bottleneck that was not a graphics-driver bottleneck
+
+Log-gap attribution made the texture block look like roughly 13–18 seconds of graphics work.
+
+Preflight built `SeamTimer` to measure entry→exit and exit→next-entry on the actual resource seam instead of charging silent intervals to whichever logger ran last.
+
+On a representative run the seam showed more than 21,000 texture calls and exposed long between-call gaps that contained no texture work. A separate replay through the game's own LWJGL path showed the launch's texture uploads consumed only about **1.15 seconds of graphics-driver time**.
+
+That result killed attractive plans around GL batching and reframed power-of-two padding as primarily a memory/VRAM concern instead of the big startup-time prize.
+
+The instrumentation was built to permit the hypothesis to lose.
+
+### The filesystem syscall that was mostly path construction
+
+Resource resolution walked up to 84 mod roots. A launch could perform well over a million root/path combinations.
+
+After caching directory listings, substantial time remained. Replay isolated approximately **2.393 seconds in repeated `new File(root, path)` construction/normalization alone** across 1,185,072 joins, with less time in the actual remembered-listing lookup and syscalls.
+
+The final intervention moved one level up, where root and relative path were still separate, allowing direct indexed lookup without repeatedly constructing normalized `File` objects.
+
+### The optimization that broke case-insensitive filesystem semantics
+
+A remembered-directory lookup initially compared filenames as strings. That made valid Starsector resources disappear on normal case-insensitive macOS/Windows filesystems when the requested spelling differed from the stored spelling.
+
+The correction preserved exact hits and exact misses cheaply, but delegated the narrow folded-name ambiguity back to `File.exists()`, the filesystem authority for that mount.
+
+The measured profile required the expensive ambiguity check for only a tiny number of probes while restoring parity with the game's real resolver.
+
+### The 600ms-looking command cache that saved ~165ms
+
+Rule-command lookup walked a declared package list until `Class.forName()`/instantiation found a winner. It looked like hundreds of milliseconds of failed classpath search.
+
+A prepared package map removed most of those probes but recovered only about **165ms**. Measurement showed the successful class load/verification/initialization dominated; failures were cheap.
+
+The same investigation exposed a larger cost outside the game: six independent prepared-artifact caches were rebuilding overlapping dependency identities before the JVM launched.
+
+That led to a shared identity pass reducing launcher-side identity work from **1,612.6ms to 451.6ms** while keeping all six resulting identities byte-identical.
+
+### The digest memo that was deliberately not built
+
+A per-file hash memo keyed by path/size/mtime looked like an obvious next optimization.
+
+After parallelization, measuring first showed the memo was worth only about **65ms**, while weakening detection of same-size content changes. The project kept full content hashing and removed duplicated passes instead.
+
+Useful interview story: optimization was rejected because the speed/safety trade did not clear the bar.
+
+### Audio: move pure decode, not unsafe shared state
+
+The game decoded roughly 2,099 Ogg Vorbis assets (about 140.7 MB encoded, 1.23 GB PCM) through a two-thread pool. The main thread eventually blocked waiting for the workers.
+
+Widening the pool was rejected because each task also touched OpenAL and an unsynchronized map.
+
+Preflight instead isolated the pure decoder seam, prepared exact decoded results outside the timed launch, and left the game's OpenAL ownership and worker topology intact.
+
+The prepared cache keys the exact encoded input/decoder policy and falls through to the original decoder when evidence does not match.
+
+### Janino generated bytecode
+
+Starsector/mod startup generates Java classes through Janino. Preflight built a complete generated-class-map cache rather than treating individual class bytes independently.
+
+The context identity covers compiler/version inputs, ordered source/archive inputs, classpath, JVM modules, parent loader, debug settings, and protection-domain policy.
+
+A live 89-mod pilot reported:
+
+- cold: 228 misses/stores, 18.014s direct aggregate;
+- warm: 228 hits, 2.364s direct aggregate;
+- **15.650s / 86.9% reduction in direct aggregate generation time**;
+- zero errors, corruptions, or policy declines in the measured pair.
+
+Whole-launch movement in that pilot was smaller, which is itself useful: direct component savings and critical-path launch savings are kept conceptually separate.
+
+Canonical packet: https://github.com/teamleaderleo/preflight/pull/319
+
+## Metrics bank
+
+Use only metrics whose measurement boundary fits the claim being made.
+
+### Current / headline candidates
+
+- 15.88s current fresh-warm record on the reviewed 83-mod development profile.
+- 42/42 transformed-class cache hits on that record.
+- 15,469/15,469 prepared texture/pixel conversion hits on that record.
+- Early accepted development launches reached roughly 101s, but not in the same final release cohort.
+
+### Historical composed campaign
+
+An earlier main-branch campaign measured:
+
+- 80.09s baseline;
+- 42.36s full Preflight;
+- 37.74s removed / 47.1%;
+- 1.89× overall.
+
+Fifteen unattended launches were run: five per condition, conditions interleaved each round, all accepted.
+
+This remains good evidence for benchmarking discipline, even though it is no longer the fastest/current build.
+
+### Repeated work
+
+Historical measured scorecards include approximately:
+
+- 64,739 direct cache or memo hits;
+- 192,089 operations removed or shortcut;
+- 50,879 texture prefetch enqueues skipped;
+- 64,956 image decode/pixel conversion/color calculations bypassed;
+- 11,690 merged spec values served;
+- 30,726 rule tokenizations memoized;
+- 21,059 repeated duplicate scans replaced by hash checks;
+- 671 command-package resolutions prepared;
+- 12,103 real-path resolutions avoided.
+
+These numbers are useful as texture, not as a resume-number wall.
+
+### Resource / memory
+
+Historical texture work reduced upload volume from approximately:
+
+- 3.65 GiB → 2.43 GiB;
+- **1.22 GiB of empty power-of-two padding removed**.
+
+### Loader examples
+
+Historical isolated loader measurements include:
+
+- merged variant JSON: 10.15× faster merge/parse;
+- weapon data: 3.34× faster loader;
+- projectile data: 2.34× faster loader;
+- ship hull data: 3.52× faster loader;
+- shared cache-profile identity: 1.613s → 0.452s / 3.57×;
+- AshLib callback work reduced by multiple seconds;
+- GraphicsLib compact replay reduced a measured callback by multiple seconds.
+
+Do not combine isolated component multipliers as if they were independent end-to-end speedups.
+
+## Runtime / bytecode engineering bank
+
+Potential resume language can draw from:
+
+- Java instrumentation agent and `ClassFileTransformer` path;
+- exact source/class-loader/bytecode-shape gates;
+- preserving untouched original implementations as fallback;
+- generated Janino bytecode-map persistence and exact context identity;
+- ASM-style transformation plans against obfuscated game/mod classes;
+- JFR collection and attribution;
+- seam-level timing and exact critical-path probes;
+- adapter health reporting after each run;
+- source-history/boundary audits across thousands of blobs/files.
+
+The important point is not "used bytecode" as jargon. It is that Preflight safely intervenes in code it does not own while explicitly defining when the intervention is valid and when it must decline.
+
+## Productization bank
+
+Current work has crossed beyond a benchmark harness.
+
+The development branch includes:
+
+- CLI plus Tauri desktop host;
+- Launch, Prepare, Profiles, Storage, diagnostics, and tracked launch flows;
+- macOS arm64 DMG;
+- Windows x64 NSIS;
+- Linux x64 Debian and AppImage packages;
+- bundled minimal Java runtime;
+- checksum manifests;
+- update signing pipeline and isolated update/rollback tests;
+- explicit settings write boundaries and backups;
+- support ZIP generation with bounded allowlists/size limits/redaction;
+- opt-in diagnostics intake through a hostile-input-validating Worker and private R2 retention/deletion flow;
+- gameplay pilots across startup, save loading, campaign navigation, simulator/refit, large combat, retreat, audio transitions, and shutdown.
+
+For career signal, this matters because it changes Preflight from "private performance experiment" toward "software distributed into uncontrolled user environments."
+
+## Mod linter / secondary evidence
+
+The same codebase contains read-only analysis tooling. Historical profiles found examples including:
+
+- progressive JPEGs decoding 8.75× slower through the game's ImageIO path;
+- avoidable texture/audio allocation;
+- duplicate/shadowed resources;
+- unused assets;
+- extension mismatches;
+- configuration placed where the game never reads it.
+
+This is probably portfolio/interview material rather than scarce resume space.
+
+## Strong resume story families
+
+The final resume should not try to fit every metric. Strong composite families are:
+
+### 1. Outcome + product
+
+Current launch record, scale of the mod profile, and distribution/productization.
+
+### 2. Runtime compatibility engineering
+
+Exact-gated Java-agent transformations, generated bytecode/data preparation, and original-path fallback under source drift.
+
+### 3. Investigation discipline
+
+Critical-path instrumentation repeatedly disproved attractive first theories and redirected effort to the true bottleneck: queue wait, resource walks/path construction, duplicated identity work, generated-code compilation, etc.
+
+A general resume can probably spend three dense bullets / roughly six lines here. A Valve/performance-oriented resume can spend more.
+
+## Candidate prose, intentionally overcomplete
+
+These are ingredients, not final resume bullets.
+
+- Built a Java-agent performance layer for an 80+ mod Starsector installation; current development builds reach the main menu in a 15.88s warm record while preserving exact source/bytecode compatibility gates and original runtime fallbacks.
+- Precompute and replay merged game/mod data, textures, audio, resource indexes, and Janino-generated class maps only when exact input/compiler/archive identities match; unsupported or changed builds automatically execute the original implementation.
+- Built JFR, seam-level timing, unattended A/B campaigns, loader probes, and exact replay harnesses that repeatedly overturned initial bottleneck theories and redirected optimization toward critical-path work rather than profiler/log volume.
+- Reduced Janino generated-class-map work 18.014s → 2.364s (86.9%) in a live 89-mod cold/warm pilot with 228/228 warm cache hits and zero corruption/policy declines.
+- Eliminated over a GiB of empty texture padding in a historical full load while preserving upload-ready pixels and original OpenGL ownership.
+- Reworked resource resolution after tracing more than a million root/path joins and discovering that path construction/normalization, not only filesystem syscalls, dominated the remaining resolver cost.
+- Shipped the engine behind a Tauri desktop app with multi-platform beta artifacts, signed-update/rollback machinery, opt-in bounded diagnostics, and explicit fail-safe compatibility reporting.
+
+## Open verification / release notes
+
+Before using a clean percentage such as "84% faster" publicly, run the fresh release-candidate same-profile before/after cohort and record:
+
+- exact game build;
+- exact enabled-mod profile/order;
+- machine/hardware;
+- cold/warm definition;
+- sample count and interleaving;
+- baseline and optimized distribution;
+- accepted/rejected run rules;
+- adapter health / activation evidence.
+
+The 15.88s current record is already a legitimate current-performance fact. The fresh cohort determines the clean release delta.

--- a/work/resume-candidates.md
+++ b/work/resume-candidates.md
@@ -1,0 +1,252 @@
+# Resume candidates
+
+This file is intentionally churny. It answers: **if Leo had to ship a one-page resume today, which evidence earns the space?**
+
+The ranking should change as work lands, products ship, users appear, and target roles change. Falling out of this file does not make work less real; it means the marginal signal is weaker than something else competing for the same line.
+
+## Current market framing
+
+Working description:
+
+> Software engineer with roughly three years of substantive engineering experience: about sixteen months of conventional industry employment plus roughly two years of independent/open-source/product engineering.
+
+Avoid claiming three years of full-time post-graduate professional employment. Avoid calling the profile "0 YOE" when the question is ordinary software-engineering experience.
+
+The resume itself probably does not need a YOE headline. Let the chronology and evidence support the answer when asked.
+
+## General one-page cut — current recommendation
+
+### Header
+
+No summary paragraph unless a target application clearly benefits from one. Name, contact, GitHub, site, LinkedIn.
+
+Possible quiet descriptor if space remains useful:
+
+> Software Engineer — Runtimes, Developer Tools & Performance
+
+Do not over-specialize if the target role is generalist.
+
+### Selected Open-Source Engineering
+
+#### 1. Vercel AI SDK — lock
+
+Best current proof:
+
+- merged and published upstream;
+- subtle shared-state/API correctness;
+- human approval plus release receipt;
+- compact enough to understand quickly.
+
+Candidate bullet family:
+
+> Fixed nondeterministic global/sticky URL-regex evaluation in `@ai-sdk/provider-utils` by evaluating from index zero and restoring caller-owned `lastIndex`; added Node/Edge regressions covering repeated, mismatch and throw paths; merged and published upstream.
+
+Do not waste resume space saying "contributed to Vercel AI SDK." The mechanism is the signal.
+
+#### 2. Cloud Hypervisor — lock
+
+Combine the two merged changes into one entry. Together they show lifecycle and error-boundary work inside a Rust VMM.
+
+Candidate bullet family:
+
+> Landed two Cloud Hypervisor fixes: replaced SSH-loss shutdown proxies with the VMM's exact shutdown event before VM/disk reuse, and propagated ACPI address/`fw_cfg`/guest-memory failures through typed VM boot errors instead of panicking.
+
+A second line can mention validation breadth if the role is systems-heavy:
+
+> Validated the ACPI path across x86_64/AArch64 KVM/MSHV plus fw_cfg, TDX, Clippy and the repository's RISC-V build.
+
+For a general resume, the first line may be enough.
+
+#### 3. Cloudflare Workers SDK — strong current
+
+Candidate bullet family:
+
+> Fixed stale Cloudflare Access service-token headers surviving environment changes by separating current credential state from legitimately cached interactive authorization; added regressions for removed/partial credentials while preserving cookie reuse.
+
+Refresh exact merge/review status before final export. Do not imply merged if still open.
+
+#### 4. SWC — high-upside pending slot
+
+If maintainer review accepts the direction, this likely displaces Vite because it adds a compiler/minifier axis.
+
+Candidate bullet family:
+
+> Preserved observable `instanceof` evaluation across SWC optimizer/minifier paths where dead-result cleanup could discard `Symbol.hasInstance` calls or exceptions; removed unsafe operand-shape folds and added optimizer-owned regressions.
+
+Until human/upstream acceptance exists, keep in the bullpen rather than presenting it as equivalent to landed work.
+
+#### Bench / alternates
+
+- Vite correctness/lifecycle cluster — recognizable and solid; crowded by newer work.
+- Zustand hydration generation race — technically clean, lower marginal signal after AI SDK/Cloudflare; useful if upstream attribution becomes especially strong.
+- BuildKit rootless/rootful reproducibility — excellent for systems-specific applications.
+- Bat/Delta/fd/urllib3/Serde/Rspack — strong Fieldwork/portfolio/interview bench; promote selectively with upstream validation or target-role fit.
+- runc #5389 — interview story, not current resume headline.
+
+### Independent Engineering
+
+#### Preflight — absolute lock, largest allocation
+
+Do not compress Preflight into a single generic project bullet. It is the strongest owned-work proof and should receive roughly **three dense bullets / six-ish lines** in Leo's actual typography.
+
+Current story families:
+
+**Outcome / product**
+
+> Built a Java-agent performance layer for an 80+ mod Starsector installation; current development builds reach the main menu in a 15.88s warm record, with a fresh same-cohort release benchmark pending before publishing a final before/after percentage.
+
+Potential future replacement after release cohort:
+
+> Reduced 83-mod Starsector startup from X to Y across N interleaved release-candidate runs ...
+
+Use the fresh cohort, not mismatched development-stage endpoints, for the final public delta.
+
+**Runtime / compatibility**
+
+> Precompute and replay merged game/mod data, textures, audio, resource indexes and Janino-generated class maps through exact source/classloader/bytecode-shape gates; changed, corrupt or unsupported inputs automatically fall back to the original runtime path.
+
+**Investigation / performance**
+
+> Built JFR, seam-level timing and unattended A/B tooling that exposed critical-path bottlenecks hidden by logs/profilers—including a ~27s prefetch wait and million-scale resource-path walks—and repeatedly killed lower-value optimization theories before implementation.
+
+Possible role-specific swaps:
+
+- Janino direct aggregate 18.014s → 2.364s / 86.9%;
+- 1.22 GiB texture padding removed;
+- resource/path construction story;
+- audio predecode architecture;
+- Tauri/multi-platform packaging and opt-in diagnostics;
+- current 42/42 class-cache and 15,469 texture hit evidence.
+
+For Valve/performance roles, Preflight can consume more space and Stensibly can disappear.
+
+#### Stensibly — one dense line in general cut
+
+The useful distinction is not "made an MCP app." It is the responsibility/authority model and live hosted implementation.
+
+Candidate:
+
+> Built and operate a hosted human-agent responsibility/authority ledger across Cloudflare Workers, Convex, REST and MCP, with durable claims/leases, idempotent commands, scoped credentials and compare-and-swap GitHub publication.
+
+One line is probably enough unless the target is agent infrastructure/distributed coordination.
+
+#### SmolRunner — optional one dense line
+
+Candidate:
+
+> Building a Rust controller for disposable GitHub Actions workers on Lima, with pinned worker/template identity, durable no-replay lifecycle checkpoints, capacity admission, crash recovery and fail-closed VM ownership/cleanup.
+
+Good for systems/infra/security roles. For broad product roles it may lose the space to Glossless or disappear entirely.
+
+#### Glossless — role-specific
+
+Use for frontend/product/graphics roles. The project gives visual/product breadth and a concrete deployed surface that Stensibly/SmolRunner do not replace.
+
+Do not force it into every cut merely because it was historically a major resume project.
+
+### Industry Experience
+
+#### IBM — compact corroboration
+
+IBM proves conventional team/employer experience. It no longer needs to define the page.
+
+Likely one or two bullets:
+
+- Java E2E/integration work across IBM Cloud AI/ML/big-data paths with Kafka/Spark/Snowflake and hybrid/on-prem environments; critical RBAC issue coordinated across three teams.
+- Onboarding/setup reduced 3h → 15m through a consolidated maintained workflow/documentation path.
+
+Do not over-polish IBM into something more technically important than the current work. Its value is conventional production/team context.
+
+### Education
+
+One line near the bottom:
+
+> University of Toronto — BSc, Mathematics, Statistics & Computer Science — 2024
+
+### Skills
+
+Keep boring and compact.
+
+Current default candidate:
+
+> **Languages:** TypeScript/JavaScript, Rust, Java, Python, Go, SQL  
+> **Technologies:** Linux, React, Node.js, Cloudflare Workers, Docker, AWS, PostgreSQL, Git
+
+Tailor lightly by role.
+
+Do not put KVM/MSHV/fw_cfg/TDX in the generic skills line merely because Cloud Hypervisor validation touched them. Those details belong in the evidence that used them.
+
+## Target cut: Vercel / devtools / AI runtime
+
+Priority order:
+
+1. Vercel AI SDK.
+2. Cloud Hypervisor (proves range outside TS/AI).
+3. Cloudflare Workers SDK.
+4. SWC if accepted, otherwise best Vite/AI SDK current candidate.
+5. Preflight, but frame as runtime/instrumentation/performance rather than game fandom first.
+6. Stensibly gets one stronger line because agent coordination/MCP/hosted authority is relevant.
+7. SmolRunner only if space survives.
+
+Useful application thesis:
+
+> Already able to enter Vercel-owned code, understand lifecycle/state boundaries, and produce accepted fixes; independent work shows the ability generalizes beyond the codebase.
+
+Do not imply OSS creates entitlement to an interview. It makes a targeted cold application unusually well-supported.
+
+## Target cut: Valve / game/runtime/performance
+
+Priority order changes substantially:
+
+1. **Preflight dominates the page.** Give it the most acreage.
+2. Cloud Hypervisor.
+3. Best systems/compiler OSS specimens.
+4. SmolRunner may beat Stensibly because runtime/crash/recovery systems are more relevant.
+5. Glossless can appear if visual/graphics/product breadth helps.
+6. Web-library correctness examples are supporting evidence, not identity.
+
+Possible Preflight emphasis:
+
+- runtime instrumentation of an obfuscated game/mod ecosystem;
+- Java bytecode transformations;
+- JFR and critical-path performance work;
+- graphics/audio/resource-loader investigation;
+- generated code / Janino;
+- Rosetta/JIT/platform behavior;
+- mod compatibility and fail-open source drift;
+- real desktop packaging, updater/rollback, diagnostics and gameplay pilots.
+
+The pitch is not "Starsector modder." It is "engineer who cracked open a real game/mod runtime, built instrumentation around it, made it radically faster, and productized the result without owning the underlying source ecosystem."
+
+## Target cut: systems / infra
+
+Priority order:
+
+1. Cloud Hypervisor.
+2. BuildKit or another strong Linux Fieldwork candidate if externally validated.
+3. Preflight runtime/bytecode/performance.
+4. SmolRunner.
+5. Vercel AI SDK as cross-language correctness proof.
+6. Cloudflare as state/credential semantics.
+
+Stensibly becomes optional unless the role values distributed coordination.
+
+## What not to do
+
+- Do not make the page a logo wall.
+- Do not list every open PR to prove volume.
+- Do not over-index on "high impact" wording without a specific mechanism/result.
+- Do not call independent work freelance work unless client/service work actually happened.
+- Do not call the profile 0 YOE when the question is ordinary engineering experience.
+- Do not claim three years of conventional post-grad full-time employment.
+- Do not let IBM sit above the current work simply because it is an employer name.
+- Do not waste Preflight's acreage on a generic technology stack line.
+- Do not encode internal Fieldwork evidence levels into recruiter-facing prose unless they solve a real credibility question.
+
+## Current identity thesis
+
+The page should make a reader infer something close to:
+
+> Early-career chronology, roughly three years of substantive engineering activity, unusually strong evidence of entering unfamiliar systems and finding correctness/performance/lifecycle boundaries, plus one owned performance product deep enough to demonstrate sustained technical pursuit.
+
+The resume's job is to resolve the chronology/capability mismatch quickly enough that a human wants to ask about it.

--- a/work/resume-candidates.md
+++ b/work/resume-candidates.md
@@ -169,7 +169,7 @@ Keep boring and compact.
 
 Current default candidate:
 
-> **Languages:** TypeScript/JavaScript, Rust, Java, Python, Go, SQL  
+> **Languages:** TypeScript/JavaScript, Rust, Java, Python, Go, SQL
 > **Technologies:** Linux, React, Node.js, Cloudflare Workers, Docker, AWS, PostgreSQL, Git
 
 Tailor lightly by role.


### PR DESCRIPTION
## Purpose

Create a repository-backed synthesis layer for Leo's engineering work and publish a selective, readable `/work` projection from it. The source repositories remain authoritative; Scrapbook records what happened, why it matters, and where the evidence lives.

## Repository record

- `work/README.md` — purpose, evidence language, and public posture
- `work/AGENTS.md` — local rules for future agents updating the record
- `work/resume-candidates.md` — deliberately churny general/Vercel/Valve/systems ranking
- `work/records/preflight.md` — detailed performance, runtime, compatibility, measurement, and productization evidence
- `work/records/open-source.md` — strongest upstream receipts plus the larger bench
- `work/archive/2026-08-11-signal-audit.md` — broad snapshot of the current technical/career narrative

## Public surface

- `/work` — dense, responsive selected record using the homepage type system
- `/api/work` — typed read-only JSON projection for chats, agents, and connectors
- five selected records: Preflight, upstream repairs, Stensibly, SmolRunner, and Fieldwork
- concrete changes, useful reversals, statuses, and direct evidence instead of promotional copy or a logo wall
- Work added to primary navigation, the mobile room shelf, Site Atlas, and sitemap
- `/api/agent-access` and `/llms.txt` advertise the human and machine-readable Work surfaces

## Verification

- `pnpm ci:local --skip-install` — passed all 6 stages in 179.3s
  - lint (37 existing warnings, 0 errors)
  - typecheck
  - Vitest: 62 files / 393 tests
  - production build, including static `/work` and `/api/work`
  - diff check
  - Playwright Chromium: 134 passed / 7 live-data skips
- post-discovery update: focused ESLint, typecheck, 12 focused tests, production build, and diff check passed
- related navigation/work Chromium suite: 30/30 passed
- phone light and desktop dark visual review: no overflow, error overlay, console error, or duplicate main landmark

## Risk

Low and reversible. Repository and public-content changes only; no auth, private data, database, external write path, or production-control changes. The exhaustive record stays in Git while the page exposes only the selected typed projection.