### PR TITLE
Teach Work the append-first retrieval model

### DIFF
--- a/work/AGENTS.md
+++ b/work/AGENTS.md
@@ -10,6 +10,20 @@ Read the root `AGENTS.md` first. The normal Scrapbook pull-request and authority
 
 When substantive work elsewhere produces something potentially useful, independently ask whether it changes Leo's work record or current resume candidate pool.
 
+## Append first, reconcile later
+
+Leo often synthesizes rapidly and moves on. Do not make complete reorganization a prerequisite for preserving a useful thought.
+
+When a session produces a concrete result, interpretation, reversal, career implication, or reusable working-model insight:
+
+1. capture it in the narrowest existing durable record that fits, or create one when the concept is genuinely new;
+2. link primary evidence where the statement depends on external work;
+3. preserve uncertainty rather than forcing premature resolution;
+4. avoid rewriting older snapshots merely to make the current story look cleaner;
+5. let later agents reconcile duplication, stale status, contradictions, and ranking when a concrete question requires it.
+
+Agents are part of the retrieval layer. When answering a new career or engineering question, search the existing work records and primary repositories before assuming Leo has not encountered the relevant pattern before. Surface useful old evidence back into working memory instead of requiring the human to remember where it lived.
+
 ## Before writing
 
 1. Read the primary evidence in the originating repository. Prefer the exact issue, pull request, benchmark report, README evidence section, review, CI receipt, or current handoff over memory.
@@ -30,6 +44,8 @@ Record work when at least one of these is true:
 - a review interaction materially refined the repair boundary;
 - the work adds a new technical axis to the portfolio (compiler, VMM, runtime, browser tooling, distributed coordination, packaging, etc.);
 - the result would plausibly be useful in a resume, interview, portfolio, outreach note, or career narrative.
+
+Also record working-model changes when they explain how the broader corpus should be interpreted or retrieved later, for example changes in career framing, interview preparation strategy, agent/human division of labor, or active-recall practice.
 
 Do not record typo fixes, mechanical churn, routine dependency updates, superficial activity totals, or speculative findings that never reached a useful evidence boundary.
 
@@ -69,6 +85,8 @@ Never delete a durable record merely because it falls out of the current resume 
 Use canonical direct GitHub links inside durable work records. If a Scrapbook pull-request body mentions third-party upstream work and a backlink would be noisy, follow the root repository policy and use `redirect.github.com` there.
 
 Where useful, link both the upstream surface and the richer owned evidence packet.
+
+For current job descriptions, hiring processes, product status, package releases, or other time-sensitive career facts, refresh the primary source before updating the record. Date point-in-time role-fit notes so they are not silently treated as permanent facts.
 
 ## Voice
 

--- a/work/README.md
+++ b/work/README.md
@@ -32,6 +32,7 @@ Agents are therefore part of the retrieval layer as well as the implementation l
 - [`records/open-source.md`](records/open-source.md) — selected open-source engineering evidence and the larger bench.
 - [`records/working-style.md`](records/working-style.md) — append-first synthesis, domain-agnostic slope, agents-as-retrieval, and the recall-practice model.
 - [`records/vercel-fit-2026-08-11.md`](records/vercel-fit-2026-08-11.md) — point-in-time Vercel role-fit calibration and current earlier-shaped role evidence.
+- [`records/interview-success-set.md`](records/interview-success-set.md) — all-cause interview coverage model, current risk ranking, and backlog-derived drill generator.
 - [`archive/2026-08-11-signal-audit.md`](archive/2026-08-11-signal-audit.md) — first broad snapshot of the current body of work and the narrative it supports.
 - [`AGENTS.md`](AGENTS.md) — local instructions for agents updating this record.
 

--- a/work/README.md
+++ b/work/README.md
@@ -33,6 +33,7 @@ Agents are therefore part of the retrieval layer as well as the implementation l
 - [`records/working-style.md`](records/working-style.md) — append-first synthesis, domain-agnostic slope, agents-as-retrieval, and the recall-practice model.
 - [`records/vercel-fit-2026-08-11.md`](records/vercel-fit-2026-08-11.md) — point-in-time Vercel role-fit calibration and current earlier-shaped role evidence.
 - [`records/interview-success-set.md`](records/interview-success-set.md) — all-cause interview coverage model, current risk ranking, and backlog-derived drill generator.
+- [`records/prerequisite-doctrine.md`](records/prerequisite-doctrine.md) — remove interview information asymmetry by mapping explicit/implied prerequisites, personal deltas, and required mastery depth before studying.
 - [`archive/2026-08-11-signal-audit.md`](archive/2026-08-11-signal-audit.md) — first broad snapshot of the current body of work and the narrative it supports.
 - [`AGENTS.md`](AGENTS.md) — local instructions for agents updating this record.
 

