### PR TITLE
work: record Workers SDK Access fix merge

### DIFF
--- a/work/portfolio-inventory.md
+++ b/work/portfolio-inventory.md
@@ -83,7 +83,7 @@ Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
 State:
 
 - Vite: one merged optimizer resource-lifecycle fix, a second lifecycle repair approved by two maintainers, and a config-idempotence follow-on in review;
-- Cloudflare Workers SDK: Miniflare teardown repair merged; Access credential-cache repair human-approved with Wrangler CODEOWNERS satisfied and still open.
+- Cloudflare Workers SDK: two merged repairs covering Miniflare teardown ordering and Cloudflare Access credential freshness/cache semantics.
 
 What they prove:
 

--- a/work/records/open-source.md
+++ b/work/records/open-source.md
@@ -135,15 +135,15 @@ Resume signal: **strong merged lifecycle specimen**. It is now a clean Cloudflar
 
 Upstream PR: https://redirect.github.com/cloudflare/workers-sdk/pull/15080
 
-State: **open; human-approved; Wrangler CODEOWNERS satisfied; changesets prepared** at the latest refresh.
+State: **merged**.
 
 `getAccessHeaders()` cached Access service-token headers by domain. If the environment later removed or partially changed the client ID/secret, the same domain could reuse stale complete credentials.
 
 The repair returns service-token headers from the current environment and leaves interactive `CF_Authorization` cookie caching intact. Regressions cover unsetting either/both service-token variables and preservation of legitimate interactive-cookie reuse.
 
-A human reviewer approved the current head and the repository's CODEOWNERS gate explicitly reports satisfied. GitHub still reports the PR open rather than merged, so public wording should distinguish accepted review from merge.
+The PR merged on 2026-08-16 after human approval and Wrangler CODEOWNERS satisfaction.
 
-Resume signal: **strong**. Together with the merged Miniflare repair, this is a small but coherent Cloudflare cluster around lifecycle and state correctness.
+Resume signal: **strong**. Together with the Miniflare repair, this gives a two-merge Cloudflare cluster around lifecycle and state correctness.
 
 ## Accepted findings through another repair path
 
@@ -376,7 +376,7 @@ A good general mix at this refresh is:
 
 1. Vercel AI SDK — one direct merge plus two Factory-adopted merged repairs with explicit co-author credit; one propagated across maintained v5/v6 branches.
 2. Cloud Hypervisor — two merged Rust/VMM lifecycle/error-propagation changes, with a deeper QCOW metadata-ownership repair through substantive maintainer review.
-3. Cloudflare Workers SDK — merged Miniflare teardown lifecycle repair plus Access credential/cache semantics with human + CODEOWNERS approval.
+3. Cloudflare Workers SDK — two merged repairs covering Miniflare teardown lifecycle and Access credential/cache semantics.
 4. Vite — one merged optimizer lifecycle fix plus a second teardown repair approved by two maintainers.
 5. SWC if accepted — narrowed compiler/minifier constant-folding correctness repair; otherwise choose the four strongest role-specific specimens above.
 

--- a/work/resume-candidates.md
+++ b/work/resume-candidates.md
@@ -80,7 +80,7 @@ For a general resume, the first merged-work line may be enough. For systems role
 
 #### 3. Cloudflare Workers SDK — strong current
 
-The Miniflare teardown/lifecycle PR #15143 is now **merged**. The Access credential fix #15080 remains open but is human-approved with Wrangler CODEOWNERS satisfied.
+The Miniflare teardown/lifecycle PR #15143 and the Access credential fix #15080 are both **merged**.
 
 Candidate bullet family:
 
@@ -88,9 +88,9 @@ Candidate bullet family:
 
 Useful paired line for Cloudflare/devtools roles:
 
-> Separately fixed stale Cloudflare Access service-token headers surviving environment changes by separating current credential state from legitimately cached interactive authorization; the current patch is human-approved with CODEOWNERS satisfied.
+> Separately fixed stale Cloudflare Access service-token headers surviving environment changes by separating current credential state from legitimately cached interactive authorization; the repair merged with regression coverage for removed and incomplete credentials.
 
-This is now a real two-item Cloudflare cluster: one merged lifecycle repair plus one accepted credential/cache repair awaiting merge.
+This is now a two-merge Cloudflare cluster spanning teardown lifecycle and credential/cache state correctness.
 
 #### 4. Vite — promoted current
 
@@ -229,7 +229,7 @@ Priority order:
 
 1. Vercel AI SDK — direct merge plus Factory-adopted/co-authored fixes is now the strongest upstream cluster.
 2. Cloud Hypervisor (proves range outside TS/AI).
-3. Cloudflare Workers SDK — one merged lifecycle fix plus one human-approved credential/cache repair.
+3. Cloudflare Workers SDK — two merged lifecycle/state correctness fixes.
 4. Vite — one merge plus a two-maintainer-approved lifecycle repair.
 5. SWC rises above Vite if the narrowed constant-folding repair is accepted and the compiler/minifier axis is useful for the target.
 6. Preflight, framed as runtime/instrumentation/performance and controlled evaluation rather than game fandom first.


### PR DESCRIPTION
Update the career-facing open-source records after cloudflare/workers-sdk#15080 merged.

This keeps the existing story intact and only changes the stale status language: the Access credential/cache repair is now landed, making the Cloudflare cluster two merged fixes.