### PR TITLE
Refresh current career evidence after upstream landings

### DIFF
--- a/lib/work-records.test.ts
+++ b/lib/work-records.test.ts
@@ -12,7 +12,9 @@ describe('public work records', () => {
       expect(record.accomplishments.length).toBeGreaterThanOrEqual(2);
       expect(record.evidence.length).toBeGreaterThan(0);
       for (const evidence of record.evidence) {
-        expect(evidence.href).toMatch(/^https:\/\/github\.com\//);
+        expect(evidence.href).toMatch(
+          /^https:\/\/(?:github\.com|redirect\.github\.com)\//
+        );
       }
     }
   });

--- a/lib/work-records.test.ts
+++ b/lib/work-records.test.ts
@@ -12,9 +12,15 @@ describe('public work records', () => {
       expect(record.accomplishments.length).toBeGreaterThanOrEqual(2);
       expect(record.evidence.length).toBeGreaterThan(0);
       for (const evidence of record.evidence) {
-        expect(evidence.href).toMatch(
-          /^https:\/\/(?:github\.com|redirect\.github\.com)\//
-        );
+        const url = new URL(evidence.href);
+        const owner = url.pathname.split('/').filter(Boolean)[0];
+
+        expect(url.protocol).toBe('https:');
+        if (owner === 'teamleaderleo') {
+          expect(url.hostname).toBe('github.com');
+        } else {
+          expect(url.hostname).toBe('redirect.github.com');
+        }
       }
     }
   });