--- a/work/README.md
+++ b/work/README.md
@@ -34,6 +34,8 @@ Agents are therefore part of the retrieval layer as well as the implementation l
 - [`records/vercel-fit-2026-08-11.md`](records/vercel-fit-2026-08-11.md) — point-in-time Vercel role-fit calibration and current earlier-shaped role evidence.
 - [`records/interview-success-set.md`](records/interview-success-set.md) — all-cause interview coverage model, current risk ranking, and backlog-derived drill generator.
 - [`records/prerequisite-doctrine.md`](records/prerequisite-doctrine.md) — remove interview information asymmetry by mapping explicit/implied prerequisites, personal deltas, and required mastery depth before studying.
+- [`records/cpp-positioning.md`](records/cpp-positioning.md) — C++ as a role prerequisite and market shift rather than an automatic differentiation strategy.
+- [`records/frontend-positioning.md`](records/frontend-positioning.md) — frontend as first-class product engineering, where it differentiates, and where artistic experimentation belongs.
 - [`archive/2026-08-11-signal-audit.md`](archive/2026-08-11-signal-audit.md) — first broad snapshot of the current body of work and the narrative it supports.
 - [`AGENTS.md`](AGENTS.md) — local instructions for agents updating this record.
 

--- a/work/README.md
+++ b/work/README.md
@@ -21,11 +21,17 @@ The operating idea is simple:
 - keep links to the canonical evidence;
 - do not manufacture impact merely because a repository name is recognizable.
 
+A second operating principle is **append first, reconcile later**. Leo often synthesizes quickly and then moves on. The record should make that sustainable: capture useful conclusions while they are fresh, then let later agents retrieve, compare, deduplicate, challenge, and compress the corpus when a concrete decision needs it.
+
+Agents are therefore part of the retrieval layer as well as the implementation layer. They should be able to bring old evidence back into working memory, notice stale claims, and answer "haven't I already done something like this?" without forcing the human to reconstruct old context from chats.
+
 ## Files
 
 - [`resume-candidates.md`](resume-candidates.md) — intentionally churny ranking of the strongest current resume material.
 - [`records/preflight.md`](records/preflight.md) — detailed Preflight performance/product evidence and candidate stories.
 - [`records/open-source.md`](records/open-source.md) — selected open-source engineering evidence and the larger bench.
+- [`records/working-style.md`](records/working-style.md) — append-first synthesis, domain-agnostic slope, agents-as-retrieval, and the recall-practice model.
+- [`records/vercel-fit-2026-08-11.md`](records/vercel-fit-2026-08-11.md) — point-in-time Vercel role-fit calibration and current earlier-shaped role evidence.
 - [`archive/2026-08-11-signal-audit.md`](archive/2026-08-11-signal-audit.md) — first broad snapshot of the current body of work and the narrative it supports.
 - [`AGENTS.md`](AGENTS.md) — local instructions for agents updating this record.
 

