### PR TITLE
Centralize the career-facing portfolio inventory

### DIFF
--- a/work/README.md
+++ b/work/README.md
@@ -23,11 +23,14 @@ The operating idea is simple:
 
 ## Files
 
+- [`portfolio-inventory.md`](portfolio-inventory.md) — unified retrieval index across owned systems, upstream contributions, adopted findings, reversals, reports, and research-only work; start here before a resume or LinkedIn rewrite.
 - [`resume-candidates.md`](resume-candidates.md) — intentionally churny ranking of the strongest current resume material.
 - [`records/preflight.md`](records/preflight.md) — detailed Preflight performance/product evidence and candidate stories.
 - [`records/open-source.md`](records/open-source.md) — selected open-source engineering evidence and the larger bench.
 - [`archive/2026-08-11-signal-audit.md`](archive/2026-08-11-signal-audit.md) — first broad snapshot of the current body of work and the narrative it supports.
 - [`AGENTS.md`](AGENTS.md) — local instructions for agents updating this record.
+
+The inventory is intentionally the central index rather than a second source of technical truth. Detailed records own the deeper story; source repositories and upstream threads own the facts.
 
 ## What belongs here
 

--- a/work/portfolio-inventory.md
+++ b/work/portfolio-inventory.md
@@ -1,0 +1,361 @@
+# Portfolio inventory
+
+This is the retrieval index for career-facing engineering evidence.
+
+It exists so a future resume, LinkedIn rewrite, portfolio page, interview packet, or application does not have to reconstruct the body of work from GitHub memory. It is deliberately broader than `resume-candidates.md` and much shorter than the source repositories.
+
+The source repositories, upstream issues/pull requests, benchmark packets, review threads, and CI receipts remain authoritative. This file records **what each body of work currently proves, what state the evidence is in, and where it belongs in a career narrative**.
+
+## Evidence classes used here
+
+Keep these distinctions explicit:
+
+- **landed / published** — the change actually merged or shipped upstream;
+- **maintainer-approved / accepted** — substantive upstream acceptance exists even if merge is separate;
+- **finding adopted through another landing path** — the diagnosis or repair mechanism was taken upstream, but the final PR/commit belongs to another author or automation path;
+- **finding accepted, repair boundary changed** — maintainers agreed there was a real problem but chose a different project-native repair;
+- **submitted / awaiting disposition** — public issue or PR exists, but external acceptance is not yet established;
+- **owned product / system** — evidence comes from a repository Leo controls rather than third-party review;
+- **research investigation** — mechanism and experiments are substantial, but it must not be represented as an upstream contribution.
+
+Merge count is useful evidence, not the ontology.
+
+---
+
+## Current headline pool
+
+### Preflight
+
+Repository: https://github.com/teamleaderleo/preflight
+
+Detailed Scrapbook record: [`records/preflight.md`](records/preflight.md)
+
+State: **owned performance system; strongest current independent-engineering artifact**.
+
+Current controlled timing evidence is the 2026-08-15 same-profile campaign carried in Preflight PR 440: 89.00s baseline median versus 15.53s accelerated median on one 83-mod profile, five accepted runs per condition, interleaved in one session, no exclusions.
+
+What it proves:
+
+- Java runtime and bytecode instrumentation in a codebase/ecosystem Leo does not own;
+- performance investigation using JFR, seam timing, replay harnesses, controlled A/B campaigns, and evidence archives;
+- exact compatibility identities and fail-open fallback rather than assuming cached/prepared work remains valid;
+- willingness to discard or reframe attractive optimization theories when better measurement disproves them;
+- packaging, diagnostics, rollback/update work, and productization beyond a benchmark script.
+
+Career use: **resume lock**. Largest owned-project allocation in a general, Valve/runtime, performance, or evaluation-oriented cut.
+
+### Vercel AI SDK
+
+Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
+
+State: **one direct merged/published fix plus two repairs adopted through AI SDK Factory with explicit co-author credit in merged upstream commits**.
+
+The clean public cluster covers stateful regular-expression evaluation and Web Streams cleanup/error-precedence behavior. One Factory-adopted repair was also propagated into maintained v5 and v6 release branches.
+
+What it proves:
+
+- subtle TypeScript/runtime state and lifecycle correctness;
+- focused regression design around repeated calls, cleanup, failure precedence, and caller-owned state;
+- ability to produce work that survives a fast-moving AI-tooling repository's own maintenance workflow.
+
+Career use: **resume lock**, especially for Vercel, AI tooling, developer tools, coding-agent infrastructure, and evaluation work.
+
+### Cloud Hypervisor
+
+Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
+
+State: **two merged upstream Rust/VMM contributions; deeper QCOW metadata-ownership repair under substantive maintainer review**.
+
+The merged work replaces SSH disappearance as a shutdown-completion proxy with the VMM's exact shutdown event, and replaces ACPI construction panic paths with typed boot errors. The QCOW follow-on reaches persistent metadata ownership/refcount ordering and failure/reopen safety.
+
+What it proves:
+
+- low-level systems work in a real VMM rather than only application/library code;
+- lifecycle synchronization, error propagation, architecture/feature validation, and persistent-state reasoning;
+- productive review iteration, including accepting and incorporating a deeper maintainer objection.
+
+Career use: **resume lock** for systems/infra and strong breadth proof elsewhere.
+
+### Vite and Cloudflare Workers SDK
+
+Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
+
+State:
+
+- Vite: one merged optimizer resource-lifecycle fix, a second lifecycle repair approved by two maintainers, and a config-idempotence follow-on in review;
+- Cloudflare Workers SDK: Access credential-cache repair human-approved with Wrangler CODEOWNERS satisfied; Miniflare teardown repair in active human review.
+
+What they prove:
+
+- repeated ability to enter large mature TypeScript monorepos and locate lifecycle/state boundaries;
+- resource cleanup, repeated-resolution idempotence, credential freshness, and teardown error semantics;
+- responsiveness to maintainer feedback without widening the patch unnecessarily.
+
+Career use: strong selected OSS specimens. Do not turn the resume into a logo wall when AI SDK + Cloud Hypervisor already establish the larger point.
+
+---
+
+## Accepted findings where the final landing path differed
+
+These are important because they demonstrate technical diagnosis and project-boundary judgment even when the final GitHub badge is not `merged` on Leo's PR.
+
+### Zustand — stale async hydration after `clearStorage()`
+
+Public report: https://github.com/pmndrs/zustand/discussions/3554
+
+Upstream landing: https://github.com/pmndrs/zustand/pull/3555
+
+State: **reported with a concrete repair; upstream subsequently merged the same core production mechanism through its own PR**.
+
+The report identified that `clearStorage()` could remove persisted state while an older async hydration remained authorized to publish afterward. Zustand already had a `hydrationVersion` generation for stale hydration; the proposed core repair was to advance that generation when clearing storage. Upstream PR 3555 merged that mechanism and broader regression coverage.
+
+Career interpretation: stronger than "filed a bug" and weaker/different than "my PR merged." Safe wording is that Leo **identified the race and supplied the generation-invalidation repair subsequently implemented upstream**.
+
+Resume value: technically clean but usually bench material because stronger landed specimens already prove async/state correctness.
+
+### BuildKit — rootless/rootful mount-point reproducibility
+
+Leo's PR: https://github.com/moby/buildkit/pull/7033
+
+Maintainer replacement: https://github.com/moby/buildkit/pull/7039
+
+State: **real divergence identified and submitted; maintainer replaced the repair with a different compatibility policy**.
+
+The underlying problem was rootless/rootful output divergence caused by mount points removed during rootless spec conversion. Leo's candidate cleaned the finalized runtime-created mount stubs after rootless conversion. The maintainer replacement kept the diagnosis but chose to restore the missing rootless mount points instead, preserving existing rootful output and avoiding a compatibility-version change.
+
+Career interpretation: this is a strong systems review story because the important disagreement is **which side of the compatibility boundary should move**, not whether the bug existed.
+
+Resume value: strong alternate for systems/container roles; usually interview/portfolio material in a general cut.
+
+### runc — `MaxCPU` boundary semantics
+
+Issue: https://github.com/opencontainers/runc/issues/5388
+
+Leo's PR: https://github.com/opencontainers/runc/pull/5389
+
+Maintainer replacement: https://github.com/opencontainers/runc/pull/5392
+
+State: **real off-by-one relationship identified; maintainer preferred repairing the historical semantic boundary on the other side; Leo agreed and closed the competing patch**.
+
+Leo's patch made the reset-mask allocation match the then-documented inclusive `MaxCPU` meaning. Maintainer review showed repository history supported making `MaxCPU` exclusive instead, which made the existing allocation expression correct and restored one meaning across the codebase.
+
+Career interpretation: excellent evidence of review judgment. The win is recognizing the symptom, understanding the historical boundary after review, and preferring the cleaner project-native repair over personal merge count.
+
+Resume value: interview story, not headline bullet.
+
+---
+
+## Public reports awaiting stronger external disposition
+
+### Playwright MCP HTTP shutdown authority
+
+Issue: https://github.com/microsoft/playwright/issues/42129
+
+State: **public bug report; no maintainer response recorded at the latest career refresh**.
+
+The MCP HTTP server exposed a fixed-header `/killkillkill` route that allowed an ordinary reachable HTTP client to trigger the server's graceful `SIGINT` shutdown path. The report traces why the test hook exists, distinguishes CSRF mitigation from caller/process ownership, provides a direct reproduction, and describes a prepared parent-stdin alternative that keeps lifecycle authority with the spawning process.
+
+Career interpretation: substantive authority/lifecycle analysis, but do not count it as external validation until upstream responds or acts.
+
+---
+
+## FEX research — third-party systems work, not an upstream contribution
+
+Primary Linux Fieldwork investigation: https://github.com/teamleaderleo/linux-fieldwork/pull/669
+
+Continuation: https://github.com/teamleaderleo/linux-fieldwork/issues/672
+
+State: **deep research investigation with owned-fork implementations and real runtime evidence; upstream FEX remains read-only/no-contact under its AI-generated-code policy**.
+
+The investigation began from Apple M5 → ARM Linux VM → FEX → x86 Vulkan/Wine execution and separated into two findings:
+
+1. a Vulkan dynamic proc-address routing hole that could bypass FEX's existing callback-safe custom path;
+2. a deeper generated-thunk executable-lifetime problem where a native function pointer remains valid while its guest-side generated adapter belongs to an unloaded wrapper generation.
+
+The lifetime work went beyond pinning as a workaround. It forced moved wrapper reloads, separated future-dispatch invalidation from already-selected executable code, reproduced the selected-before-unmap race, and compared ownership architectures. The strongest demonstrated long-term direction is a generated process-resident bridge containing only escaped executable glue while ordinary wrapper code/state remains unloadable. Real generated Vulkan and GL tests cover dynamic function pointers, host→guest callbacks, moved reloads, and a real amd64 `vulkaninfo --summary` under ARM64 FEX.
+
+What it proves if/when the human-owned implementation is prepared for external use:
+
+- dynamic-loader and executable-lifetime reasoning;
+- cross-ISA thunk/ABI mediation;
+- Vulkan/GL callback and function-pointer semantics;
+- concurrency/reclamation boundaries;
+- experimental design that lets plausible architectures lose.
+
+Career use **today**: private/internal portfolio and interview context only. Do not represent research code as upstream FEX contribution. If a compliant human-derived submission eventually exists, reclassify it then.
+
+For Valve/runtime/platform roles this is a particularly useful frame beside Preflight and Cloud Hypervisor because it makes the common thread unmistakably runtime/compatibility/systems work rather than one unusually deep game project.
+
+---
+
+# Owned systems inventory
+
+## Stensibly
+
+Repository: https://github.com/teamleaderleo/stensibly
+
+State: **live hosted coordination foundation; active product/system development**.
+
+Core thesis: the board shows work; the ledger governs who may do it. Stensibly separates responsibility from authority and keeps shared coordination state outside any particular model/runtime.
+
+Current implemented surface includes Convex-backed state, Cloudflare Worker API, browser sessions, bearer clients, REST v1, remote MCP, claims/renewable leases, events/artifacts/handoffs, idempotent commands, project/workspace scoping, and guarded exact-CAS GitHub publication. Recent work has pushed further into durable worker enrolment/selection, race-safe responsibility acceptance, continuation, mail/provider reconciliation, and explicit authority/effect boundaries.
+
+A recent merged example, PR 1532, takes a read-only work-selection recommendation and requires one exact owner-bound worker to atomically accept responsibility against the current item version, claim generation, work fingerprint, WIP budget, and independence rules. Competing workers racing on the same recommendation produce one winner and one refresh-required loser rather than duplicate ownership.
+
+What it proves:
+
+- system invention rather than isolated repair;
+- distributed coordination and race/lease semantics;
+- authn/authz, provenance, replay/idempotency, exact preconditions, and external-effect fencing;
+- ability to keep model behavior separate from server-owned authority.
+
+Career use: **strong owned-system specimen**. One dense line on a general resume; much larger allocation for agent infrastructure, durable execution, coordination, or reliability roles.
+
+Do not overstate: the README still explicitly says guarded single-project pilot, not unattended multi-project autonomy or irreversible effects.
+
+## SmolRunner
+
+Repository: https://github.com/teamleaderleo/smolrunner
+
+State: **pre-alpha; substantial durable controller foundations; no complete unattended disposable JIT-runner loop yet**.
+
+The product aims to turn an operator-owned Mac into bounded disposable GitHub Actions capacity using fresh Lima/VZ Linux workers while GitHub remains scheduler/status/log owner.
+
+The repository already contains durable attempts/catalogs, resource admission, exact worker/template/source identities, shell-free bounded process execution, ownership proofs, crash recovery, staged/atomic persistence, and fail-closed mutation rules. Current M3 work now consumes retained GitHub Runner Scale Set lifecycle evidence using exact request/job/runner identities rather than event ordering or mutable names.
+
+PRs 448–452 are a useful current slice: typed retained Scale Set events, exact job/request lookup, durable runner-request binding, fail-closed lifecycle reconciliation, and finally a paired durable catalog/delivery transaction that can atomically advance catalog revisions while binding crash recovery to exact prior/target bytes.
+
+What it proves:
+
+- Rust systems/control-plane design;
+- crash-consistent local state and recovery;
+- identity/ownership before destructive mutation;
+- CI runner/sandbox threat modeling;
+- careful separation of observation, authorization, planning, persistence, and execution.
+
+Career use: **strong for infra/systems/security/coding-agent execution roles**. Keep the pre-alpha boundary visible.
+
+## Elatura
+
+Repository: https://github.com/teamleaderleo/elatura
+
+State: **M0 evidence/observation on main; conceptually broad, live transformation still intentionally disabled**.
+
+Elatura is a local-first adaptive browser sidecar for oversized interactive applications. ChatGPT conversations large enough to freeze/crash a normal browser are the first workload, but the architecture is deliberately adapter-driven rather than ChatGPT-specific.
+
+Main already contains observe-only Firefox transport, content-free benchmark reports, generic adapter contracts/conformance, graph-shape inspection, synthetic oversized/malformed fixtures, active-path planning, fail-open orchestration, structural fingerprints, synthetic-only cache/materialization, representation/provenance contracts, and transform emergency controls.
+
+An open Firefox slimming stack explores bounded DOM discovery, latest-window planning, fail-open drift handling, content-free fixtures, preflight-before-mutation execution, and a browser host that records whether destructive mutation actually started so partial failure can force the existing Stock recovery path. These branches are experiments, not landed main behavior.
+
+What it proves:
+
+- a generalized product idea around **adaptive representation of oversized authenticated web applications**;
+- browser interception, privacy-preserving measurement, schema drift, fail-open transforms, cache/provenance contracts, and conservative authority gating;
+- a willingness to keep destructive behavior disabled until evidence and recovery semantics are strong enough.
+
+Career use: **high-concept owned-project bench**. Potentially strong for browser/runtime/product-infrastructure roles once a real live workload crosses the current safety gate. Do not present open slimming stacks as shipped behavior.
+
+## Renderprove
+
+Repository: https://github.com/teamleaderleo/renderprove
+
+State: **early-stage but working evidence tool**.
+
+Renderprove starts a trusted local app or inspects an existing deployment in Chromium and emits versioned browser evidence: screenshots and hashes, navigation/page facts, diagnostics, and policy disposition. It also has bounded local MCP, repeatability probes in fresh containers, bounded interaction plans, deterministic visual comparison, and optional advisory AI artifacts that remain explicitly non-authoritative.
+
+What it proves:
+
+- browser evidence contracts and deterministic/reproducible visual review;
+- security boundaries around agent-driven browser interaction;
+- separation of deterministic browser evidence from optional model advice;
+- a coherent place in the larger SmolRunner → Renderprove → Proofwake → Stensibly toolchain.
+
+Career use: supporting project, particularly for coding-agent evaluation, developer tooling, visual QA, and agent infrastructure. Usually below Preflight/Stensibly/SmolRunner on a one-page resume.
+
+## Proofwake
+
+Repository: https://github.com/teamleaderleo/proofwake
+
+State: **working local evidence index with durable ledger, collectors, reports/dashboard, diagnostics, Git/GitHub observation, and read-only MCP**.
+
+Proofwake stores content-minimised observations by repository/revision so humans and agents can ask what changed, which revisions have convincing evidence, what is failing/stale/silent, and what recovered. It explicitly does not schedule work, approve mutations, operate runners, deploy, or rank developers from raw activity.
+
+Recent merged work adds strict appendable evaluation observations, deterministic evaluation-evidence projections, and a read-only MCP view over those projections. An opt-in evaluation-write MCP transport remains separately gated/in review.
+
+What it proves:
+
+- append-oriented durable evidence modeling;
+- strict privacy/content-minimisation boundaries;
+- deterministic projections that preserve sparse/partial evidence instead of manufacturing a score;
+- useful systems composition with Renderprove/SmolRunner/Stensibly without collapsing their authority boundaries.
+
+Career use: supporting agent/evaluation/reliability project. More interesting as part of the broader toolchain than as a generic standalone resume bullet today.
+
+## Scrapbook / teamleaderleo.com
+
+Repository: https://github.com/teamleaderleo/scrapbook
+
+State: **live personal site, knowledge workspace, and agent-facing publication/evidence lab**.
+
+The current repository includes the private Supabase-backed Space workspace, public tools/experiments, Workbench publishing, repository-backed agent check-ins, an Agent Journal evidence ledger, machine-readable access/contribution contracts, GitHub activity integration, browser/native-history work, and explicit retirement of obsolete surfaces.
+
+What it proves:
+
+- long-lived product stewardship and willingness to delete/deprecate obsolete architecture;
+- a fairly unusual agent/human collaboration surface with explicit provenance and repository-backed publication;
+- frontend/product breadth alongside the lower-level systems work.
+
+Career use: useful supporting proof and a public container for the rest of the portfolio. It should not displace stronger technical specimens on a one-page systems/devtools resume.
+
+## Glossless and other owned projects
+
+Glossless remains the stronger role-specific owned specimen for frontend/product/graphics breadth. Keep it available for creator-tool, UI, browser, or graphics-oriented applications.
+
+Other repositories can remain discoverable through GitHub without becoming resume candidates merely because they exist. Promote them here when they add a genuinely new technical axis or external/product evidence.
+
+---
+
+# How to use this inventory later
+
+## One-page resume
+
+The one-page resume should remain ruthless. Current default hierarchy is roughly:
+
+1. Preflight;
+2. Vercel AI SDK;
+3. Cloud Hypervisor;
+4. the best role-specific Vite/Cloudflare/system specimen;
+5. one or two owned systems selected for the target: Stensibly, SmolRunner, Elatura, Glossless;
+6. compact IBM corroboration and education.
+
+Do not list Zustand, BuildKit, runc, Playwright, FEX, Renderprove, Proofwake, and Scrapbook all at once. Their existence strengthens the body of evidence even when they lose the one-page space competition.
+
+## LinkedIn
+
+LinkedIn does not need to mimic conventional employment history. A later rewrite can use a small number of project entries or a consolidated independent/open-source engineering section with concrete mechanisms and direct evidence links.
+
+Useful project candidates for LinkedIn are Preflight, Stensibly, SmolRunner, and potentially Elatura once its product boundary advances. Renderprove/Proofwake/Scrapbook fit better as supporting links or portfolio context unless a target audience specifically values them.
+
+## Interviews
+
+Keep the non-merge stories. BuildKit and runc are especially good because they show the ability to change conclusion after maintainer/project-history evidence. FEX is useful for systems depth if described as research rather than contribution. Zustand is useful for explaining substantive authorship when GitHub landing mechanics obscure it.
+
+## Applications
+
+Tailor by actual work:
+
+- **Valve / runtime / performance:** Preflight, Cloud Hypervisor, FEX research, SmolRunner, selected graphics/browser breadth;
+- **Vercel / devtools / AI runtime:** AI SDK, Vite, Cloudflare, Preflight, Stensibly;
+- **coding-agent evaluation / environments:** Preflight, AI SDK, SmolRunner, Renderprove, Proofwake, Stensibly, cross-repository OSS repair record;
+- **systems / infrastructure:** Cloud Hypervisor, BuildKit story, Preflight runtime work, SmolRunner, FEX research;
+- **agent coordination / durable execution:** Stensibly, SmolRunner, Proofwake, Renderprove, AI SDK.
+
+## Refresh rule
+
+Before exporting any claim to a resume, LinkedIn, application, or public portfolio:
+
+1. reread the current upstream/product state;
+2. distinguish merged, approved, adopted, replaced, submitted, and research-only status;
+3. use the smallest mechanism/result that demonstrates the work;
+4. preserve project-specific review reversals instead of laundering them into merge claims;
+5. prefer current controlled measurements over prettier chronological endpoints.


