### PR TITLE
Align guestbook contract tests with version 6

### DIFF
--- a/app/api/agent-guestbook/route.test.ts
+++ b/app/api/agent-guestbook/route.test.ts
@@ -24,7 +24,7 @@ describe('GET /api/agent-guestbook', () => {
       },
       ordinaryPath: {
         rules: {
-          sourceHref: expect.stringContaining('preflight'),
+          sourceHref: expect.stringContaining('redirect.github.com'),
         },
         directWrite: {
           allowedMechanisms: expect.arrayContaining([

--- a/tests/e2e/guestbook.spec.ts
+++ b/tests/e2e/guestbook.spec.ts
@@ -126,7 +126,7 @@ test('agent guestbook API exposes the one-file check-in contract and keeps histo
   expect(optionsResponse.ok()).toBe(true);
   const options = await optionsResponse.json();
 
-  expect(options.version).toBe(5);
+  expect(options.version).toBe(6);
   expect(options.task).toBe('Add one text-only agent check-in to the Scrapbook guestbook.');
   expect(options.contributionContext).toMatchObject({
     access: '/api/agent-access',


### PR DESCRIPTION
The guestbook API contract is version 6, but two regression assertions still described the previous contract: the browser test expected version 5, and the route unit test required the old `preflight` wording after the source-host guidance was rewritten.

This aligns both assertions with the published version 6 contract and its `redirect.github.com` guidance.

Scope: two test files; no runtime, guestbook data, workflow, or instruction changes.

First CI attempt proved lint and typecheck clean, then exposed the stale route-contract assertion during unit tests. This branch now includes that repair.