--- a/work/records/cpp-positioning.md
+++ b/work/records/cpp-positioning.md
@@ -1,0 +1,147 @@
+# C++ positioning: prerequisite, not differentiation strategy
+
+Updated: 2026-08-11
+
+This record captures a recurring career meme worth explicitly rejecting: **"the software market is crowded, so learn C++ to differentiate yourself."**
+
+There is a sensible kernel inside that advice and a much larger category error around it.
+
+## The sensible kernel
+
+C++ genuinely opens or strengthens access to some kinds of work:
+
+- game engines and runtime systems;
+- browsers, databases, compilers and language runtimes;
+- low-latency systems;
+- native desktop/application infrastructure;
+- embedded/hardware-adjacent systems;
+- performance-critical libraries;
+- some infrastructure and storage systems.
+
+Those jobs often have a smaller qualified pool than ordinary application/frontend roles, and practical C++ fluency can be a real prerequisite.
+
+For Leo specifically, C++ is therefore a useful **bounded prerequisite** when targeting Valve/game/runtime/low-level roles. It is not a permanent identity claim.
+
+## The category error
+
+A programming language is not, by itself, a scarce engineering capability.
+
+"I learned C++" does not imply:
+
+- strong systems reasoning;
+- experience debugging undefined behavior, races, ownership or lifetime bugs;
+- performance measurement skill;
+- operating-system knowledge;
+- concurrency competence;
+- engine/runtime architecture;
+- graphics, networking, storage, compiler or embedded expertise;
+- ability to navigate a large mature native codebase;
+- ability to ship and maintain production software.
+
+If many candidates respond to a weak market by learning C++ syntax and standard-library mechanics, they can simply create a new crowded pool of **entry-level C++ learners** without creating a matching pool of C++ jobs that accept entry-level domain experience.
+
+The labor-market scarcity in many native roles is usually the bundle:
+
+> C++ fluency + systems/domain knowledge + production/debugging judgment + evidence of shipping in that environment.
+
+The language is one gate in the bundle, not the bundle itself.
+
+## Harder language does not imply easier market
+
+Another bad inference is:
+
+> C++ is harder, therefore C++ jobs are easier to get.
+
+Harder prerequisites can reduce candidate supply, but they can also reduce job supply and raise the experience floor at the same time.
+
+Many C++ roles exist because the underlying work is unusually sensitive to latency, memory, hardware, runtime behavior, safety, compatibility, or legacy/native integration. That often means employers want *more* prior domain evidence, not merely a harder-language credential.
+
+So a candidate can spend months moving from a crowded broad market into a narrower market where they are still junior relative to the role's real requirements.
+
+## Opportunity cost
+
+C++ can become a particularly expensive avoidance strategy because the learning surface is effectively unbounded.
+
+There is always another layer:
+
+- syntax and STL;
+- value categories and move semantics;
+- RAII and object lifetime;
+- templates and generic programming;
+- concurrency and atomics;
+- allocators and memory layout;
+- ABI/build/linking/toolchains;
+- undefined behavior and sanitizers;
+- platform APIs;
+- performance profiling;
+- domain-specific libraries and architecture.
+
+A person can remain indefinitely in "preparing to become differentiated" mode while not applying, shipping, interviewing, or building evidence in the actual target domain.
+
+The right question is not **"Would C++ make me more impressive?"**
+
+It is:
+
+> What target roles require C++, which prerequisite rung do their interviews and daily work actually require, and what is the smallest curriculum that closes that gap?
+
+## Leo-specific interpretation
+
+For Leo, the situation is unusually favorable because the language would sit on top of existing adjacent evidence rather than start from zero.
+
+Existing transferable axes include:
+
+- Rust/Cloud Hypervisor work in a VMM;
+- Linux/container/process investigations;
+- Java/JVM bytecode/runtime instrumentation in Preflight;
+- performance measurement and cache/locality reasoning;
+- lifecycle/ownership/error-boundary debugging;
+- broad unfamiliar-codebase entry.
+
+So C++ can be learned as a **translation layer onto systems concepts already encountered**, especially for Valve or similar native-runtime roles.
+
+That is fundamentally different from "learn C++ because JavaScript applicants are crowded."
+
+The study goal should be practical interview/work fluency:
+
+- RAII and deterministic lifetime;
+- stack/heap/value/reference/pointer semantics;
+- copy vs move;
+- `unique_ptr` / `shared_ptr` and ownership design;
+- containers, iterators and invalidation;
+- virtual dispatch and object layout intuition;
+- templates/generics at ordinary production depth;
+- synchronization, atomics and race/deadlock reasoning;
+- memory/cache locality;
+- common undefined-behavior classes;
+- build/link/debug/sanitizer workflow;
+- enough idiomatic modern C++ to implement ordinary bounded exercises without fighting the language.
+
+Then practice those concepts inside the kinds of systems the target employer actually builds.
+
+## Differentiation comes from evidence bundles
+
+A stronger positioning model is:
+
+- **language fluency** gets through a language gate;
+- **domain/system knowledge** makes the fluency relevant;
+- **real work** establishes credibility;
+- **judgment under ambiguity** differentiates;
+- **shipping/external consequence** compounds the signal.
+
+Examples:
+
+"Knows C++" is weak.
+
+"Can profile a game/runtime, explain ownership/lifetime costs, navigate a large C++ codebase, find a critical-path bug and ship the repair" is strong.
+
+Likewise, a candidate does not become differentiated by Rust, Go, TypeScript or any other language in isolation. Languages are interfaces to problem domains.
+
+## Career rule
+
+Do not choose a language as an escape hatch from the job market.
+
+Choose target work. Map its prerequisites. Learn the language to the depth that work requires. Then create evidence in the actual problem class.
+
+For Leo, C++ should currently be treated as:
+
+> a high-value, learnable prerequisite that expands Valve/native-runtime optionality, not a rescue plan and not a new permanent specialization.

