### PR TITLE
Align Workbench browser tests with current editorial state

### DIFF
--- a/tests/e2e/bot-desk.spec.ts
+++ b/tests/e2e/bot-desk.spec.ts
@@ -1,38 +1,38 @@
 import { expect, test } from '@playwright/test';
 
-test('Bot Desk exposes the publication index', async ({ page }) => {
+test('Workbench exposes the publication index', async ({ page }) => {
   const response = await page.goto('/desk');
   expect(response?.ok()).toBe(true);
-  await expect(page.getByRole('heading', { name: 'The Bot Desk' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Workbench' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Evidence journal' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'The Error Object Is an Input Boundary' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'The Fetch That Never Left the Worker' })).toBeVisible();
   await expect(page.locator('main')).toHaveCount(1);
 });
 
-test('Bot Desk renders a harvested agent-led draft', async ({ page }) => {
+test('Workbench renders a revised agent-led essay', async ({ page }) => {
   const response = await page.goto('/desk/the-error-object-is-an-input-boundary');
   expect(response?.ok()).toBe(true);
   await expect(page.getByRole('heading', { name: 'The Error Object Is an Input Boundary' })).toBeVisible();
-  await expect(page.getByText('Essay · Draft', { exact: true })).toBeVisible();
+  await expect(page.getByText('Essay · Revised', { exact: true })).toBeVisible();
   await expect(page.getByText('Agent-led', { exact: true })).toBeVisible();
   await expect(page.getByText('Published', { exact: true })).toBeVisible();
   await expect(page.getByText('JavaScript · error handling · trust boundaries · MCP', { exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'The trap inside the catch' })).toBeVisible();
 });
 
-test('Bot Desk renders a recovered article with separate editorial metadata', async ({ page }) => {
+test('Workbench renders a recovered revised article with separate editorial metadata', async ({ page }) => {
   const response = await page.goto('/desk/the-fetch-that-never-left-the-worker');
   expect(response?.ok()).toBe(true);
   await expect(page.getByRole('heading', { name: 'The Fetch That Never Left the Worker' })).toBeVisible();
-  await expect(page.getByText('Postmortem · Draft', { exact: true })).toBeVisible();
+  await expect(page.getByText('Postmortem · Revised', { exact: true })).toBeVisible();
   await expect(page.getByText('Agent-led', { exact: true })).toBeVisible();
   await expect(page.getByText('Published', { exact: true })).toBeVisible();
   await expect(page.getByText('Recovered archive', { exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'The innocent-looking line' })).toBeVisible();
 });
 
-test('a Desk essay continues into its exact evidence record', async ({ page }) => {
+test('a Workbench essay continues into its exact evidence record', async ({ page }) => {
   await page.goto('/desk/evaluation-structures');
 
   const related = page.locator('[data-scrapbook-related]');


### PR DESCRIPTION
The full Chromium sweep exposed three stale Workbench expectations after the public surface and editorial records evolved:

- `/desk` is headed `Workbench`, not `The Bot Desk`;
- `The Error Object Is an Input Boundary` is now `Essay · Revised`;
- `The Fetch That Never Left the Worker` is now `Postmortem · Revised`.

This updates only `tests/e2e/bot-desk.spec.ts` to assert the current published registry and page copy. Runtime code and editorial data stay unchanged.

The failures were discovered while validating PR #623; all three reproduced across retries while the rest of that Chromium run passed 134 tests.