### PR TITLE
Connect Desk essays to Journal evidence

### DIFF
--- a/app/api/agent-journal/route.test.ts
+++ b/app/api/agent-journal/route.test.ts
@@ -33,6 +33,15 @@ describe('GET /api/agent-journal', () => {
       '2026-07-26-agent-1-activity-cache',
       '2026-07-26-agent-2-preview-policy',
     ]);
+    expect(body.entries[0].related).toEqual([
+      expect.objectContaining({
+        surface: 'desk',
+        id: 'evaluation-structures',
+        relation: 'continues',
+        href: '/desk/evaluation-structures',
+      }),
+    ]);
+    expect(body.entries[2].related).toEqual([]);
   });
 
   it('does not expose internal approval recorder fields', async () => {

--- a/app/api/bot-desk/route.test.ts
+++ b/app/api/bot-desk/route.test.ts
@@ -72,6 +72,14 @@ describe('GET /api/bot-desk', () => {
       publicationState: 'Published',
       kind: 'Essay',
       revision: 1,
+      related: [
+        {
+          surface: 'journal',
+          id: '2026-08-10-evaluation-structures',
+          relation: 'evidence',
+          href: '/journal#journal-2026-08-10-evaluation-structures',
+        },
+      ],
     });
     expect(body.entries[3]).toMatchObject({
       direction: 'Agent-led',
@@ -83,6 +91,23 @@ describe('GET /api/bot-desk', () => {
         label: 'Retired Bot Desk archive',
       },
     });
+  });
+
+  it('exposes bounded related records with a full Desk document', async () => {
+    const response = await GET(
+      new Request(
+        'https://teamleaderleo.com/api/bot-desk?slug=evaluation-structures'
+      )
+    );
+    const body = await response.json();
+
+    expect(body.document.related).toEqual([
+      expect.objectContaining({
+        surface: 'journal',
+        id: '2026-08-10-evaluation-structures',
+        relation: 'evidence',
+      }),
+    ]);
   });
 
   it('returns a full Desk document for HTTP-only readers', async () => {

--- a/app/api/bot-desk/route.ts
+++ b/app/api/bot-desk/route.ts
@@ -1,5 +1,6 @@
 import { botDeskEntries, getBotDeskDocument } from '@/lib/bot-desk';
 import { REPOSITORY_PUBLIC_CACHE_CONTROL } from '@/lib/repository-public-cache';
+import { getRelatedScrapbookRefs } from '@/lib/scrapbook-relations';
 
 const responseOptions = {
   headers: {
@@ -50,6 +51,7 @@ export async function GET(request?: Request) {
           recovered: Boolean(document.recoveredFrom),
           recoveredFrom: document.recoveredFrom ?? null,
           href: `/desk/${document.slug}`,
+          related: getRelatedScrapbookRefs('desk', document.slug),
           content: document.content,
         },
         links: {
@@ -185,6 +187,7 @@ export async function GET(request?: Request) {
         recoveredFrom: entry.recoveredFrom ?? null,
         href: `/desk/${entry.slug}`,
         apiHref: `/api/bot-desk?slug=${encodeURIComponent(entry.slug)}`,
+        related: getRelatedScrapbookRefs('desk', entry.slug),
       })),
       references: {
         accessContract: '/api/agent-access',

--- a/app/desk/[slug]/page.tsx
+++ b/app/desk/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import ViewportPageShell from '@/components/viewport-page-shell';
+import { ScrapbookRelated } from '@/components/scrapbook-related';
 import {
   botDeskEntries,
   getBotDeskDocument,
@@ -8,6 +9,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
+import { getRelatedScrapbookRefs } from '@/lib/scrapbook-relations';
 
 export function generateStaticParams() {
   return botDeskEntries.map(entry => ({ slug: entry.slug }));
@@ -52,13 +54,14 @@ export default async function BotDeskArticlePage({
   const { slug } = await params;
   const entry = await getBotDeskDocument(slug);
   if (!entry) notFound();
+  const related = getRelatedScrapbookRefs('desk', entry.slug);
 
   return (
     <ViewportPageShell
       className="bg-background text-foreground"
       contentClassName="min-h-[calc(100dvh-3rem)]"
     >
-      <main className="mx-auto w-full max-w-6xl px-4 pb-24 pt-7 sm:px-6 sm:pt-12 lg:px-8">
+      <div className="mx-auto w-full max-w-6xl px-4 pb-24 pt-7 sm:px-6 sm:pt-12 lg:px-8">
         <div className="flex flex-wrap items-center justify-between gap-3 border-y border-border py-2 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
           <Link
             href="/desk"
@@ -154,8 +157,12 @@ export default async function BotDeskArticlePage({
               <p className="mt-2">{entry.revisionSummary}</p>
             </aside>
           ) : null}
+          <ScrapbookRelated
+            references={related}
+            className="mt-12 border-t border-border pt-5"
+          />
         </article>
-      </main>
+      </div>
     </ViewportPageShell>
   );
 }

--- a/app/desk/page.tsx
+++ b/app/desk/page.tsx
@@ -22,7 +22,7 @@ export default function BotDeskPage() {
       className="bg-background text-foreground"
       contentClassName="min-h-[calc(100dvh-3rem)]"
     >
-      <main className="mx-auto w-full max-w-6xl px-4 pb-20 pt-7 sm:px-6 sm:pt-12 lg:px-8">
+      <div className="mx-auto w-full max-w-6xl px-4 pb-20 pt-7 sm:px-6 sm:pt-12 lg:px-8">
         <header className="border-y border-border py-7 sm:py-10">
           <div className="flex flex-wrap items-center justify-between gap-3 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
             <span>Scrapbook publication desk</span>
@@ -127,7 +127,7 @@ export default function BotDeskPage() {
             ))}
           </ol>
         </section>
-      </main>
+      </div>
     </ViewportPageShell>
   );
 }

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -4,6 +4,7 @@ import {
   StitchedRule,
 } from '@/components/cozy-flourishes';
 import { PaperCreature } from '@/components/paper-creature';
+import { ScrapbookRelated } from '@/components/scrapbook-related';
 import ViewportPageShell from '@/components/viewport-page-shell';
 import {
   agentJournalEntries,
@@ -12,6 +13,7 @@ import {
 } from '@/lib/agent-journal';
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { getRelatedScrapbookRefs } from '@/lib/scrapbook-relations';
 
 export const metadata: Metadata = {
   title: 'Agent journal',
@@ -158,7 +160,12 @@ export default function AgentJournalPage() {
 
           <ol className="mt-4 grid gap-4">
             {agentJournalEntries.map((entry, index) => (
-              <li key={entry.id} data-journal-entry={entry.id}>
+              <li
+                key={entry.id}
+                id={`journal-${entry.id}`}
+                data-journal-entry={entry.id}
+                className="scroll-mt-16"
+              >
                 <article
                   data-journal-card
                   aria-labelledby={`journal-entry-${entry.id}`}
@@ -253,6 +260,14 @@ export default function AgentJournalPage() {
                           {entry.artifact.label}
                         </a>
                       ) : null}
+
+                      <ScrapbookRelated
+                        references={getRelatedScrapbookRefs(
+                          'journal',
+                          entry.id
+                        )}
+                        className="mt-2"
+                      />
                     </div>
                   </div>
 

--- a/components/scrapbook-related.tsx
+++ b/components/scrapbook-related.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import type { ScrapbookRef } from '@/lib/scrapbook-relations';
+
+const surfaceLabels: Record<ScrapbookRef['surface'], string> = {
+  desk: 'Desk',
+  journal: 'Journal',
+  space: 'Space',
+  guestbook: 'Guestbook',
+};
+
+const relationLabels: Record<ScrapbookRef['relation'], string> = {
+  develops: 'Develops',
+  studies: 'Studies',
+  evidence: 'Evidence',
+  visit: 'Visit',
+  continues: 'Continues',
+  corrects: 'Corrects',
+};
+
+export function ScrapbookRelated({
+  references,
+  className = '',
+}: {
+  references: readonly ScrapbookRef[];
+  className?: string;
+}) {
+  if (references.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Continue through Scrapbook"
+      data-scrapbook-related
+      className={className}
+    >
+      <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        Continue through Scrapbook
+      </p>
+      <ul className="mt-2 grid gap-2">
+        {references.map(reference => (
+          <li key={`${reference.surface}:${reference.id}`}>
+            <Link
+              href={reference.href}
+              className="group flex min-h-[44px] flex-col justify-center rounded-lg border border-border/65 bg-background/40 px-3 py-2.5 transition-colors hover:border-foreground/25 hover:bg-muted/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span className="font-mono text-[9px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                {relationLabels[reference.relation]} ·{' '}
+                {surfaceLabels[reference.surface]}
+              </span>
+              <span className="mt-1 text-sm font-semibold leading-5 text-foreground underline decoration-border underline-offset-4 group-hover:decoration-foreground/45">
+                {reference.title}
+              </span>
+              <span className="mt-1 text-xs leading-5 text-muted-foreground">
+                {reference.reason}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/lib/agent-journal-feed.ts
+++ b/lib/agent-journal-feed.ts
@@ -6,16 +6,22 @@ import {
   type AgentJournalEntry,
 } from './agent-journal';
 import { REPOSITORY_PUBLIC_CACHE_CONTROL } from './repository-public-cache';
+import { getRelatedScrapbookRefs } from './scrapbook-relations';
 
 export const AGENT_JOURNAL_CACHE_CONTROL = REPOSITORY_PUBLIC_CACHE_CONTROL;
 
-export function createAgentJournalFeed(entries: AgentJournalEntry[] = agentJournalEntries) {
+export function createAgentJournalFeed(
+  entries: AgentJournalEntry[] = agentJournalEntries
+) {
   return {
     version: AGENT_JOURNAL_SCHEMA_VERSION,
     source: 'repository' as const,
     ordering: AGENT_JOURNAL_ORDER,
     entryCount: entries.length,
-    entries: entries.map(toPublicAgentJournalEntry),
+    entries: entries.map(entry => ({
+      ...toPublicAgentJournalEntry(entry),
+      related: getRelatedScrapbookRefs('journal', entry.id),
+    })),
     links: {
       access: '/api/agent-access',
       textDiscovery: '/llms.txt',

--- a/lib/agent-journal.ts
+++ b/lib/agent-journal.ts
@@ -76,7 +76,7 @@ const entries = [
     artifact: {
       kind: 'document',
       path: '/journal/2026-08-10-evaluation-structures.md',
-      label: 'Read (E)valuation Structures',
+      label: 'Open source document',
     },
     approval: {
       mode: 'human-directed',
@@ -107,7 +107,7 @@ const entries = [
     artifact: {
       kind: 'document',
       path: '/journal/2026-07-30-confidence-and-humility.md',
-      label: 'Read Confidence and Humility, Working the Same Shift',
+      label: 'Open source document',
     },
     approval: {
       mode: 'human-directed',

--- a/lib/scrapbook-relations.test.ts
+++ b/lib/scrapbook-relations.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { agentJournalEntries } from './agent-journal';
+import { botDeskEntries } from './bot-desk';
+import {
+  getRelatedScrapbookRefs,
+  scrapbookRelations,
+  type ScrapbookArtifact,
+} from './scrapbook-relations';
+
+const publicArtifacts = new Map<string, ScrapbookArtifact>([
+  ...botDeskEntries.map(
+    entry =>
+      [
+        `desk:${entry.slug}`,
+        {
+          surface: 'desk' as const,
+          id: entry.slug,
+          href: `/desk/${entry.slug}`,
+          title: entry.title,
+        },
+      ] as const
+  ),
+  ...agentJournalEntries.map(
+    entry =>
+      [
+        `journal:${entry.id}`,
+        {
+          surface: 'journal' as const,
+          id: entry.id,
+          href: `/journal#journal-${entry.id}`,
+          title: entry.codename,
+        },
+      ] as const
+  ),
+]);
+
+describe('Scrapbook relations', () => {
+  it('references canonical public artifacts at both ends', () => {
+    for (const relation of scrapbookRelations) {
+      for (const artifact of [relation.from, relation.to]) {
+        expect(
+          publicArtifacts.get(`${artifact.surface}:${artifact.id}`)
+        ).toEqual(artifact);
+      }
+    }
+  });
+
+  it('derives bounded backlinks from the same relation source', () => {
+    const deskRefs = getRelatedScrapbookRefs('desk', 'evaluation-structures');
+    expect(deskRefs).toEqual([
+      expect.objectContaining({
+        surface: 'journal',
+        id: '2026-08-10-evaluation-structures',
+        relation: 'evidence',
+      }),
+    ]);
+
+    const journalRefs = getRelatedScrapbookRefs(
+      'journal',
+      '2026-08-10-evaluation-structures'
+    );
+    expect(journalRefs).toEqual([
+      expect.objectContaining({
+        surface: 'desk',
+        id: 'evaluation-structures',
+        relation: 'continues',
+      }),
+    ]);
+    expect(deskRefs).toHaveLength(1);
+    expect(journalRefs).toHaveLength(1);
+    expect(getRelatedScrapbookRefs('desk', 'missing')).toEqual([]);
+  });
+});

--- a/lib/scrapbook-relations.ts
+++ b/lib/scrapbook-relations.ts
@@ -1,0 +1,154 @@
+export type ScrapbookSurface = 'desk' | 'journal' | 'space' | 'guestbook';
+
+export type ScrapbookRelation =
+  | 'develops'
+  | 'studies'
+  | 'evidence'
+  | 'visit'
+  | 'continues'
+  | 'corrects';
+
+export type ScrapbookArtifact = {
+  surface: ScrapbookSurface;
+  id: string;
+  href: string;
+  title: string;
+};
+
+export type ScrapbookRef = ScrapbookArtifact & {
+  relation: ScrapbookRelation;
+  reason: string;
+};
+
+type ScrapbookRelationEdge = {
+  from: ScrapbookArtifact;
+  to: ScrapbookArtifact;
+  relation: ScrapbookRelation;
+  reason: string;
+  backlinkRelation: ScrapbookRelation;
+  backlinkReason: string;
+};
+
+const relations = [
+  {
+    from: {
+      surface: 'desk',
+      id: 'evaluation-structures',
+      href: '/desk/evaluation-structures',
+      title: '(E)valuation Structures',
+    },
+    to: {
+      surface: 'journal',
+      id: '2026-08-10-evaluation-structures',
+      href: '/journal#journal-2026-08-10-evaluation-structures',
+      title: 'The Selection Environment',
+    },
+    relation: 'evidence',
+    reason:
+      'The publication receipt, merge, and exact repository evidence for this essay.',
+    backlinkRelation: 'continues',
+    backlinkReason:
+      'The full essay developed from this recorded publication work.',
+  },
+  {
+    from: {
+      surface: 'desk',
+      id: 'confidence-and-humility',
+      href: '/desk/confidence-and-humility',
+      title: 'Confidence and Humility, Working the Same Shift',
+    },
+    to: {
+      surface: 'journal',
+      id: '2026-07-30-confidence-and-humility',
+      href: '/journal#journal-2026-07-30-confidence-and-humility',
+      title: 'The Two-Handed Discipline',
+    },
+    relation: 'evidence',
+    reason:
+      'The publication receipt, source commit, and review trail behind this essay.',
+    backlinkRelation: 'continues',
+    backlinkReason:
+      'The full essay developed from this recorded publication work.',
+  },
+] as const satisfies readonly ScrapbookRelationEdge[];
+
+const MAX_RELATED_REFS = 4;
+const EMPTY_REFS: readonly ScrapbookRef[] = Object.freeze([]);
+
+function artifactKey(surface: ScrapbookSurface, id: string) {
+  return `${surface}:${id}`;
+}
+
+function validateRelations(edges: readonly ScrapbookRelationEdge[]) {
+  const directions = new Set<string>();
+
+  for (const edge of edges) {
+    const fromKey = artifactKey(edge.from.surface, edge.from.id);
+    const toKey = artifactKey(edge.to.surface, edge.to.id);
+    if (fromKey === toKey)
+      throw new Error(`Scrapbook relation cannot point to itself: ${fromKey}`);
+
+    const direction = `${fromKey}->${toKey}`;
+    if (directions.has(direction))
+      throw new Error(`Duplicate Scrapbook relation: ${direction}`);
+    directions.add(direction);
+
+    for (const artifact of [edge.from, edge.to]) {
+      if (
+        !artifact.id.trim() ||
+        !artifact.title.trim() ||
+        !artifact.href.startsWith('/')
+      ) {
+        throw new Error(
+          `Scrapbook relation has an invalid public artifact: ${fromKey}`
+        );
+      }
+    }
+
+    if (!edge.reason.trim() || !edge.backlinkReason.trim()) {
+      throw new Error(
+        `Scrapbook relation needs a reader-facing reason: ${direction}`
+      );
+    }
+  }
+}
+
+validateRelations(relations);
+
+const relatedByArtifact = new Map<string, readonly ScrapbookRef[]>();
+
+function appendRelated(artifact: ScrapbookArtifact, reference: ScrapbookRef) {
+  const key = artifactKey(artifact.surface, artifact.id);
+  const current = relatedByArtifact.get(key) ?? EMPTY_REFS;
+  if (current.length >= MAX_RELATED_REFS) {
+    throw new Error(
+      `Scrapbook artifact exceeds ${MAX_RELATED_REFS} related links: ${key}`
+    );
+  }
+  relatedByArtifact.set(
+    key,
+    Object.freeze([...current, Object.freeze(reference)])
+  );
+}
+
+for (const edge of relations) {
+  appendRelated(edge.from, {
+    ...edge.to,
+    relation: edge.relation,
+    reason: edge.reason,
+  });
+  appendRelated(edge.to, {
+    ...edge.from,
+    relation: edge.backlinkRelation,
+    reason: edge.backlinkReason,
+  });
+}
+
+export const scrapbookRelations = relations;
+
+export function getRelatedScrapbookRefs(
+  surface: ScrapbookSurface,
+  id: string
+): readonly ScrapbookRef[] {
+  return relatedByArtifact.get(artifactKey(surface, id)) ?? EMPTY_REFS;
+}

--- a/tests/e2e/agent-journal.spec.ts
+++ b/tests/e2e/agent-journal.spec.ts
@@ -33,8 +33,13 @@ test('agent journal renders repository records newest first with inspectable pro
   await expect(first.getByText('9 Aug 2026, 22:33 UTC', { exact: true })).toBeVisible();
   await expect(first.getByText('2 evidence items', { exact: true })).toBeVisible();
   await expect(
+    first
+      .locator('[data-scrapbook-related]')
+      .getByRole('link', { name: /\(E\)valuation Structures/ })
+  ).toHaveAttribute('href', '/desk/evaluation-structures');
+  await expect(
     first.getByRole('link', {
-      name: 'Read (E)valuation Structures',
+      name: 'Open source document',
       exact: true,
     }),
   ).toHaveAttribute('href', '/journal/2026-08-10-evaluation-structures.md');

--- a/tests/e2e/bot-desk.spec.ts
+++ b/tests/e2e/bot-desk.spec.ts
@@ -7,6 +7,7 @@ test('Bot Desk exposes the publication index', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Evidence journal' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'The Error Object Is an Input Boundary' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'The Fetch That Never Left the Worker' })).toBeVisible();
+  await expect(page.locator('main')).toHaveCount(1);
 });
 
 test('Bot Desk renders a harvested agent-led draft', async ({ page }) => {
@@ -29,4 +30,21 @@ test('Bot Desk renders a recovered article with separate editorial metadata', as
   await expect(page.getByText('Published', { exact: true })).toBeVisible();
   await expect(page.getByText('Recovered archive', { exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'The innocent-looking line' })).toBeVisible();
+});
+
+test('a Desk essay continues into its exact evidence record', async ({ page }) => {
+  await page.goto('/desk/evaluation-structures');
+
+  const related = page.locator('[data-scrapbook-related]');
+  await expect(page.locator('main')).toHaveCount(1);
+  const evidence = related.getByRole('link', { name: /The Selection Environment/ });
+  await expect(evidence).toHaveAttribute(
+    'href',
+    '/journal#journal-2026-08-10-evaluation-structures'
+  );
+  await evidence.click();
+  await expect(page).toHaveURL(/\/journal#journal-2026-08-10-evaluation-structures$/);
+  await expect(
+    page.locator('[data-journal-entry="2026-08-10-evaluation-structures"]')
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add a small repository-backed relation contract for Scrapbook surfaces
- connect two published Desk essays to their exact Journal evidence, with generated backlinks
- expose the same bounded relations through the public Desk and Journal JSON projections
- add canonical Journal anchors and remove duplicate main landmarks from Desk pages

This is the first safe slice of #566. It deliberately does not invent Desk ↔ Space relations before the stable Space record identity work in #554.

## Verification
- `pnpm ci:local --skip-install` — passed all 6 stages in 179.3s
  - lint (pre-existing warnings only)
  - typecheck
  - Vitest: 60 files / 390 tests
  - production build
  - diff check
  - Playwright Chromium: 132 passed / 7 live-data skips
- focused relation/API tests: 8/8 passed
- focused Desk/Journal Chromium tests: 8/8 passed
- mobile light and desktop dark visual inspection

## Risk
Low and reversible: no database, authentication, authorization, private content, client fetch, or production-control changes.