--- a/work/records/frontend-positioning.md
+++ b/work/records/frontend-positioning.md
@@ -1,0 +1,73 @@
+# Frontend positioning
+
+Updated: 2026-08-11
+
+Frontend remains a first-class engineering surface, but generic frontend fluency is not enough by itself to establish a durable labor-market base.
+
+## What remains important
+
+The web interface is where users experience product quality directly. Strong frontend work can demonstrate:
+
+- product judgment and interaction design;
+- accessibility and inclusive defaults;
+- performance and responsiveness;
+- browser/platform understanding;
+- state management and failure handling;
+- design-system discipline;
+- end-to-end ownership from API/data shape to user-visible consequence;
+- the ability to make complex systems legible.
+
+Excellent frontend therefore still earns its keep.
+
+## What does not differentiate much anymore
+
+A stack label such as React/Next.js/TypeScript is not much of a moat on its own. Those technologies are common, and many candidates can assemble competent application surfaces.
+
+The useful signal comes from what the engineer can do through the frontend:
+
+- difficult interaction/state problems;
+- real browser/runtime constraints;
+- performance and accessibility work;
+- complex product flows;
+- strong taste exercised within maintainable systems;
+- integration with backend/runtime/tooling behavior rather than UI isolation.
+
+Frontend can absolutely be a deep specialty when the depth is real: browser internals, rendering/performance, accessibility, design systems, graphics, rich editors, complex application state, interaction architecture, or large-scale product systems. The weak positioning is not frontend itself; it is treating framework familiarity as the whole base.
+
+## Artistic skill versus company work
+
+Personal work is a good place to push artistic taste, visual experimentation, unusual interaction models, and idiosyncratic aesthetics aggressively.
+
+Company work has a different optimization target. Taste still matters, but it must survive:
+
+- existing product language and design systems;
+- user expectations;
+- accessibility;
+- maintainability and handoff;
+- performance budgets;
+- deadlines and scope;
+- experimentation/measurement;
+- cross-functional ownership;
+- the fact that somebody else may maintain the work later.
+
+The job is not the place to prove artistic individuality at the expense of the product. Strong craft is expressed by making the right thing clearer, faster, more coherent, and more usable inside the actual constraints.
+
+## Positioning consequence
+
+For Leo, frontend is better treated as a capability layer than as a permanent identity.
+
+A broad market description can remain:
+
+> Software engineer who gets useful quickly in unfamiliar systems, with current strengths in runtimes, developer tooling, performance, state/lifecycle correctness, and product engineering.
+
+Frontend strengthens that profile because it means the same engineer can also own the user-facing projection of the system instead of handing everything off at the API boundary.
+
+The differentiating combination is closer to:
+
+> strong product/frontend taste + systems/runtime depth + ability to move across the stack
+
+rather than:
+
+> frontend engineer who also knows some backend.
+
+This distinction should guide resume cuts. Glossless/Scrapbook/visual work can re-enter aggressively for product/frontend/graphics roles, while general systems/devtools cuts do not need to make React/Next.js the identity simply because those skills remain useful.

