### PR TITLE
Add a quiet current-work shelf to Home

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -240,28 +240,27 @@ export default function Page() {
       <div className="relative mx-auto flex min-h-[calc(100dvh-3rem)] w-full max-w-7xl flex-col justify-start gap-10 px-4 py-5 sm:px-6 sm:py-7 lg:px-8 lg:py-8">
         <OperatorConsole mode="featured" />
 
-        <section aria-labelledby="home-activity-title" className="min-w-0">
-          <div className="mb-3 px-0.5">
-            <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-              Activity
-            </p>
-            <h2
-              id="home-activity-title"
-              className="mt-1 text-xl font-black tracking-tight"
-            >
-              GitHub, still here
-            </h2>
-          </div>
-          <Suspense fallback={<HomeActivitySkeleton />}>
-            <HomeActivityContent />
-          </Suspense>
-          <div className="mt-4 sm:mt-5">
-            <HomeNowShelf />
-          </div>
-          <div className="mt-4 sm:mt-5">
-            <HomeRoomShelf />
-          </div>
-        </section>
+        <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
+          <section aria-labelledby="home-activity-title" className="min-w-0">
+            <div className="mb-3 px-0.5">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Activity
+              </p>
+              <h2
+                id="home-activity-title"
+                className="mt-1 text-xl font-black tracking-tight"
+              >
+                GitHub, still here
+              </h2>
+            </div>
+            <Suspense fallback={<HomeActivitySkeleton />}>
+              <HomeActivityContent />
+            </Suspense>
+          </section>
+
+          <HomeNowShelf />
+          <HomeRoomShelf />
+        </div>
       </div>
     </ViewportPageShell>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -119,53 +119,55 @@ async function HomeActivityContent() {
           ))}
         </div>
       </section>
-
-      <HomeNowShelf />
-
-      <section
-        aria-labelledby="explore-scrapbook-title"
-        className="min-w-0 md:hidden"
-        data-home-room-shelf
-      >
-        <div className="px-0.5">
-          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
-            Explore
-          </p>
-          <h2
-            id="explore-scrapbook-title"
-            className="mt-1 text-lg font-semibold tracking-tight"
-          >
-            Open a room
-          </h2>
-        </div>
-
-        <div className="-mx-4 mt-2.5 grid snap-x snap-mandatory grid-flow-col auto-cols-[10.5rem] gap-2.5 overflow-x-auto px-4 pb-2">
-          {homeRoomNavigationItems.map(destination => {
-            const Icon = homeRoomIcons[destination.id] ?? Compass;
-            return (
-              <Link
-                key={destination.id}
-                href={destination.href}
-                prefetch
-                data-home-room-link={destination.id}
-                className="group flex min-h-28 snap-start flex-col justify-between rounded-2xl border border-border/65 bg-card p-3.5 text-card-foreground shadow-[0_8px_20px_rgba(35,31,26,0.07)] transition-[border-color,background-color,box-shadow] hover:border-foreground/25 hover:bg-card/95 hover:shadow-[0_14px_30px_rgba(35,31,26,0.11)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:shadow-[0_8px_20px_rgba(0,0,0,0.22)]"
-              >
-                <span className="grid h-10 w-10 place-items-center rounded-xl border border-border/70 bg-background/60">
-                  <Icon className="h-5 w-5" aria-hidden="true" />
-                </span>
-                <span className="flex items-center justify-between gap-2 font-semibold">
-                  {destination.label}
-                  <ArrowRight
-                    className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
-                    aria-hidden="true"
-                  />
-                </span>
-              </Link>
-            );
-          })}
-        </div>
-      </section>
     </div>