### PR DESCRIPTION
## Summary

- add one `work/portfolio-inventory.md` retrieval index for future resume, LinkedIn, portfolio, interview, and application work;
- unify the strongest owned systems, landed upstream work, maintainer-accepted/adopted findings, useful reversals, public reports, and research-only evidence without flattening their status differences;
- add current synthesis for Stensibly, SmolRunner, Elatura, Renderprove, Proofwake, Scrapbook itself, Zustand, BuildKit, runc, Playwright, and the FEX research lane;
- link the inventory from `work/README.md` as the starting point before future career rewrites.

## Evidence boundary

The source repositories and upstream review threads remain authoritative. The new inventory explicitly distinguishes merged/published work, maintainer acceptance, another landing path, a changed repair boundary, submitted work, owned systems, and research-only work.

FEX remains research/owned-fork evidence only under its upstream contribution policy. Open Elatura slimming branches remain experiments rather than shipped main behavior. SmolRunner retains its pre-alpha boundary, and Stensibly retains its guarded-pilot boundary.

No private recruiter details, compensation, credentials, mailbox content, or other private material is recorded.

## Validation / self-review

- branch starts exactly from current `main` and is zero commits behind;
- complete two-file diff inspected after writing: one 361-line career-synthesis index plus three index lines in `work/README.md`;
- current Stensibly atomic-worker-claim and SmolRunner durable Scale Set examples were rechecked against their merged PR state;
- exact-head CI run `31873021821` is green: lint, typecheck, unit tests, build, and Chromium regressions all passed;
- no runtime/public Work projection behavior changes;
- no third-party GitHub interaction or notification was created by this Scrapbook PR prose.

Ready for merge as a low-risk documentation-only career record update.