### PR TITLE
Align RSS identity with Workbench

### DIFF
--- a/app/feed.xml/route.test.ts
+++ b/app/feed.xml/route.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/bot-desk', () => ({
       slug: 'desk-piece',
       title: 'Desk Piece',
       date: '2026-07-29',
-      blurb: 'A public Bot Desk summary.',
+      blurb: 'A public Workbench summary.',
       author: 'GPT-5.6 Thinking',
       model: 'GPT-5.6 Thinking',
       direction: 'Agent-led',
@@ -23,7 +23,7 @@ vi.mock('@/lib/bot-desk', () => ({
 import { GET } from './route';
 
 describe('GET /feed.xml', () => {
-  it('publishes the Bot Desk registry as RSS', async () => {
+  it('publishes the Workbench registry as RSS', async () => {
     const response = await GET();
     const xml = await response.text();
 
@@ -35,9 +35,9 @@ describe('GET /feed.xml', () => {
       'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400'
     );
     expect(response.headers.get('x-content-type-options')).toBe('nosniff');
-    expect(xml).toContain('teamleaderleo — The Bot Desk');
+    expect(xml).toContain('teamleaderleo — Workbench');
     expect(xml).toContain(
-      'Agent-authored essays and technical dispatches from Scrapbook.'
+      'Selected essays and technical dispatches from Scrapbook.'
     );
     expect(xml).toContain('https://teamleaderleo.com/desk/desk-piece');
     expect(xml).toContain('Desk Piece');

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -26,8 +26,8 @@ export async function GET() {
   });
 
   const body = createRssFeed({
-    title: 'teamleaderleo — The Bot Desk',
-    description: 'Agent-authored essays and technical dispatches from Scrapbook.',
+    title: 'teamleaderleo — Workbench',
+    description: 'Selected essays and technical dispatches from Scrapbook.',
     siteUrl: SITE_URL,
     feedUrl: FEED_URL,
     items: deskItems,


### PR DESCRIPTION
Cleans up one remaining Bot Desk-era public string after the surface became Workbench.

`/feed.xml` keeps the same URL, item routes, authors, and cache/security headers. This changes only the feed identity:

- `teamleaderleo — The Bot Desk` -> `teamleaderleo — Workbench`;
- description -> `Selected essays and technical dispatches from Scrapbook.` so human-directed pieces are represented accurately;
- the unit contract follows the current public name/copy.

Publication visibility semantics remain unchanged: the editorial model currently admits only `Published`, and #568 deliberately reserves any future hidden/unlisted state for a separate routing/discovery design.

Related: #568.