+  );
+}
+
+function HomeRoomShelf() {
+  return (
+    <section
+      aria-labelledby="explore-scrapbook-title"
+      className="min-w-0 md:hidden"
+      data-home-room-shelf
+    >
+      <div className="px-0.5">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+          Explore
+        </p>
+        <h2
+          id="explore-scrapbook-title"
+          className="mt-1 text-lg font-semibold tracking-tight"
+        >
+          Open a room
+        </h2>
+      </div>
+
+      <div className="-mx-4 mt-2.5 grid snap-x snap-mandatory grid-flow-col auto-cols-[10.5rem] gap-2.5 overflow-x-auto px-4 pb-2">
+        {homeRoomNavigationItems.map(destination => {
+          const Icon = homeRoomIcons[destination.id] ?? Compass;
+          return (
+            <Link
+              key={destination.id}
+              href={destination.href}
+              prefetch
+              data-home-room-link={destination.id}
+              className="group flex min-h-28 snap-start flex-col justify-between rounded-2xl border border-border/65 bg-card p-3.5 text-card-foreground shadow-[0_8px_20px_rgba(35,31,26,0.07)] transition-[border-color,background-color,box-shadow] hover:border-foreground/25 hover:bg-card/95 hover:shadow-[0_14px_30px_rgba(35,31,26,0.11)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:shadow-[0_8px_20px_rgba(0,0,0,0.22)]"
+            >
+              <span className="grid h-10 w-10 place-items-center rounded-xl border border-border/70 bg-background/60">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <span className="flex items-center justify-between gap-2 font-semibold">
+                {destination.label}
+                <ArrowRight
+                  className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5"
+                  aria-hidden="true"
+                />
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
@@ -253,6 +255,12 @@ export default function Page() {
           <Suspense fallback={<HomeActivitySkeleton />}>
             <HomeActivityContent />
           </Suspense>
+          <div className="mt-4 sm:mt-5">
+            <HomeNowShelf />
+          </div>
+          <div className="mt-4 sm:mt-5">
+            <HomeRoomShelf />
+          </div>
         </section>
       </div>
     </ViewportPageShell>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { ActivityDashboard } from '@/components/home/activity-dashboard';
+import { HomeNowShelf } from '@/components/home/home-now-shelf';
 import { OperatorConsole } from '@/components/operator/operator-console';
 import { Skeleton } from '@/components/ui/skeleton';
 import ViewportPageShell from '@/components/viewport-page-shell';
@@ -23,9 +24,9 @@ import { Suspense } from 'react';
 import styles from './page.module.css';
 
 export const metadata: Metadata = {
-  title: 'Leo · Operator',
+  title: 'Leo · Scrapbook',
   description:
-    'Copyable operator phrases, recent GitHub activity, and Scrapbook rooms.',
+    'Operator tools, current writing and learning, recent GitHub activity, and Scrapbook rooms.',
   alternates: { canonical: '/' },
 };
 
@@ -118,6 +119,8 @@ async function HomeActivityContent() {
           ))}
         </div>
       </section>
+
+      <HomeNowShelf />
 
       <section
         aria-labelledby="explore-scrapbook-title"

--- a/components/home/home-now-shelf.tsx
+++ b/components/home/home-now-shelf.tsx
@@ -13,7 +13,7 @@ function latestLearningRecord() {
 }
 
 export function HomeNowShelf() {
-  const workbench = botDeskEntries[0];
+  const workbench = botDeskEntries.find(entry => entry.publicationState === 'Published');
   const learning = latestLearningRecord();
   const visit = agentVisits[0];
 

--- a/components/home/home-now-shelf.tsx
+++ b/components/home/home-now-shelf.tsx
@@ -1,0 +1,102 @@
+import { agentVisits } from '@/lib/agent-guestbook';
+import { botDeskEntries } from '@/lib/bot-desk';
+import { publicLearningRecords } from '@/lib/learning-records';
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+
+function latestLearningRecord() {
+  return [...publicLearningRecords].sort((left, right) => {
+    const leftDate = left.revisions.at(-1)?.createdAt ?? '';
+    const rightDate = right.revisions.at(-1)?.createdAt ?? '';
+    return rightDate.localeCompare(leftDate);
+  })[0];
+}
+
+export function HomeNowShelf() {
+  const workbench = botDeskEntries[0];
+  const learning = latestLearningRecord();
+  const visit = agentVisits[0];
+
+  const items = [
+    workbench
+      ? {
+          id: `workbench-${workbench.slug}`,
+          kind: 'new dispatch',
+          title: workbench.title,
+          note: workbench.blurb,
+          href: `/desk/${workbench.slug}`,
+        }
+      : null,
+    learning
+      ? {
+          id: `learning-${learning.slug}`,
+          kind: 'studying',
+          title: learning.title,
+          note: learning.spark,
+          href: learning.canonicalUrl,
+        }
+      : null,
+    visit
+      ? {
+          id: `visit-${visit.id}`,
+          kind: 'agent visit',
+          title: visit.name,
+          note: visit.note,
+          href: `/gallery#visit-${visit.id}`,
+        }
+      : null,
+  ].filter((item): item is NonNullable<typeof item> => Boolean(item));
+
+  if (items.length === 0) return null;
+
+  return (
+    <section aria-labelledby="home-now-title" className="min-w-0" data-home-now-shelf>
+      <div className="mb-2 flex items-end justify-between gap-4 px-0.5">
+        <div>
+          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+            Now
+          </p>
+          <h2 id="home-now-title" className="mt-1 text-base font-semibold tracking-tight">
+            On the desk
+          </h2>
+        </div>
+        <Link
+          href="/atlas"
+          className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          Site Atlas
+        </Link>
+      </div>
+
+      <div className="grid min-w-0 overflow-hidden rounded-xl border border-border/65 bg-card/70 sm:grid-cols-3">
+        {items.map((item, index) => (
+          <Link
+            key={item.id}
+            href={item.href}
+            data-home-now-kind={item.kind}
+            className="group flex min-h-24 min-w-0 flex-col justify-between gap-3 border-border/55 px-3.5 py-3 transition-colors hover:bg-muted/55 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&:nth-child(n+2)]:border-t sm:[&:nth-child(n+2)]:border-l sm:[&:nth-child(n+2)]:border-t-0"
+          >
+            <span className="font-mono text-[8px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              {item.kind}
+            </span>
+            <span className="flex min-w-0 items-end justify-between gap-3">
+              <span className="min-w-0">
+                <span className="block line-clamp-1 text-sm font-semibold tracking-tight">
+                  {item.title}
+                </span>
+                <span className="mt-1 block line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                  {item.note}
+                </span>
+              </span>
+              <ArrowRight
+                className="mb-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+                aria-hidden="true"
+              />
+            </span>
+            <span className="sr-only">Item {index + 1} of {items.length}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/home/home-now-shelf.tsx
+++ b/components/home/home-now-shelf.tsx
@@ -51,21 +51,13 @@ export function HomeNowShelf() {
 
   return (
     <section aria-labelledby="home-now-title" className="min-w-0" data-home-now-shelf>
-      <div className="mb-2 flex items-end justify-between gap-4 px-0.5">
-        <div>
-          <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
-            Now
-          </p>
-          <h2 id="home-now-title" className="mt-1 text-base font-semibold tracking-tight">
-            On the desk
-          </h2>
-        </div>
-        <Link
-          href="/atlas"
-          className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-        >
-          Site Atlas
-        </Link>
+      <div className="mb-2 px-0.5">
+        <p className="font-mono text-[9px] font-semibold uppercase tracking-[0.17em] text-muted-foreground">
+          Now
+        </p>
+        <h2 id="home-now-title" className="mt-1 text-base font-semibold tracking-tight">
+          On the desk
+        </h2>
       </div>
 
       <div className="grid min-w-0 overflow-hidden rounded-xl border border-border/65 bg-card/70 sm:grid-cols-3">

--- a/components/home/home-now-shelf.tsx
+++ b/components/home/home-now-shelf.tsx
@@ -21,7 +21,7 @@ export function HomeNowShelf() {
     workbench
       ? {
           id: `workbench-${workbench.slug}`,
-          kind: 'new dispatch',
+          kind: 'latest writing',
           title: workbench.title,
           note: workbench.blurb,
           href: `/desk/${workbench.slug}`,

--- a/tests/e2e/home-now-shelf.spec.ts
+++ b/tests/e2e/home-now-shelf.spec.ts
@@ -11,7 +11,7 @@ test('shows a bounded repository-backed now shelf with canonical destinations', 
   const items = shelf.locator('[data-home-now-kind]');
   await expect(items).toHaveCount(3);
 
-  await expect(shelf.locator('[data-home-now-kind="new dispatch"]')).toHaveAttribute(
+  await expect(shelf.locator('[data-home-now-kind="latest writing"]')).toHaveAttribute(
     'href',
     /^\/desk\//
   );

--- a/tests/e2e/home-now-shelf.spec.ts
+++ b/tests/e2e/home-now-shelf.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test('shows a bounded repository-backed now shelf with canonical destinations', async ({ page }) => {
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const shelf = page.locator('[data-home-now-shelf]');
+  await expect(shelf).toBeVisible({ timeout: 15_000 });
+  await expect(shelf.getByRole('heading', { name: 'On the desk' })).toBeVisible();
+
+  const items = shelf.locator('[data-home-now-kind]');
+  await expect(items).toHaveCount(3);
+
+  await expect(shelf.locator('[data-home-now-kind="new dispatch"]')).toHaveAttribute(
+    'href',
+    /^\/desk\//
+  );
+  await expect(shelf.locator('[data-home-now-kind="studying"]')).toHaveAttribute(
+    'href',
+    /^\/space\/records\//
+  );
+  await expect(shelf.locator('[data-home-now-kind="agent visit"]')).toHaveAttribute(
+    'href',
+    /^\/gallery#visit-/
+  );
+});


### PR DESCRIPTION
Implements the first bounded slice of issue #569.

Home now surfaces exactly three repository-backed public items after the activity repositories and before the mobile room shelf:
- newest Workbench entry whose `publicationState` is `Published`;
- most recently revised public learning record;
- newest Guest Check-in, deep-linked to its Gallery visitor anchor.

The shelf adds no database or external request. It reads existing registries during server rendering, keeps the GitHub activity instrument ahead of it, and adds a focused browser regression for item count and destination families.

The repository-backed shelf and the existing mobile room shelf sit outside the GitHub activity `Suspense` boundary, so upstream GitHub latency does not delay local navigation/content and the activity fallback owns only the geometry it actually replaces. They are also sibling sections in the page hierarchy, instead of being announced as part of the GitHub activity section.

Also updates homepage metadata to describe Scrapbook's current operator/writing/learning/activity mix.

Self-review removed an invalid `/atlas` link, separated local shelves from GitHub suspense, corrected the section hierarchy, and made Workbench selection explicitly published-only.