--- a/lib/work-records.ts
+++ b/lib/work-records.ts
@@ -24,7 +24,7 @@ export const workRecords: readonly WorkRecord[] = [
     summary:
       'A performance launcher for heavily modded Starsector. It prepares deterministic work before launch and intercepts only runtime seams whose source, class-loader, and bytecode contracts are known.',
     accomplishments: [
-      'A current controlled candidate campaign measured 89.00s baseline → 15.53s accelerated on the same 83-mod profile, with five interleaved accepted runs per condition and no exclusions.',
+      'A controlled campaign measured 89.00s baseline → 15.53s accelerated on the same 83-mod profile, with five interleaved accepted runs per condition and no exclusions.',
       'The product path keeps exact source/bytecode compatibility gates, prepared texture/data work, runtime adapter health reporting, and original-path fallback for changed or unsupported inputs.',
       'Built fail-open runtime adapters, launch instrumentation, persistent prepared artifacts, desktop packaging, and rollback-aware update work around a game and mod ecosystem we do not control.',
     ],
@@ -58,39 +58,44 @@ export const workRecords: readonly WorkRecord[] = [
     accomplishments: [
       'In Vercel AI SDK, directly merged and published a deterministic URL-regex fix; two independently developed Web Streams fixes were adopted by AI SDK Factory into merged upstream commits that credit teamleaderleo as co-author, with one also merged to the v5 and v6 release branches.',
       'Landed two Cloud Hypervisor fixes: exact shutdown-event gating before VM/disk reuse and typed ACPI table-construction failures instead of VMM panics.',
-      'Merged a Vite optimizer lifecycle fix; a second Vite teardown repair has two maintainer approvals, while a Cloudflare Access credential-cache repair is human-approved with Wrangler CODEOWNERS satisfied.',
+      'Merged a Vite optimizer lifecycle fix and a Cloudflare Miniflare teardown fix; a second Vite teardown repair has two maintainer approvals, while the Cloudflare Access credential-cache repair is human-approved with Wrangler CODEOWNERS satisfied.',
     ],
     reversal:
       'A real runc off-by-one was patched on the allocation side. Repository history showed the better repair belonged in MaxCPU semantics instead, so the proposed patch was closed rather than defended for its merge statistic.',
     evidence: [
       {
         label: 'AI SDK · deterministic URL matching',
-        href: 'https://github.com/vercel/ai/pull/18570',
+        href: 'https://redirect.github.com/vercel/ai/pull/18570',
         kind: 'pull-request',
       },
       {
         label: 'AI SDK Factory · async stream cleanup',
-        href: 'https://github.com/vercel/ai/pull/18400',
+        href: 'https://redirect.github.com/vercel/ai/pull/18400',
         kind: 'pull-request',
       },
       {
         label: 'AI SDK Factory · size-limit cleanup',
-        href: 'https://github.com/vercel/ai/pull/18695',
+        href: 'https://redirect.github.com/vercel/ai/pull/18695',
         kind: 'pull-request',
       },
       {
         label: 'Cloud Hypervisor · shutdown event',
-        href: 'https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8699',
+        href: 'https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8699',
         kind: 'pull-request',
       },
       {
         label: 'Cloud Hypervisor · typed ACPI failures',
-        href: 'https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8709',
+        href: 'https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8709',
         kind: 'pull-request',
       },
       {
         label: 'Vite · optimizer bundle lifecycle',
-        href: 'https://github.com/vitejs/vite/pull/23207',
+        href: 'https://redirect.github.com/vitejs/vite/pull/23207',
+        kind: 'pull-request',
+      },
+      {
+        label: 'Cloudflare · Miniflare disposal lifecycle',
+        href: 'https://redirect.github.com/cloudflare/workers-sdk/pull/15143',
         kind: 'pull-request',
       },
       {

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('Work presents a dense selected record with direct evidence', async ({
+test('Work presents a dense selected record with inspectable evidence', async ({
   page,
 }) => {
   await page.goto('/work');

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -15,7 +15,7 @@ test('Work presents a dense selected record with direct evidence', async ({
   );
   await expect(
     page.getByRole('link', { name: 'AI SDK · deterministic URL matching' })
-  ).toHaveAttribute('href', 'https://github.com/vercel/ai/pull/18570');
+  ).toHaveAttribute('href', 'https://redirect.github.com/vercel/ai/pull/18570');
   await expect(
     page.getByRole('link', { name: 'Read as JSON' })
   ).toHaveAttribute('href', '/api/work');

--- a/work/portfolio-inventory.md
+++ b/work/portfolio-inventory.md
@@ -32,7 +32,7 @@ Detailed Scrapbook record: [`records/preflight.md`](records/preflight.md)
 
 State: **owned performance system; strongest current independent-engineering artifact**.
 
-Current controlled timing evidence is the 2026-08-15 same-profile campaign carried in Preflight PR 440: 89.00s baseline median versus 15.53s accelerated median on one 83-mod profile, five accepted runs per condition, interleaved in one session, no exclusions.
+Current controlled timing evidence is the 2026-08-15 same-profile campaign merged through Preflight PR 440: 89.00s baseline median versus 15.53s accelerated median on one 83-mod profile, five accepted runs per condition, interleaved in one session, no exclusions.
 
 What it proves:
 
@@ -83,7 +83,7 @@ Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
 State:
 
 - Vite: one merged optimizer resource-lifecycle fix, a second lifecycle repair approved by two maintainers, and a config-idempotence follow-on in review;
-- Cloudflare Workers SDK: Access credential-cache repair human-approved with Wrangler CODEOWNERS satisfied; Miniflare teardown repair in active human review.
+- Cloudflare Workers SDK: Miniflare teardown repair merged; Access credential-cache repair human-approved with Wrangler CODEOWNERS satisfied and still open.
 
 What they prove:
 
@@ -101,9 +101,9 @@ These are important because they demonstrate technical diagnosis and project-bou
 
 ### Zustand — stale async hydration after `clearStorage()`
 
-Public report: https://github.com/pmndrs/zustand/discussions/3554
+Public report: https://redirect.github.com/pmndrs/zustand/discussions/3554
 
-Upstream landing: https://github.com/pmndrs/zustand/pull/3555
+Upstream landing: https://redirect.github.com/pmndrs/zustand/pull/3555
 
 State: **reported with a concrete repair; upstream subsequently merged the same core production mechanism through its own PR**.
 
@@ -115,9 +115,9 @@ Resume value: technically clean but usually bench material because stronger land
 
 ### BuildKit — rootless/rootful mount-point reproducibility
 
-Leo's PR: https://github.com/moby/buildkit/pull/7033
+Leo's PR: https://redirect.github.com/moby/buildkit/pull/7033
 
-Maintainer replacement: https://github.com/moby/buildkit/pull/7039
+Maintainer replacement: https://redirect.github.com/moby/buildkit/pull/7039
 
 State: **real divergence identified and submitted; maintainer replaced the repair with a different compatibility policy**.
 
@@ -129,11 +129,11 @@ Resume value: strong alternate for systems/container roles; usually interview/po
 
 ### runc — `MaxCPU` boundary semantics
 
-Issue: https://github.com/opencontainers/runc/issues/5388
+Issue: https://redirect.github.com/opencontainers/runc/issues/5388
 
-Leo's PR: https://github.com/opencontainers/runc/pull/5389
+Leo's PR: https://redirect.github.com/opencontainers/runc/pull/5389
 
-Maintainer replacement: https://github.com/opencontainers/runc/pull/5392
+Maintainer replacement: https://redirect.github.com/opencontainers/runc/pull/5392
 
 State: **real off-by-one relationship identified; maintainer preferred repairing the historical semantic boundary on the other side; Leo agreed and closed the competing patch**.
 
@@ -143,19 +143,21 @@ Career interpretation: excellent evidence of review judgment. The win is recogni
 
 Resume value: interview story, not headline bullet.
 
----
+### Playwright — MCP HTTP shutdown authority
 
-## Public reports awaiting stronger external disposition
+Issue: https://redirect.github.com/microsoft/playwright/issues/42129
 
-### Playwright MCP HTTP shutdown authority
+Maintainer landing: https://redirect.github.com/microsoft/playwright/pull/42133
 
-Issue: https://github.com/microsoft/playwright/issues/42129
+State: **finding accepted; maintainer-owned fix merged; report closed as completed**.
 
-State: **public bug report; no maintainer response recorded at the latest career refresh**.
+The report showed that the production MCP HTTP server exposed a fixed-header `/killkillkill` route that allowed an ordinary reachable HTTP client to trigger the server's graceful `SIGINT` shutdown path. It traced the route to a Windows lifecycle test, distinguished CSRF mitigation from caller/process ownership, and included a prepared parent-stdin alternative.
 
-The MCP HTTP server exposed a fixed-header `/killkillkill` route that allowed an ordinary reachable HTTP client to trigger the server's graceful `SIGINT` shutdown path. The report traces why the test hook exists, distinguishes CSRF mitigation from caller/process ownership, provides a direct reproduction, and describes a prepared parent-stdin alternative that keeps lifecycle authority with the spawning process.
+Upstream agreed with the authority problem but chose a smaller project-native boundary: PR 42133 gates `/killkillkill` on `isUnderTest()` so production MCP HTTP servers do not expose the test-only shutdown hook. That merged and closed the report.
 
-Career interpretation: substantive authority/lifecycle analysis, but do not count it as external validation until upstream responds or acts.
+Career interpretation: accepted diagnosis with a different final repair. The strong part is locating the lifecycle-authority leak and providing a reproducible report; do not claim the prepared stdin design as the upstream implementation.
+
+Resume value: solid accepted-finding/interview material, but usually below the merged Vite/Cloudflare/Cloud Hypervisor specimens on a one-page cut.
 
 ---
 
@@ -332,13 +334,13 @@ Do not list Zustand, BuildKit, runc, Playwright, FEX, Renderprove, Proofwake, an
 
 ## LinkedIn
 
-LinkedIn does not need to mimic conventional employment history. A later rewrite can use a small number of project entries or a consolidated independent/open-source engineering section with concrete mechanisms and direct evidence links.
+LinkedIn does not need to mimic conventional employment history. A later rewrite can use a small number of project entries or a consolidated independent/open-source engineering section with concrete mechanisms and evidence links.
 
 Useful project candidates for LinkedIn are Preflight, Stensibly, SmolRunner, and potentially Elatura once its product boundary advances. Renderprove/Proofwake/Scrapbook fit better as supporting links or portfolio context unless a target audience specifically values them.
 
 ## Interviews
 
-Keep the non-merge stories. BuildKit and runc are especially good because they show the ability to change conclusion after maintainer/project-history evidence. FEX is useful for systems depth if described as research rather than contribution. Zustand is useful for explaining substantive authorship when GitHub landing mechanics obscure it.
+Keep the non-merge stories. BuildKit and runc are especially good because they show the ability to change conclusion after maintainer/project-history evidence. Playwright is useful as an accepted diagnosis where upstream chose a smaller repair boundary. FEX is useful for systems depth if described as research rather than contribution. Zustand is useful for explaining substantive authorship when GitHub landing mechanics obscure it.
 
 ## Applications
 

--- a/work/records/open-source.md
+++ b/work/records/open-source.md
@@ -8,11 +8,11 @@ The useful claim is repeatability across unrelated systems: enter an unfamiliar 
 
 ### Vercel AI SDK — direct merge plus Factory adoption
 
-The current AI SDK record now has three distinct accepted repairs.
+The current AI SDK record has three distinct accepted repairs.
 
 #### Deterministic URL-regex evaluation
 
-Upstream PR: https://github.com/vercel/ai/pull/18570
+Upstream PR: https://redirect.github.com/vercel/ai/pull/18570
 
 State: **merged and published**.
 
@@ -29,9 +29,9 @@ The upstream bugfix review called the change fully addressing, low-risk, minimal
 
 #### Async stream reader cleanup after source errors
 
-Contributor PR: https://github.com/vercel/ai/pull/18371
+Contributor PR: https://redirect.github.com/vercel/ai/pull/18371
 
-Factory landing PR: https://github.com/vercel/ai/pull/18400
+Factory landing PR: https://redirect.github.com/vercel/ai/pull/18400
 
 State: **contributor repair approved; Factory implementation merged with explicit co-author credit**.
 
@@ -39,17 +39,17 @@ A rejected `reader.read()` could bypass cleanup in the AI SDK's async-iterable s
 
 The contributor PR reproduced the behavior across both helper implementations, preserved the exact source rejection, released the reader without cancelling an already errored stream, and covered exact, undefined, partial-consumption, concurrent, reacquisition, and subsequent-iteration cases in Node and Edge environments.
 
-AI SDK Factory reviewed the contributor PR as fully addressing and appropriately tested. The final upstream implementation landed through Factory PR #18400; the merged fix commit explicitly includes `Co-authored-by: teamleaderleo` alongside Lars Grammel.
+AI SDK Factory reviewed the contributor PR as fully addressing and appropriately tested. The final upstream implementation landed through Factory PR 18400; the merged fix commit explicitly includes `Co-authored-by: teamleaderleo` alongside Lars Grammel.
 
 That is stronger attribution than merely saying the idea overlapped upstream: the repository's own landing workflow preserved contributor credit in the merged commit.
 
 #### Preserve streamed size-limit errors when cancellation fails
 
-Contributor PR: https://github.com/vercel/ai/pull/18572
+Contributor PR: https://redirect.github.com/vercel/ai/pull/18572
 
-Factory landing PR: https://github.com/vercel/ai/pull/18695
+Factory landing PR: https://redirect.github.com/vercel/ai/pull/18695
 
-Release-branch landings: https://github.com/vercel/ai/pull/18700 and https://github.com/vercel/ai/pull/18702
+Release-branch landings: https://redirect.github.com/vercel/ai/pull/18700 and https://redirect.github.com/vercel/ai/pull/18702
 
 State: **contributor repair approved; Factory implementation merged with explicit co-author credit on main and merged into maintained v5/v6 release branches**.
 
@@ -57,13 +57,13 @@ State: **contributor repair approved; Factory implementation merged with explici
 
 The contributor PR contained cancellation rejection, preserved lock release, and added a native `ReadableStream` regression proving the size-limit error survives while cancellation is still attempted.
 
-AI SDK Factory reviewed the change as fully addressing with minimal scope. Factory PR #18695 landed the fix on main and its merged commits explicitly credit `teamleaderleo` as co-author. The same repair then landed through Factory PRs #18700 and #18702 on the v5 and v6 release branches.
+AI SDK Factory reviewed the change as fully addressing with minimal scope. Factory PR 18695 landed the fix on main and its merged commits explicitly credit `teamleaderleo` as co-author. The same repair then landed through Factory PRs 18700 and 18702 on the v5 and v6 release branches.
 
-Resume signal: **absolute lock** for Vercel/devtools and unusually strong general OSS evidence. The value is now a cluster: one direct merge plus two repairs independently adopted by the owning repository's maintenance system with retained co-author credit, including one propagated across three maintained branches.
+Resume signal: **absolute lock** for Vercel/devtools and unusually strong general OSS evidence. The value is a cluster: one direct merge plus two repairs independently adopted by the owning repository's maintenance system with retained co-author credit, including one propagated across three maintained branches.
 
 ### Cloud Hypervisor — exact shutdown lifecycle gates
 
-Upstream PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8699
+Upstream PR: https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8699
 
 State: **merged**.
 
@@ -77,7 +77,7 @@ Resume signal: **lock**. Strong lifecycle/concurrency correctness story in a rea
 
 ### Cloud Hypervisor — propagate ACPI construction failures
 
-Upstream PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8709
+Upstream PR: https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8709
 
 State: **merged**.
 
@@ -93,7 +93,7 @@ Resume signal: best paired with the lifecycle PR as one Cloud Hypervisor entry r
 
 ### Cloud Hypervisor — QCOW L2 ownership before L1 publication
 
-Upstream PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8721
+Upstream PR: https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8721
 
 State: **open; one maintainer approval; a later requested-change review has been addressed and awaits refreshed disposition** at the latest refresh.
 
@@ -117,9 +117,23 @@ Focused validation reports 298 block tests passing normally and 326 with `io_uri
 
 Signal: **high-upside systems follow-on with substantive maintainer engagement**. Even before final merge, the review history is a strong interview story about making persistent metadata ownership local and failure-safe instead of defending the first narrow patch.
 
+### Cloudflare Workers SDK — Miniflare runtime disposal ordering
+
+Upstream PR: https://redirect.github.com/cloudflare/workers-sdk/pull/15143
+
+State: **merged**.
+
+`Miniflare.dispose()` waited for browser/proxy cleanup before requesting `Runtime.dispose()`, so slow or failed auxiliary cleanup could delay or skip the `workerd` termination request.
+
+The landed repair starts runtime disposal first, preserves the existing browser → exit-hook → proxy cleanup ordering, remembers the first cleanup error, waits for the already-started runtime exit, continues remaining cleanup, then returns the preserved cleanup error.
+
+Human maintainer review materially improved the boundary: an earlier version stopped remaining cleanup after the first failure; the final merged version preserves the first error while continuing teardown with runtime termination already in flight.
+
+Resume signal: **strong merged lifecycle specimen**. It is now a clean Cloudflare receipt rather than a pending follow-on.
+
 ### Cloudflare Workers SDK — current credentials vs cached authorization state
 
-Upstream PR: https://github.com/cloudflare/workers-sdk/pull/15080
+Upstream PR: https://redirect.github.com/cloudflare/workers-sdk/pull/15080
 
 State: **open; human-approved; Wrangler CODEOWNERS satisfied; changesets prepared** at the latest refresh.
 
@@ -129,21 +143,67 @@ The repair returns service-token headers from the current environment and leaves
 
 A human reviewer approved the current head and the repository's CODEOWNERS gate explicitly reports satisfied. GitHub still reports the PR open rather than merged, so public wording should distinguish accepted review from merge.
 
-Resume signal: **strong**. This has crossed from merely submitted work into real external validation even before merge.
+Resume signal: **strong**. Together with the merged Miniflare repair, this is a small but coherent Cloudflare cluster around lifecycle and state correctness.
 
-### Cloudflare Workers SDK — Miniflare runtime disposal ordering
+## Accepted findings through another repair path
 
-Upstream PR: https://github.com/cloudflare/workers-sdk/pull/15143
+### Zustand — clear-storage hydration generation race
 
-State: **open; active human maintainer review** at the latest refresh.
+Public report: https://redirect.github.com/pmndrs/zustand/discussions/3554
 
-`Miniflare.dispose()` currently waits for browser/proxy cleanup before requesting `Runtime.dispose()`, so slow or failed auxiliary cleanup can delay or skip the `workerd` termination request.
+Upstream landing: https://redirect.github.com/pmndrs/zustand/pull/3555
 
-The repair starts runtime disposal first, preserves the existing browser → exit-hook → proxy cleanup ordering, remembers the first cleanup error, waits for the already-started runtime exit, continues remaining cleanup, then returns the preserved cleanup error.
+The persist middleware already used a `hydrationVersion` generation to prevent stale concurrent hydration publication, but `clearStorage()` did not advance the generation. A delayed read or migration could therefore publish state and lifecycle callbacks after the caller had cleared persisted storage.
 
-A bot review first flagged release-note wording; Leo revised the changeset to describe user-facing behavior. Human maintainer review later asked why a cleanup failure should stop the rest of teardown. The current head adopts that direction: preserve the first error while continuing remaining cleanup, with runtime termination already in flight.
+The independently developed candidate added `++hydrationVersion` before `removeItem()` and validated delayed read/migration, synchronous removal failure, live-state preservation, stale callback suppression, `hasHydrated()` behavior, and later successful hydration.
 
-Signal: strong lifecycle follow-on if accepted. Together with #15080, it would make Cloudflare a small cluster of state/credential and teardown work rather than a single isolated contribution.
+Upstream subsequently merged the same core production mechanism through its own PR with broader regression coverage.
+
+Safe career wording:
+
+> Identified an async persist hydration race and supplied the generation-invalidation repair subsequently implemented upstream.
+
+Signal: excellent mechanism, lower marginal resume value once AI SDK/Cloud Hypervisor/Cloudflare already prove correctness work.
+
+### Playwright — MCP HTTP shutdown authority
+
+Report: https://redirect.github.com/microsoft/playwright/issues/42129
+
+Maintainer landing: https://redirect.github.com/microsoft/playwright/pull/42133
+
+State: **finding accepted; maintainer-owned fix merged; report closed as completed**.
+
+The report showed that an ordinary reachable MCP HTTP client could invoke a fixed-header `/killkillkill` route and enter the server's graceful `SIGINT` shutdown path. The route existed for a Windows lifecycle test; the fixed header reduced CSRF exposure but did not establish process ownership.
+
+The report proposed moving graceful-shutdown authority back to the spawning test parent through stdin. Upstream agreed with the authority problem but chose a smaller project-native repair: gate `/killkillkill` on `isUnderTest()` so production MCP HTTP servers do not expose the test hook.
+
+Signal: strong accepted-finding story. The diagnosis landed; the final repair boundary changed. Do not claim the prepared stdin implementation as the upstream fix.
+
+### BuildKit — rootless/rootful mount-point reproducibility
+
+Contributor PR: https://redirect.github.com/moby/buildkit/pull/7033
+
+Maintainer replacement: https://redirect.github.com/moby/buildkit/pull/7039
+
+Linux Fieldwork reproduced a rootful/rootless filesystem divergence involving runtime-created `/proc`/`/sys` mountpoint stubs. Pre-creating the mountpoints made the control converge. The candidate reused BuildKit's existing mount-stub ownership cleanup against the finalized OCI spec after rootless conversion.
+
+The maintainer accepted the underlying divergence but chose the opposite compatibility policy: restore the missing rootless mount points rather than remove rootful ones, preserving existing rootful output and avoiding a compatibility-version change.
+
+Signal: deep systems review story about which side of a compatibility boundary should move, not a merge-statistic story.
+
+### runc — useful reversal, not resume headline
+
+Upstream issue: https://redirect.github.com/opencontainers/runc/issues/5388
+
+Contributor PR: https://redirect.github.com/opencontainers/runc/pull/5389
+
+Maintainer replacement: https://redirect.github.com/opencontainers/runc/pull/5392
+
+A boundary mismatch between inclusive `configs.MaxCPU` meaning and exclusive `unix.NewCPUSet()` sizing produced an off-by-one reset mask. A patch changed the allocation to `MaxCPU + 1` and added a boundary regression.
+
+The maintainer preferred repairing the historical meaning of `MaxCPU` on the other side. After reviewing that history, Leo agreed and closed the competing patch.
+
+Signal: **great interview story, low resume value**. It demonstrates recognizing a real symptom, accepting a better repair boundary, and not optimizing for personal merge count.
 
 ## Vercel AI SDK — wider current bench
 
@@ -153,7 +213,7 @@ The three accepted repairs above are the clean public receipts. Current Fieldwor
 
 Owned clean candidate: `teamleaderleo/ai#78`.
 
-Some OpenAI-compatible providers can report internally inconsistent counters (for example reasoning tokens exceeding completion tokens while raw total is consistent with prompt + reasoning). Current normalization can publish an output total smaller than the reasoning detail.
+Some OpenAI-compatible providers can report internally inconsistent counters, for example reasoning tokens exceeding completion tokens while raw total is consistent with prompt + reasoning. Current normalization can publish an output total smaller than the reasoning detail.
 
 The selected candidate uses a conservative envelope over completion, reasoning, and `total - prompt` evidence while preserving literal provider counters in `raw`.
 
@@ -165,7 +225,7 @@ Signal: technically good, especially for a Vercel conversation; avoid presenting
 
 ### Claude built-in permission-kind parity
 
-Fieldwork found drift between the public Claude built-in tool catalog and the sandbox bridge's separate permission-kind representation. One concrete example: public metadata classifies PowerShell as bash-like while the bridge can fall through through an edit-class default, changing approval behavior under `allow-edits`.
+Fieldwork found drift between the public Claude built-in tool catalog and the sandbox bridge's separate permission-kind representation. One concrete example: public metadata classifies PowerShell as bash-like while the bridge can fall through an edit-class default, changing approval behavior under `allow-edits`.
 
 Work expanded into a mechanical public-catalog-to-bridge parity matrix plus unknown-native and external-MCP compatibility discriminators.
 
@@ -185,33 +245,30 @@ Current research includes inline-extension failure visibility, project-local Ope
 
 Signal: demonstrates continuing familiarity with the AI SDK harness codebase. Do not turn every finding into a resume line.
 
-## SWC
+## SWC — narrowed `instanceof` constant-folding repair
 
-Upstream PR: https://github.com/swc-project/swc/pull/12110
+Upstream PR: https://redirect.github.com/swc-project/swc/pull/12110
 
-Current state at audit: submitted current work; human approval not yet established.
+State: **open; narrowed after maintainer feedback; no current approval recorded**.
 
-The optimizer/minifier can treat `instanceof` as though preserving operand effects is enough when the result is unused. But the operation itself can be observable through `Symbol.hasInstance` and can throw for an invalid RHS. Existing operand-shape folds can also return the wrong boolean for cases such as null-prototype objects.
+The original investigation found two different `instanceof` concerns:
 
-The candidate preserves complete `instanceof` evaluation where shared effect analysis/minification/dead-branch cleanup would otherwise keep only operand effects, removes unsafe operand-shape folds, adds SWC-owned regressions, and runs relevant formatting, Clippy, utility, optimization and minifier suites.
+1. operand-shape constant folding could return the wrong boolean result;
+2. discarded-result cleanup could remove observable `instanceof` evaluation involving `Symbol.hasInstance` or exceptions.
 
-Signal: **high upside** because it adds a compiler/minifier axis to the portfolio. Promote quickly if maintainers accept the direction. Until then, bullpen rather than headline resume claim.
+A maintainer explicitly preferred retaining SWC's existing Terser-compatible assumption for the discarded-result path. Leo accepted that project boundary and reduced the PR instead of defending the broader semantic change.
 
-## Zustand
+The current PR is therefore narrower: avoid incorrect constant folding from operand shape alone. For example:
 
-Owned Fieldwork record: clear-storage hydration generation race.
+```js
+({ __proto__: null }) instanceof Object
+```
 
-The persist middleware already used a `hydrationVersion` generation to prevent stale concurrent hydration publication, but `clearStorage()` did not advance the generation. A delayed read or migration could therefore publish state and lifecycle callbacks after the caller had cleared persisted storage.
+evaluates to `false`, but could be folded to `true`. The current head removes those unsafe folds, adds regressions in the existing optimizer/minifier fixture suites, and explicitly leaves the discarded-result behavior unchanged.
 
-The independently developed candidate adds `++hydrationVersion` before `removeItem()` and validates delayed read/migration, synchronous removal failure, live-state preservation, stale callback suppression, `hasHydrated()` behavior, and later successful hydration.
+The latest maintainer inline objection is attached to an outdated diff and remains unresolved; there is no current maintainer approval. Do not describe the broad `Symbol.hasInstance` observability thesis as the current upstream patch.
 
-Current upstream PR #3555 uses the same one-line production change and substantively overlapping tests.
-
-Attribution/issue linkage should be rechecked before a public resume sentence. Avoid the ambiguous term `co-author` unless GitHub/upstream metadata supports it directly. Safer eventual wording if evidence remains as understood:
-
-> Reported/investigated an async persist hydration race and developed the generation-invalidation repair subsequently implemented upstream.
-
-Signal: excellent mechanism, lower marginal resume value once AI SDK/Cloud Hypervisor already prove correctness work.
+Signal: still **high upside** because it adds a compiler/minifier axis, and the narrowing itself is a good review-boundary story. Promote if the constant-folding repair is accepted or merged.
 
 ## Vite
 
@@ -219,7 +276,7 @@ Vite now has enough upstream validation to be a real resume specimen rather than
 
 ### Close temporary custom-extension optimizer analysis bundles
 
-Upstream PR: https://github.com/vitejs/vite/pull/23207
+Upstream PR: https://redirect.github.com/vitejs/vite/pull/23207
 
 State: **merged**.
 
@@ -229,7 +286,7 @@ The repair wraps analysis in `try/finally` and closes the build after success or
 
 ### Preserve `closeBundle(error)` after `buildEnd` failure
 
-Upstream PR: https://github.com/vitejs/vite/pull/23165
+Upstream PR: https://redirect.github.com/vitejs/vite/pull/23165
 
 State: **open; approved by two Vite members**.
 
@@ -239,7 +296,7 @@ Two Vite members have approved the current head. This is meaningful technical ac
 
 ### Keep repeated config resolution idempotent
 
-Upstream PR: https://github.com/vitejs/vite/pull/23208
+Upstream PR: https://redirect.github.com/vitejs/vite/pull/23208
 
 State: **open; active review, no current approval recorded**.
 
@@ -248,24 +305,6 @@ Repeated `resolveConfig()` calls with the same inline config can re-merge resolv
 A maintainer asked that the regression live in the existing config test suite; the current head incorporates that request. All visible review threads are resolved, while the prior approval was dismissed after subsequent changes.
 
 Resume signal: **promoted**. The merged optimizer cleanup plus two-maintainer-approved teardown correction are enough external validation to use Vite selectively on a general/devtools resume. Keep all three PRs discoverable in the work record without turning the resume into a Vite mini-changelog.
-
-## BuildKit
-
-Linux Fieldwork has an end-to-end-proven rootless/rootful reproducibility candidate on the runc/native path.
-
-The investigation reproduced a rootful/rootless filesystem divergence involving runtime-created `/proc`/`/sys` mountpoint stubs. Pre-creating the mountpoints made the control converge. The candidate reuses BuildKit's existing mount-stub ownership cleanup against the finalized OCI spec after rootless conversion; focused ownership tests, candidate builds, matching workers, and parity controls passed. Live containerd-worker/runtime coverage remained a scope caveat at the recorded boundary.
-
-Signal: deep systems proof. Strong bench item; could replace a web-tooling item on a systems-focused resume.
-
-## runc — useful reversal, not resume headline
-
-Upstream issue/PR: https://github.com/opencontainers/runc/issues/5388 / https://github.com/opencontainers/runc/pull/5389
-
-A boundary mismatch between inclusive `configs.MaxCPU` meaning and exclusive `unix.NewCPUSet()` sizing produced an off-by-one reset mask. A patch changed the allocation to `MaxCPU + 1` and added a boundary regression.
-
-The maintainer preferred repairing the historical meaning of `MaxCPU` on the other side (PR #5392). After reviewing that history, Leo agreed and closed #5389.
-
-Signal: **great interview story, low resume value**. It demonstrates recognizing a real symptom, accepting a better repair boundary, and not optimizing for personal merge count.
 
 ## Bat — grapheme-aware character wrapping
 
@@ -337,10 +376,10 @@ A good general mix at this refresh is:
 
 1. Vercel AI SDK — one direct merge plus two Factory-adopted merged repairs with explicit co-author credit; one propagated across maintained v5/v6 branches.
 2. Cloud Hypervisor — two merged Rust/VMM lifecycle/error-propagation changes, with a deeper QCOW metadata-ownership repair through substantive maintainer review.
-3. Cloudflare Workers SDK — credential/caching semantics with human + CODEOWNERS approval; Miniflare lifecycle follow-on in human review.
+3. Cloudflare Workers SDK — merged Miniflare teardown lifecycle repair plus Access credential/cache semantics with human + CODEOWNERS approval.
 4. Vite — one merged optimizer lifecycle fix plus a second teardown repair approved by two maintainers.
-5. SWC if accepted — compiler/minifier observability; otherwise choose the four strongest role-specific specimens above.
+5. SWC if accepted — narrowed compiler/minifier constant-folding correctness repair; otherwise choose the four strongest role-specific specimens above.
 
-Then let GitHub/`/work` reveal the much larger collection.
+Then let GitHub/`/work` reveal the much larger collection. Playwright, Zustand, BuildKit and runc remain useful examples of accepted findings or repaired boundaries even when they lose scarce resume space.
 
 The marginal question is no longer "can Leo contribute to unfamiliar repositories?" The stronger question is which examples best demonstrate that the capability survives changes in language, domain, lifecycle, and abstraction level.

--- a/work/records/preflight.md
+++ b/work/records/preflight.md
@@ -8,7 +8,7 @@ This record intentionally stores more detail than any one-page resume should use
 
 ## Current headline
 
-The strongest current before/after evidence is the 2026-08-15 controlled 83-mod campaign now carried in Preflight PR #440:
+The strongest current before/after evidence is the 2026-08-15 controlled 83-mod campaign merged through Preflight PR #440:
 
 - **89.00s baseline median**;
 - **15.53s accelerated median**;
@@ -17,7 +17,7 @@ The strongest current before/after evidence is the 2026-08-15 controlled 83-mod 
 - no exclusions;
 - exact same 83-mod profile for both conditions.
 
-That is the comparison to lead with when the claim/update candidate is published. It replaces the old temptation to present chronological endpoints from different development states as one before/after experiment.
+That is now the comparison to lead with. PR #440 merged it into the project's published claim/docs, replacing the old temptation to present chronological endpoints from different development states as one before/after experiment.
 
 The earlier reviewed 83-mod development profile also recorded:
 
@@ -145,7 +145,7 @@ Use only metrics whose measurement boundary fits the claim being made.
 
 ### Current / headline candidates
 
-- **89.00s baseline → 15.53s accelerated** on the same 83-mod profile in one interleaved session, five accepted runs per condition, no exclusions (2026-08-15 campaign candidate).
+- **89.00s baseline → 15.53s accelerated** on the same 83-mod profile in one interleaved session, five accepted runs per condition, no exclusions (2026-08-15 controlled campaign).
 - Earlier 83-mod gates include 16.66s cold, 16.28s warm, and a 15.88s warm record with 42/42 transformed-class hits and 15,469/15,469 prepared texture/pixel-conversion hits.
 - Earlier accepted launches reached roughly 101s, but that is chronology rather than the controlled baseline for the 15.53s result.
 - The historical 88.13s five-run median came from a 77-mod profile and should not be mislabeled as the later 83-mod baseline.
@@ -282,7 +282,7 @@ These are ingredients, not final resume bullets.
 
 ## Open verification / release notes
 
-The 2026-08-15 campaign now supplies the clean same-profile controlled comparison that the record previously lacked. Before turning it into the final release/package claim, preserve the exact evidence boundary already recorded in the candidate:
+The 2026-08-15 campaign now supplies the clean same-profile controlled comparison that the record previously lacked, and the documentation claim is merged. Before turning it into a packaged-binary claim, preserve the exact evidence boundary already recorded:
 
 - exact game build;
 - exact enabled-mod profile/order;
@@ -293,4 +293,4 @@ The 2026-08-15 campaign now supplies the clean same-profile controlled compariso
 - accepted/rejected run rules;
 - adapter health / activation evidence.
 
-The current claim candidate records the same 83-mod profile, one sitting, five accepted runs per condition, interleaving, and zero exclusions. A later hosted release candidate should rerun or explicitly bind the packaged artifact before claiming that the distributed binary has the same measured result.
+The merged claim records the same 83-mod profile, one sitting, five accepted runs per condition, interleaving, and zero exclusions. A later hosted release candidate should rerun or explicitly bind the packaged artifact before claiming that the distributed binary has the same measured result.

--- a/work/resume-candidates.md
+++ b/work/resume-candidates.md
@@ -14,18 +14,18 @@ Avoid claiming three years of full-time post-graduate professional employment. A
 
 The resume itself probably does not need a YOE headline. Let the chronology and evidence support the answer when asked.
 
-### Current market signal
+### Recent role-fit prompt
 
-A recent inbound recruiting approach for a senior software-engineering contract on a Snorkel AI coding-agent benchmark project is useful corroboration of the portfolio's current direction. The work described code and architecture review, technical writing, and benchmark development for coding agents.
+Recent recruiter outreach described a senior software-engineering contract centered on code/architecture review, technical writing, and benchmark development for coding agents. The sourcing path is unknown and may have been automated, so **do not treat the outreach itself as external validation or evidence that a Snorkel/Terminal engineer manually selected the portfolio**.
 
-Do **not** put recruiter outreach on the resume as an accomplishment. Treat it as evidence about what the market is already selecting for:
+The useful part is narrower: the role description is a concrete fit hypothesis worth testing against the existing work.
 
 - Preflight demonstrates benchmark design, instrumentation, controlled comparison, and technical writing around a difficult real system;
 - the upstream work demonstrates repeated code review, repair-boundary judgment, and externally accepted changes in unfamiliar repositories;
 - SmolRunner demonstrates disposable execution, recovery, and hostile-CI concerns that become directly relevant when evaluating generated code;
 - Stensibly demonstrates sustained work on agent coordination, authority, provenance, and continuation.
 
-The interesting part is the overlap between the requested work and the public engineering record, not the existence of an email.
+Keep recruiter sourcing and technical fit separate. A coding-agent benchmark role surfacing in this direction is useful context for application targeting; it is not a resume accomplishment or a market endorsement by itself.
 
 ## General one-page cut — current recommendation
 
@@ -80,17 +80,17 @@ For a general resume, the first merged-work line may be enough. For systems role
 
 #### 3. Cloudflare Workers SDK — strong current
 
-The Access credential fix is human-approved with Wrangler CODEOWNERS satisfied and remains open. The Miniflare teardown/lifecycle PR has also crossed into active human maintainer review.
+The Miniflare teardown/lifecycle PR #15143 is now **merged**. The Access credential fix #15080 remains open but is human-approved with Wrangler CODEOWNERS satisfied.
 
 Candidate bullet family:
 
-> Fixed stale Cloudflare Access service-token headers surviving environment changes by separating current credential state from legitimately cached interactive authorization; added regressions for removed/partial credentials while preserving cookie reuse.
+> Landed a Miniflare teardown fix that starts `workerd` termination before independent browser/proxy cleanup can delay it, preserves the first cleanup failure, waits for runtime exit, and continues remaining teardown.
 
-Possible follow-on after the teardown PR is accepted:
+Useful paired line for Cloudflare/devtools roles:
 
-> Reordered Miniflare disposal so `workerd` termination begins before independent browser/proxy cleanup can delay it, while preserving the first cleanup failure and continuing remaining teardown.
+> Separately fixed stale Cloudflare Access service-token headers surviving environment changes by separating current credential state from legitimately cached interactive authorization; the current patch is human-approved with CODEOWNERS satisfied.
 
-The second PR's current human review asked whether cleanup should continue after the first failure; the revised head adopts that direction. Keep the final resume wording status-accurate until approval/merge is recorded.
+This is now a real two-item Cloudflare cluster: one merged lifecycle repair plus one accepted credential/cache repair awaiting merge.
 
 #### 4. Vite — promoted current
 
@@ -106,20 +106,23 @@ Candidate bullet family while #23165 remains open:
 
 If #23165 merges, simplify the status language and treat the pair as two landed lifecycle/correctness fixes.
 
-#### 5. SWC — high-upside pending slot
+#### 5. SWC — compiler-axis pending slot
 
-If maintainer review accepts the direction, this remains unusually valuable because it adds a compiler/minifier axis rather than another adjacent web-tooling example.
+The original SWC investigation included discarded-result `instanceof` observability. A maintainer explicitly preferred retaining SWC/Terser's existing assumption for that path, so the current PR was narrowed instead of defending the broader semantics change.
 
-Candidate bullet family:
+PR #12110 now targets the cleaner correctness bug: operand-shape constant folding can produce the **wrong boolean result**, for example folding a null-prototype object as `instanceof Object` incorrectly. The current head removes those unsafe folds and keeps the existing discarded-result behavior unchanged. There is no current maintainer approval; the latest maintainer thread is outdated against the current diff but remains unresolved.
 
-> Preserved observable `instanceof` evaluation across SWC optimizer/minifier paths where dead-result cleanup could discard `Symbol.hasInstance` calls or exceptions; removed unsafe operand-shape folds and added optimizer-owned regressions.
+Candidate bullet family if the narrowed direction lands:
 
-Until human/upstream acceptance exists, keep in the bullpen rather than presenting it as equivalent to landed work.
+> Fixed incorrect SWC `instanceof` constant folding that could return the wrong boolean for null-prototype objects; removed unsafe operand-shape folds and added regressions in the repository's existing optimizer/minifier fixtures.
+
+This is still useful because it adds a compiler/minifier axis, but the current claim should be the narrower constant-folding repair rather than the earlier `Symbol.hasInstance`/discarded-result thesis.
 
 #### Bench / alternates
 
 - Zustand hydration generation race — technically clean, lower marginal signal after AI SDK/Cloudflare; useful if upstream attribution becomes especially strong.
 - BuildKit rootless/rootful reproducibility — excellent for systems-specific applications.
+- Playwright MCP shutdown authority — reported a reachable production lifecycle-control route; a Playwright maintainer subsequently merged PR #42133 gating `/killkillkill` under test and closed the report as completed. Good accepted-finding story, probably not scarce one-page space.
 - Bat/Delta/fd/urllib3/Serde/Rspack — strong Fieldwork/portfolio/interview bench; promote selectively with upstream validation or target-role fit.
 - runc #5389 — interview story, not current resume headline.
 
@@ -129,7 +132,7 @@ Until human/upstream acceptance exists, keep in the bullpen rather than presenti
 
 Do not compress Preflight into a single generic project bullet. It is the strongest owned-work proof and should receive roughly **three dense bullets / six-ish lines** in Leo's actual typography.
 
-The 2026-08-15 controlled campaign materially improves the headline evidence. On one 83-mod profile, in one interleaved session, five accepted baseline runs and five accepted accelerated runs measured **89.00s → 15.53s**, with no exclusions. That is the comparison to lead with once the current claim/documentation candidate is published; the older 101s and 15.88s points remain chronology, not the preferred before/after pair.
+The 2026-08-15 controlled campaign materially improves the headline evidence. On one 83-mod profile, in one interleaved session, five accepted baseline runs and five accepted accelerated runs measured **89.00s → 15.53s**, with no exclusions. PR #440 has now merged that comparison into the project's published claim/docs; the older 101s and 15.88s points remain chronology, not the preferred before/after pair.
 
 Current story families:
 
@@ -217,103 +220,3 @@ Current default candidate:
 > **Technologies:** Linux, React, Node.js, Cloudflare Workers, Docker, AWS, PostgreSQL, Git
 
 Tailor lightly by role.
-
-Do not put KVM/MSHV/fw_cfg/TDX in the generic skills line merely because Cloud Hypervisor validation touched them. Those details belong in the evidence that used them.
-
-## Target cut: Vercel / devtools / AI runtime
-
-Priority order:
-
-1. Vercel AI SDK — direct merge plus Factory-adopted/co-authored fixes is now the strongest upstream cluster.
-2. Cloud Hypervisor (proves range outside TS/AI).
-3. Cloudflare Workers SDK.
-4. Vite — one merge plus a two-maintainer-approved lifecycle repair.
-5. SWC rises above Vite if accepted and the compiler/minifier axis is useful for the target.
-6. Preflight, framed as runtime/instrumentation/performance and controlled evaluation rather than game fandom first.
-7. Stensibly gets one stronger line because agent coordination/MCP/hosted authority is relevant.
-8. SmolRunner rises when the role touches coding-agent execution, sandboxes, CI, or benchmark harnesses.
-
-Useful application thesis:
-
-> Already able to enter Vercel-owned code, understand lifecycle/state boundaries, and produce fixes that merge directly or are adopted by the AI SDK Factory with retained co-author credit; independent work shows the same ability generalizes beyond the codebase.
-
-Do not imply OSS creates entitlement to an interview. It makes a targeted cold application unusually well-supported.
-
-## Target cut: coding-agent evaluation / benchmark engineering
-
-This is now a real target category rather than a hypothetical one.
-
-Priority order:
-
-1. **Preflight** — controlled experiments, benchmark design, instrumentation, falsifiable claims, technical evidence writing.
-2. **Vercel AI SDK** — AI-tooling codebase familiarity plus upstream accepted lifecycle/error-state work.
-3. **SmolRunner** — disposable execution, exact worker identity, crash recovery, cleanup, hostile-CI thinking.
-4. **Cloud Hypervisor / Vite / Cloudflare** — diverse specimens of code review and lifecycle/correctness reasoning in unfamiliar codebases.
-5. **Stensibly** — agent authority, continuation, provenance, and coordination.
-
-Useful thesis:
-
-> Already doing the ingredients of coding-agent benchmark work: entering arbitrary repositories, finding behavioral boundaries, writing discriminating regressions, building reproducible execution/evidence systems, and explaining why a result is trustworthy.
-
-This target is where the breadth becomes unusually coherent rather than looking scattered.
-
-## Target cut: Valve / game/runtime/performance
-
-Priority order changes substantially:
-
-1. **Preflight dominates the page.** Give it the most acreage.
-2. Cloud Hypervisor.
-3. Best systems/compiler OSS specimens.
-4. SmolRunner may beat Stensibly because runtime/crash/recovery systems are more relevant.
-5. Glossless can appear if visual/graphics/product breadth helps.
-6. Web-library correctness examples are supporting evidence, not identity.
-
-Possible Preflight emphasis:
-
-- controlled 89.00s → 15.53s same-profile campaign;
-- runtime instrumentation of an obfuscated game/mod ecosystem;
-- Java bytecode transformations;
-- JFR and critical-path performance work;
-- graphics/audio/resource-loader investigation;
-- generated code / Janino;
-- Rosetta/JIT/platform behavior;
-- mod compatibility and fail-open source drift;
-- real desktop packaging, updater/rollback, diagnostics and gameplay pilots.
-
-The pitch is not "Starsector modder." It is "engineer who cracked open a real game/mod runtime, built instrumentation around it, made it radically faster, and productized the result without owning the underlying source ecosystem."
-
-## Target cut: systems / infra
-
-Priority order:
-
-1. Cloud Hypervisor.
-2. BuildKit or another strong Linux Fieldwork candidate if externally validated.
-3. Preflight runtime/bytecode/performance.
-4. SmolRunner.
-5. Vercel AI SDK as cross-language correctness proof.
-6. Cloudflare as state/credential/lifecycle semantics.
-
-If the QCOW L2 ownership repair lands, Cloud Hypervisor becomes an even stronger lead because the accepted work then spans VM lifecycle, boot error propagation, and block-image metadata ownership.
-
-Stensibly becomes optional unless the role values distributed coordination.
-
-## What not to do
-
-- Do not make the page a logo wall.
-- Do not list every open PR to prove volume.
-- Do not over-index on "high impact" wording without a specific mechanism/result.
-- Do not call independent work freelance work unless client/service work actually happened.
-- Do not call the profile 0 YOE when the question is ordinary engineering experience.
-- Do not claim three years of conventional post-grad full-time employment.
-- Do not let IBM sit above the current work simply because it is an employer name.
-- Do not waste Preflight's acreage on a generic technology stack line.
-- Do not encode internal Fieldwork evidence levels into recruiter-facing prose unless they solve a real credibility question.
-- Do not turn inbound recruiting into a resume bullet; use it to calibrate which existing evidence resonates.
-
-## Current identity thesis
-
-The page should make a reader infer something close to:
-
-> Nontraditional early-career chronology, roughly three years of substantive engineering activity, unusually strong evidence of entering unfamiliar systems and finding correctness/performance/lifecycle boundaries, repeated external acceptance across Vercel AI SDK, Vite, Cloud Hypervisor and Cloudflare, plus one owned performance product deep enough to demonstrate sustained technical pursuit and benchmark discipline.
-
-The resume's job is to resolve the chronology/capability mismatch quickly enough that a human wants to ask about it.

--- a/work/resume-candidates.md
+++ b/work/resume-candidates.md
@@ -220,3 +220,103 @@ Current default candidate:
 > **Technologies:** Linux, React, Node.js, Cloudflare Workers, Docker, AWS, PostgreSQL, Git
 
 Tailor lightly by role.
+
+Do not put KVM/MSHV/fw_cfg/TDX in the generic skills line merely because Cloud Hypervisor validation touched them. Those details belong in the evidence that used them.
+
+## Target cut: Vercel / devtools / AI runtime
+
+Priority order:
+
+1. Vercel AI SDK — direct merge plus Factory-adopted/co-authored fixes is now the strongest upstream cluster.
+2. Cloud Hypervisor (proves range outside TS/AI).
+3. Cloudflare Workers SDK — one merged lifecycle fix plus one human-approved credential/cache repair.
+4. Vite — one merge plus a two-maintainer-approved lifecycle repair.
+5. SWC rises above Vite if the narrowed constant-folding repair is accepted and the compiler/minifier axis is useful for the target.
+6. Preflight, framed as runtime/instrumentation/performance and controlled evaluation rather than game fandom first.
+7. Stensibly gets one stronger line because agent coordination/MCP/hosted authority is relevant.
+8. SmolRunner rises when the role touches coding-agent execution, sandboxes, CI, or benchmark harnesses.
+
+Useful application thesis:
+
+> Already able to enter Vercel-owned code, understand lifecycle/state boundaries, and produce fixes that merge directly or are adopted by the AI SDK Factory with retained co-author credit; independent work shows the same ability generalizes beyond the codebase.
+
+Do not imply OSS creates entitlement to an interview. It makes a targeted cold application unusually well-supported.
+
+## Target cut: coding-agent evaluation / benchmark engineering
+
+This is now a concrete target category rather than only a hypothetical one.
+
+Priority order:
+
+1. **Preflight** — controlled experiments, benchmark design, instrumentation, falsifiable claims, technical evidence writing.
+2. **Vercel AI SDK** — AI-tooling codebase familiarity plus upstream accepted lifecycle/error-state work.
+3. **SmolRunner** — disposable execution, exact worker identity, crash recovery, cleanup, hostile-CI thinking.
+4. **Cloud Hypervisor / Vite / Cloudflare** — diverse specimens of code review and lifecycle/correctness reasoning in unfamiliar codebases.
+5. **Stensibly** — agent authority, continuation, provenance, and coordination.
+
+Useful thesis:
+
+> Already doing the ingredients of coding-agent benchmark work: entering arbitrary repositories, finding behavioral boundaries, writing discriminating regressions, building reproducible execution/evidence systems, and explaining why a result is trustworthy.
+
+This target is where the breadth becomes unusually coherent rather than looking scattered.
+
+## Target cut: Valve / game/runtime/performance
+
+Priority order changes substantially:
+
+1. **Preflight dominates the page.** Give it the most acreage.
+2. Cloud Hypervisor.
+3. Best systems/compiler OSS specimens.
+4. SmolRunner may beat Stensibly because runtime/crash/recovery systems are more relevant.
+5. Glossless can appear if visual/graphics/product breadth helps.
+6. Web-library correctness examples are supporting evidence, not identity.
+
+Possible Preflight emphasis:
+
+- controlled 89.00s → 15.53s same-profile campaign;
+- runtime instrumentation of an obfuscated game/mod ecosystem;
+- Java bytecode transformations;
+- JFR and critical-path performance work;
+- graphics/audio/resource-loader investigation;
+- generated code / Janino;
+- Rosetta/JIT/platform behavior;
+- mod compatibility and fail-open source drift;
+- real desktop packaging, updater/rollback, diagnostics and gameplay pilots.
+
+The pitch is not "Starsector modder." It is "engineer who cracked open a real game/mod runtime, built instrumentation around it, made it radically faster, and productized the result without owning the underlying source ecosystem."
+
+## Target cut: systems / infra
+
+Priority order:
+
+1. Cloud Hypervisor.
+2. BuildKit or another strong Linux Fieldwork candidate if externally validated.
+3. Preflight runtime/bytecode/performance.
+4. SmolRunner.
+5. Vercel AI SDK as cross-language correctness proof.
+6. Cloudflare as state/credential/lifecycle semantics.
+
+If the QCOW L2 ownership repair lands, Cloud Hypervisor becomes an even stronger lead because the accepted work then spans VM lifecycle, boot error propagation, and block-image metadata ownership.
+
+Stensibly becomes optional unless the role values distributed coordination.
+
+## What not to do
+
+- Do not make the page a logo wall.
+- Do not list every open PR to prove volume.
+- Do not over-index on "high impact" wording without a specific mechanism/result.
+- Do not call independent work freelance work unless client/service work actually happened.
+- Do not call the profile 0 YOE when the question is ordinary engineering experience.
+- Do not claim three years of conventional post-grad full-time employment.
+- Do not let IBM sit above the current work simply because it is an employer name.
+- Do not waste Preflight's acreage on a generic technology stack line.
+- Do not encode internal Fieldwork evidence levels into recruiter-facing prose unless they solve a real credibility question.
+- Do not turn recruiter outreach into a resume bullet or treat unknown sourcing as validation; use the actual role description only as a targeting hypothesis.
+
+## Current identity thesis
+
+The page should make a reader infer something close to:
+
+> Nontraditional early-career chronology, roughly three years of substantive engineering activity, unusually strong evidence of entering unfamiliar systems and finding correctness/performance/lifecycle boundaries, repeated external acceptance across Vercel AI SDK, Vite, Cloud Hypervisor and Cloudflare, plus one owned performance product deep enough to demonstrate sustained technical pursuit and benchmark discipline.
+
+The resume's job is to resolve the chronology/capability mismatch quickly enough that a human wants to ask about it.


### PR DESCRIPTION
## Summary

- record the merged Miniflare teardown repair and keep the separate Access credential repair at its current approved/open state;
- mark the controlled Preflight 83-mod claim as merged rather than pending publication;
- reclassify the Playwright MCP shutdown report as an accepted finding after the maintainer-owned test-only gate merged;
- narrow the SWC career wording to the current constant-folding repair after maintainer feedback rejected the broader discarded-result change;
- replace active third-party GitHub evidence links with `redirect.github.com` under the new repository-wide policy;
- soften recruiter outreach from “market signal” to a role-fit hypothesis because the sourcing path is unknown.

## Boundaries

This updates current/public career synthesis and `/work` evidence. Historical Guest Check-ins, Workbench articles, Git history, and old PR prose were not rewritten merely to normalize link hosts. Separately, three clearly superseded draft PRs were closed during the housekeeping pass: the earlier Operator Learns Too draft and two intermediate FEX/Linux check-ins. Broader draft/editorial salvage remains separate rather than being mass-closed here.

No upstream comments, issues, reviews, mentions, or other third-party notifications were created by this cleanup.

## Validation / self-review

- branch is zero commits behind current `main`;
- complete seven-file diff inspected after the final Work evidence validator fix;
- the first exact-head CI exposed one stale Work evidence validator that allowed only `github.com`; it was repaired to enforce the new ownership-based host rule instead;
- final exact-head CI run `31891786356` is green: lint, typecheck, unit tests, build, and Chromium regressions all passed;
- current Work-record tests require direct `github.com` for `teamleaderleo` evidence and `redirect.github.com` for third-party evidence;
- no production data, authentication, deployment, billing, or third-party interaction behavior changed.

Ready for merge as a low-risk status/evidence cleanup.