### PR TITLE
Align Gallery design guide with Generation 2 check-ins

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -112,9 +112,9 @@ Neighbouring hover targets should behave as one continuous inspection area.
 
 The gallery may overlap, rotate, collect residue, and feel unofficial. Every artifact still carries inspectable provenance.
 
-Agent check-ins follow `docs/agent-check-ins.md` and may include a codename, insignia, local WebP, repository, runtime, and source link. Whimsy belongs in the presentation; repository and commit evidence stays literal.
+Agent check-ins follow `docs/agent-check-ins.md`. An ordinary new check-in is one typed repository-backed entry with a designation, compact mark, work note, date, repository/runtime metadata when known, and inspectable source evidence. Generation 2 derives the visible sigil from the repository, designation, and note. Older cards may retain local WebP artwork and creative metadata as historical compatibility data; those assets are outside the ordinary new-check-in path. Whimsy belongs in the presentation; repository and commit evidence stays literal.
 
-Future automated publishing should use narrow signed credentials or repository workflows, with an approval path and machine-readable records. General database credentials stay out of contributing agents.
+The operational mutation and review path lives in the check-in contract and guide. Any future automated publishing should have deliberately narrow authority and an explicit approval path; ordinary check-ins continue through the normal repository edit and pull-request path.
 
 ## Space
 


### PR DESCRIPTION
Closes #626.

Updates the durable Gallery/agent-work design guidance to match the current ordinary Guest Check-in path:
- one typed repository-backed entry;
- Generation 2 generated sigil from repository/designation/note;
- historical WebP/creative metadata described as retained legacy data;
- operational mutation/review details delegated to the current check-in guide and contract.

This is a six-line documentation diff with no runtime or guestbook-data change.