--- a/work/records/interview-success-set.md
+++ b/work/records/interview-success-set.md
@@ -1,0 +1,416 @@
+# All-cause interview success set
+
+Updated: 2026-08-11
+
+This is a coverage model, not a prediction that every company uses every interview type. The goal is to reduce avoidable single-point failures across the union of common SWE hiring mechanisms while preserving Leo's actual engineering strengths.
+
+## Principle
+
+Do not optimize for one company's remembered loop. Optimize for the largest practical set of interview causes:
+
+1. application/recruiter screen;
+2. resume/project deep dive;
+3. coding fundamentals / algorithms;
+4. practical code production;
+5. debugging and code reading;
+6. testing and correctness reasoning;
+7. system design;
+8. state/distributed-systems reliability;
+9. performance and observability;
+10. language/runtime depth;
+11. low-level systems fundamentals where relevant;
+12. product/user judgment;
+13. behavioral/collaboration;
+14. take-home/work-sample execution;
+15. interview mechanics under time pressure;
+16. company/role calibration and logistics.
+
+A candidate does not need equal depth in every bucket. The target is no obvious catastrophic hole and several areas of undeniable strength.
+
+## Current strongest axes
+
+Leo already has unusually strong evidence for:
+
+- unfamiliar-codebase entry and source archaeology;
+- debugging state/lifecycle/correctness boundaries;
+- profiling and performance investigation;
+- designing discriminating controls rather than trusting first explanations;
+- cache identity/invalidation and replay semantics;
+- fail-open/fail-closed reasoning;
+- exact-source compatibility boundaries;
+- async/retry/idempotency/lease/authority reasoning;
+- open-source review and repair-boundary adjustment;
+- sustained independent technical pursuit;
+- AI-assisted engineering with strong human verification and selection.
+
+The preparation problem is therefore increasingly **compression, recall, and bounded execution**, not finding more technical material.
+
+## Coverage matrix
+
+### 1. Application and recruiter screen
+
+**Failure mode:** chronology or title history causes the profile to be classified as 0-YOE/new-grad before the work is understood.
+
+**Target standard:**
+
+- clean answer: roughly three years of substantive software-engineering experience;
+- immediately distinguish conventional employment (~16 months IBM) from independent/open-source/product engineering (~2 years);
+- explain the unusual chronology in under 30 seconds without sounding defensive;
+- role-specific application thesis in one paragraph;
+- no inflated claim of three years conventional post-grad full-time employment.
+
+**Practice:** rapid recruiter prompts: YOE, why this role, why now, what have you been doing since graduation, compensation/location/relocation, strongest recent work.
+
+### 2. Resume/project deep dive
+
+**Failure mode:** impressive bullets collapse under probing, or explanations expand into ten-minute research histories before answering the question.
+
+**Target standard:** every resume bullet supports:
+
+- 15-second headline;
+- 2-minute coherent story;
+- 10-20 minute technical drill-down;
+- exact claim/evidence boundary;
+- one thing that went wrong or changed the design;
+- one trade-off consciously rejected.
+
+**Source backlog:** Preflight, Cloud Hypervisor, Vercel AI SDK, Cloudflare Workers SDK, Stensibly, SmolRunner, IBM.
+
+### 3. Coding fundamentals / algorithms
+
+**Failure mode:** strong real-world engineer loses a conventional loop on bounded graph/array/string/DP work.
+
+**Target standard:** comfortable medium-level implementation without external help, including:
+
+- arrays/strings/hash maps/sets;
+- stacks/queues;
+- linked structures;
+- trees/BSTs;
+- graphs, BFS/DFS/topological ordering;
+- heaps/priority queues;
+- binary search and monotonic conditions;
+- intervals/sweep basics;
+- recursion/backtracking;
+- common dynamic-programming shapes;
+- complexity analysis and edge cases.
+
+**Practice:** timed, syntactically correct code with explicit tests. Favor repeated pattern retrieval over puzzle collecting.
+
+### 4. Practical code production
+
+**Failure mode:** candidate can reason but is slow writing ordinary production-shaped code without an LLM/IDE safety net.
+
+**Target standard:** quickly implement bounded real-world components in one primary interview language, probably TypeScript by default, with Python/Java/Rust/C++ available by role.
+
+Drill shapes:
+
+- async iterator cleanup;
+- stream transforms and cancellation;
+- cache with invalidation;
+- retry/backoff policy;
+- bounded concurrency;
+- idempotent command handling;
+- parser/normalizer;
+- filesystem/resource lookup;
+- small state machine;
+- rate limiter;
+- producer/consumer queue;
+- simple HTTP client/server boundary;
+- data transformation with tests.
+
+Use real patterns from prior work instead of synthetic API trivia.
+
+### 5. Debugging and unfamiliar-code reading
+
+**Failure mode:** this is actually a strength, but interview time causes over-exploration.
+
+**Target standard:** within minutes:
+
+1. state the observable failure;
+2. name 2-4 plausible classes of cause;
+3. choose the cheapest discriminator;
+4. inspect only the owning path;
+5. update the hypothesis visibly;
+6. propose the smallest defensible repair;
+7. identify the regression test.
+
+**Backlog drills:** runc MaxCPU boundary, Bat wrong-path harness, Preflight 27s queue wait, Cloudflare stale credentials, Vercel regex state, Zustand hydration generation.
+
+### 6. Testing and correctness
+
+**Failure mode:** implementation works on happy path but interviewer is evaluating adversarial reasoning.
+
+**Target standard:** for any change, naturally ask about:
+
+- ownership of mutable state;
+- retries/replay;
+- cancellation;
+- failure during cleanup;
+- stale work completing late;
+- partial failure;
+- concurrency/order;
+- invalid input;
+- resource leaks;
+- compatibility/fallback;
+- exact negative controls.
+
+The work record already contains many ideal examples. Turn them into short test-design prompts.
+
+### 7. System design
+
+**Failure mode:** knows distributed systems concepts but presents them as an unbounded design monologue.
+
+**Target standard:** disciplined interview sequence:
+
+1. clarify users/requirements;
+2. state scale and key SLOs;
+3. define API/data model;
+4. draw the minimal happy path;
+5. identify state owners;
+6. add failure/retry/idempotency semantics;
+7. discuss consistency and partitioning;
+8. observability/security/operations;
+9. explicit trade-offs and what is deferred.
+
+**Drill sources:** Stensibly, SmolRunner, Preflight diagnostics intake, GitHub publication, job/lease coordination.
+
+### 8. Distributed-state / reliability design
+
+This deserves separate depth because many modern tooling/agent roles care about it even when the interview is not labeled "system design."
+
+Be fluent in:
+
+- at-least-once vs at-most-once effects;
+- idempotency keys;
+- compare-and-swap/version fencing;
+- leases and expirations;
+- leader/owner authority;
+- durable checkpoints;
+- replay receipts;
+- ambiguous completion;
+- retries after partial external effects;
+- queues and backpressure;
+- eventual vs strong consistency;
+- time/clock assumptions;
+- recovery after crash between observation and mutation.
+
+Stensibly and SmolRunner provide concrete examples for almost every item.
+
+### 9. Performance / observability
+
+**Failure mode:** talks numbers but cannot explain measurement validity.
+
+**Target standard:** be able to reason through:
+
+- baseline definition;
+- warm/cold caches;
+- interleaving/randomization;
+- variance/noise;
+- critical path vs aggregate CPU;
+- profiler attribution errors;
+- counters vs time;
+- microbenchmark vs end-to-end effects;
+- instrumentation overhead;
+- rollback/negative controls;
+- when an optimization is not worth shipping.
+
+Preflight is the main drill corpus.
+
+### 10. Language/runtime depth
+
+Use a broad base plus role-specific specialization.
+
+**TypeScript/JavaScript:** event loop, promises/microtasks, streams, iterators, object identity/mutation, RegExp state, Node/browser runtime differences, module/package basics, TypeScript type modeling.
+
+**Rust:** ownership/borrowing, Result/error design, traits/generics, Send/Sync intuition, concurrency, lifetimes at practical level, unsafe boundaries conceptually, cargo/testing/build targets.
+
+**Java/JVM:** class loading, bytecode/instrumentation, concurrency basics, memory/GC intuition, streams/collections, exceptions, JAR/classpath behavior, JIT/runtime basics.
+
+**C++ when Valve/systems-targeted:** RAII, object lifetime, move semantics, references/pointers, smart pointers, containers, iterators, virtual dispatch, templates basics, concurrency primitives, memory layout/cache locality, undefined behavior basics, build/debug workflow.
+
+**Go/Python:** enough production fluency for role-specific loops, not resume-list trivia.
+
+### 11. Low-level systems fundamentals
+
+For systems/Valve/infra loops, keep warm:
+
+- processes vs threads;
+- virtual memory/pages;
+- files/file descriptors;
+- sockets and basic TCP/HTTP;
+- signals;
+- locks/atomics/races/deadlocks;
+- scheduling/affinity basics;
+- filesystem/path semantics;
+- syscalls and user/kernel boundaries;
+- containers/namespaces/cgroups at conceptual level;
+- serialization/endian/alignment basics;
+- CPU cache/locality intuition.
+
+Cloud Hypervisor, Linux Fieldwork, runc, Bubblewrap, util-linux and Preflight supply real examples.
+
+### 12. Product/user judgment
+
+**Failure mode:** independent technical work reads as internally interesting but disconnected from users/business.
+
+**Target standard:** answer:
+
+- who is this for?
+- what pain changed?
+- what was the smallest useful version?
+- what did you deliberately not build?
+- what evidence says the feature mattered?
+- what would real user feedback change next?
+
+Shipping Preflight materially strengthens this axis.
+
+### 13. Behavioral / collaboration
+
+Prepare reusable stories, not scripts, for:
+
+- disagreement/change of mind;
+- ambiguous problem ownership;
+- failure or wrong hypothesis;
+- cross-team collaboration;
+- initiative without assigned tickets;
+- learning a new domain quickly;
+- prioritization and killing work;
+- receiving review feedback;
+- handling a production/critical bug;
+- balancing speed and correctness;
+- communicating progress/blockers;
+- why independent work rather than conventional employment during this period.
+
+Best stories are often reversals: runc, Preflight killed theories, Cloud Hypervisor review, IBM RBAC/hotfix.
+
+### 14. Take-home / work sample
+
+**Failure mode:** overbuilds or produces a research project where a bounded deliverable was requested.
+
+**Target standard:**
+
+- read instructions first;
+- identify acceptance criteria;
+- produce a small coherent implementation;
+- tests + README + trade-offs;
+- no speculative architecture;
+- state what would be next with more time;
+- clean commit/diff hygiene.
+
+AI/tool policy should be read literally for each exercise.
+
+### 15. Interview mechanics
+
+This is a first-class skill.
+
+Practice:
+
+- clarify before coding but do not stall;
+- narrate the decision, not every thought;
+- timebox exploration;
+- accept hints cleanly;
+- write code before polishing abstractions;
+- test examples manually;
+- state complexity;
+- leave 5-10 minutes for edge cases;
+- recover calmly from a wrong path;
+- ask useful interviewer questions;
+- switch from deep research mode to bounded delivery mode on command.
+
+The target is not performative confidence. It is making real reasoning visible at interview speed.
+
+### 16. Company/role calibration and logistics
+
+Before each interview refresh:
+
+- current job description;
+- exact team/product surface;
+- stated language/runtime expectations;
+- current seniority/YOE requirements;
+- interview format if the company provides it;
+- location/relocation/work-authorization requirements;
+- which work-record specimens best match the role.
+
+Leo is TN-eligible for qualifying US employment, so US location itself is not a reason to exclude a role; exact occupation/employer paperwork still needs to satisfy the TN category in practice.
+
+## Current risk ranking
+
+### Highest deliberate-prep value
+
+1. Timed coding / algorithms.
+2. Fast unaided production coding.
+3. System-design compression.
+4. C++ depth if Valve becomes an active target.
+5. Behavioral story retrieval/compression.
+6. Product/user evidence via actually shipping Preflight.
+
+### Already strong; maintain rather than obsess
+
+- debugging unfamiliar systems;
+- state/lifecycle correctness;
+- performance investigation;
+- test design;
+- source archaeology;
+- technical depth in resume projects;
+- learning velocity.
+
+## Drill generator from the existing corpus
+
+A future Scrapbook practice surface should be able to generate multiple drill modes from work records.
+
+### Recall
+
+"Explain why `RegExp.lastIndex` mattered in AI SDK in 60 seconds."
+
+### Reimplementation
+
+"Implement a helper that evaluates a stateful regex from index zero and restores caller state even on throw."
+
+### Debugging
+
+"A cache is correct but end-to-end latency barely moves. What discriminators do you run next?"
+
+### Test design
+
+"`clearStorage()` races a pending async hydration. Write the smallest controls that establish desired semantics."
+
+### System design
+
+"Design a replay-safe GitHub file publication API with exact preconditions and ambiguous-result recovery."
+
+### Systems
+
+"Why is SSH loss not equivalent to completed VM shutdown? What event/state should own the transition?"
+
+### Performance
+
+"A log timeline attributes 13 seconds to texture loading. Design an instrument that can disprove that attribution."
+
+### Behavioral
+
+"Tell me about a technically correct observation that led you to the wrong repair boundary."
+
+### Language transfer
+
+"Rewrite one familiar TypeScript state-machine/caching exercise in Rust, Java, Go or C++ and discuss what semantic assumptions changed."
+
+## External calibration notes
+
+Current official examples support treating the union seriously rather than assuming every modern company has abandoned conventional loops.
+
+- Vercel has publicly described an intern interview that mimicked on-the-job problem solving, encouraged clarifying questions and Google, and emphasized reasoning aloud rather than LeetCode-style traps. This is useful directional evidence, not a guarantee that every 2026 full-time loop is identical.
+- Amazon's current SDE II preparation explicitly combines timed coding, system-design scenarios and behavioral/work-style evaluation; its loop includes multiple interviews and expects syntactically correct, robust, well-tested code.
+- Current Google SWE postings around the two-year experience band still explicitly mention data structures/algorithms in some roles, so conventional algorithm fluency remains useful even for a candidate whose real-world engineering is stronger than their puzzle practice.
+- Current Valve software-engineering descriptions still emphasize broad/deep engineering, shipping, self-direction, and—on game/hardware paths—C/C++.
+
+Therefore the robust strategy is hybrid: prepare practical debugging/building **and** conventional coding/design fundamentals.
+
+## Success criterion
+
+The end state is not "Leo can pass every possible interview question."
+
+It is:
+
+> Given a plausible SWE interview format for a role Leo should reasonably target, there is no predictable category where the candidate is obviously underprepared relative to the strength of the underlying engineering evidence.
+
+That is the all-cause interview success set.

