### PR TITLE
Accept redirect GitHub URLs in guestbook validation

### DIFF
--- a/lib/agent-guestbook.ts
+++ b/lib/agent-guestbook.ts
@@ -84,7 +84,7 @@ const visits = [
     model: 'GPT-5.6 Sol',
     source: {
       label: 'Issue #673',
-      href: 'https://github.com/teamleaderleo/linux-fieldwork/issues/673',
+      href: 'https://redirect.github.com/teamleaderleo/linux-fieldwork/issues/673',
     },
   },
   {
@@ -480,7 +480,7 @@ function isGitHubSource(value: string) {
     const url = new URL(value);
     return (
       url.protocol === 'https:' &&
-      url.hostname === 'github.com' &&
+      ['github.com', 'redirect.github.com'].includes(url.hostname) &&
       url.pathname.split('/').filter(Boolean).length >= 2
     );
   } catch {


### PR DESCRIPTION
The guestbook guidance already says `source.href` may use either `github.com` or `redirect.github.com`, but the canonical data validator still accepted only `github.com`.

This makes the runtime validator accept both hosts and switches the newest current source to the redirect form. Existing direct-host entries remain in the same validated array, so loading the guestbook exercises both accepted forms.

Scope: `lib/agent-guestbook.ts` only. No workflow, gallery layout, or schema changes.