--- a/work/records/prerequisite-doctrine.md
+++ b/work/records/prerequisite-doctrine.md
@@ -1,0 +1,174 @@
+# Interview prerequisite doctrine
+
+Updated: 2026-08-11
+
+This record captures a preparation principle that changes the interpretation of the broader all-cause interview-success set.
+
+## Starting evidence
+
+Leo has already passed a Google L3 software-engineering loop strongly. That matters because it is concrete evidence that conventional algorithmic/coding interviews are not an inherently inaccessible category when the expected preparation surface is known and practiced.
+
+The preparation problem should therefore not be modeled as "become generally smarter" or "grind an unlimited number of interview questions."
+
+The working model is:
+
+> remove information asymmetry, identify the prerequisite graph, learn it deliberately, then verify recall and execution under the actual interview constraints.
+
+Algorithms remain part of the coverage set because skills decay and companies vary. They are maintenance unless evidence shows a fresh weakness.
+
+## The enemy: hidden prerequisites
+
+Many interview failures are not caused by inability to learn the tested material. They are caused by discovering too late that a company silently expected a particular body of knowledge, vocabulary, language fluency, interview convention, or problem shape.
+
+Examples:
+
+- a systems role assumes practical C++ object-lifetime fluency even though the project discussion is language-agnostic;
+- a distributed-systems interview expects standard vocabulary around leases, fencing, idempotency, consistency and backpressure;
+- a product-infrastructure loop expects HTTP/cache/CDN fundamentals that were not emphasized in the recruiter conversation;
+- an ordinary coding round assumes graph/heap/interval patterns have stayed warm;
+- a debugging round rewards aggressive narrowing rather than the open-ended research style appropriate to Fieldwork;
+- a behavioral round expects concise ownership/conflict/failure stories rather than a raw technical chronology;
+- a company allows documentation/search but not LLM assistance, changing the implementation-speed requirement;
+- a game/runtime role assumes C++ and graphics/runtime vocabulary even when the candidate's transferable reasoning is strong.
+
+These are discoverable prerequisites. The preparation system should hunt them explicitly.
+
+## Per-pipeline prerequisite map
+
+Before serious preparation for an interview, construct one current map with four layers.
+
+### 1. Explicit requirements
+
+Read the current job description, recruiter material, official interview-prep pages and any instructions attached to the scheduled rounds.
+
+Capture:
+
+- languages and frameworks named;
+- systems/domain concepts named;
+- seniority and ownership expectations;
+- interview round labels;
+- allowed tools;
+- expected artifact/work-sample format;
+- role-specific operational experience;
+- product/team surface.
+
+### 2. Strongly implied prerequisites
+
+Infer only what the role/interview structure reasonably implies.
+
+Examples:
+
+- CDN/content infrastructure -> HTTP caching, cache keys, invalidation, origin/edge behavior, observability;
+- game/runtime -> C++, memory/lifetime, profiling, frame/runtime thinking;
+- workflows/agent infrastructure -> queues, retries, durable state, idempotency, cancellation, leases/fencing;
+- SDK/devtools -> API compatibility, streams/async behavior, package/runtime boundaries, testing;
+- low-level systems -> processes, files, signals, memory, concurrency, OS/kernel interfaces.
+
+Do not confuse a plausible prerequisite with a requirement. Tag inference separately from explicit evidence.
+
+### 3. Interview-format prerequisites
+
+Research the current mechanics where reliable information exists:
+
+- timed algorithmic coding;
+- practical implementation;
+- debugging/code reading;
+- system design;
+- project deep dive;
+- behavioral;
+- take-home/work sample;
+- language-specific or domain-specific round.
+
+The format itself changes what "knowing" means. A concept that can be explained with notes is not necessarily available under a 35-minute coding round.
+
+### 4. Personal delta
+
+For every prerequisite, mark one of:
+
+- **proven/warm** — recently demonstrated under similar constraints;
+- **known/cold** — understood but retrieval/implementation speed needs refresh;
+- **transferable** — adjacent evidence exists; learn the local vocabulary/idioms;
+- **new but bounded** — real prerequisite with a finite syllabus;
+- **evidence gap** — cannot be fixed by studying alone (for example years operating a production fleet);
+- **unknown** — requires more reconnaissance before allocating study time.
+
+The point is to turn vague anxiety into a finite dependency graph.
+
+## Study order
+
+Once the map exists:
+
+1. eliminate unknowns that could materially change the syllabus;
+2. learn genuinely new bounded prerequisites;
+3. warm known-but-cold foundations;
+4. translate existing deep knowledge into the target domain's vocabulary;
+5. practice the exact interview operation: code, debug, design, explain, review, or write;
+6. run timed/simulated verification;
+7. update the map from failures rather than repeating already-mastered material.
+
+Study breadth should follow expected failure probability, not generic prestige.
+
+## Definition of mastery
+
+For an interview prerequisite, "I have read about it" is not enough.
+
+A useful ladder is:
+
+- **recognize** — identify the concept and why it matters;
+- **explain** — give a clear two-minute account without notes;
+- **apply** — solve a representative bounded problem;
+- **implement** — produce correct code/design from a blank surface;
+- **debug** — recognize the concept when disguised inside a failure;
+- **transfer** — apply the same principle in another language/system;
+- **defend** — answer adversarial follow-ups and trade-offs;
+- **timed** — do the relevant operation within interview constraints.
+
+Not every prerequisite needs the final rung. The interview format determines the required rung.
+
+## Information parity as an operating goal
+
+The motivating principle is not that Leo is guaranteed to outperform every candidate once preparation is equal. That cannot be known in advance.
+
+The actionable claim is stronger than ordinary confidence and narrower than omnipotence:
+
+> When the expected knowledge surface is made explicit, Leo has unusually high motivation and learning throughput, and prior evidence shows he can convert a known syllabus into strong interview performance. Therefore remove avoidable information asymmetry as aggressively as possible.
+
+This turns preparation into an engineering problem.
+
+For every pipeline, ask:
+
+- What can they test?
+- What prerequisites does each test depend on?
+- Which are explicit, implied, or merely rumored?
+- Which have already been proven in real work?
+- Which are cold versus genuinely absent?
+- What is the smallest exercise that verifies each prerequisite at the required depth?
+- What new information would cause us to change the study plan?
+
+## Role of agents
+
+Agents should do most of the reconnaissance and curriculum assembly in parallel.
+
+Useful lanes include:
+
+- current job-description extraction;
+- current interview-process research with source quality/date tracking;
+- prerequisite decomposition by round;
+- mapping prerequisites to Leo's existing work evidence;
+- generating drills from real backlog incidents;
+- identifying missing vocabulary or language idioms;
+- producing concise reading lists and implementation exercises;
+- simulating interview follow-ups;
+- retaining outcomes so later pipelines reuse the work.
+
+Leo's scarce attention should go primarily to learning, active recall, implementation, mock interviews, and deciding where the evidence is ambiguous.
+
+## Consequence for the all-cause success set
+
+The all-cause set remains useful, but its risk ranking should be dynamic.
+
+Do not assume conventional algorithms are the highest risk merely because many candidates fail them. Leo has already passed a Google L3 loop. Keep them warm and measure current performance.
+
+The highest-value lane is instead **prerequisite discovery and targeted closure**: locate whatever this particular pipeline can expose that is not currently callable under interview conditions.
+
+The objective is a level knowledge playing field wherever preparation can create one.


### PR DESCRIPTION
## Purpose

Make the living work record reflect how Leo actually uses it: synthesize quickly, preserve useful conclusions while they are fresh, then let later agents retrieve and reconcile the corpus when a concrete decision needs it.

## Change

- link the new `working-style` and point-in-time Vercel fit records from `work/README.md`;
- make **append first, reconcile later** an explicit operating principle;
- define agents as part of the retrieval/reconciliation layer, not only implementation throughput;
- tell future career work to refresh current job descriptions and time-sensitive hiring facts before updating role-fit claims.

## Boundary

Documentation only. No runtime or public `/work` selection change in this PR.

Note: the two new records themselves were added directly to `main` immediately before this branch; that bypassed the ordinary Scrapbook PR lane. This PR restores the normal process for the durable cross-links/instructions.