### PR TITLE
Record the retrieval-first agentic engineering method

### DIFF
--- a/work/portfolio-inventory.md
+++ b/work/portfolio-inventory.md
@@ -190,6 +190,34 @@ For Valve/runtime/platform roles this is a particularly useful frame beside Pref
 
 ---
 
+# Cross-repository engineering method
+
+Detailed Scrapbook record: [`records/working-style.md`](records/working-style.md)
+
+State: **active working model; increasingly explicit across several owned systems and upstream research lanes**.
+
+The portfolio-level point is narrower than "AI makes Leo faster." The stronger evidence is that a recurring method now spans several kinds of work:
+
+- [Preflight](https://github.com/teamleaderleo/preflight) uses agents inside one deep product while tying performance and compatibility claims to runtime evidence, controlled measurement, exact identities, and fallback behavior;
+- [Fieldwork](https://github.com/teamleaderleo/fieldwork) and [Linux Fieldwork](https://github.com/teamleaderleo/linux-fieldwork) move the same code-first investigation method across unfamiliar repositories, preserve negative results, and expose selected work to independent maintainer review;
+- [Stensibly](https://github.com/teamleaderleo/stensibly) externalizes responsibility, authority, leases, handoffs, and continuation so work can survive worker replacement and stale sessions;
+- [Cultist](https://github.com/teamleaderleo/cultist) explores repository memory and just-enough evidence so a fresh worker can recover useful precedent, counterexamples, current work, and reviewed rationale before repeating manual archaeology.
+
+What it currently supports:
+
+- human attention is increasingly allocated to problem selection, contract choice, evidence quality, review boundaries, and consequential decisions while agents supply search, implementation, experimentation, and retrieval capacity;
+- the workflow treats worker/session loss as normal and tries to preserve enough durable state for another actor to continue from evidence rather than chat memory;
+- domain transfer is visible across Java/JVM performance, TypeScript SDKs/tooling, Rust virtualization, Linux/container work, browser systems, and agent coordination;
+- several outputs have encountered independent external review, while Cultist is explicitly adding held-out behavioral tests for whether surfaced repository evidence changes what a fresh worker does next.
+
+This is also the modern version of an older personal habit: capture generously, synthesize quickly, keep useful residue, and revisit it when a real problem creates demand. Speech-to-text and agents make the residue cheaper to create and much cheaper to recover; Stensibly and Cultist attempt to make continuation and retrieval explicit engineering concerns rather than personal-memory tricks.
+
+Career use: **synthesis narrative rather than a standalone logo/bullet**. It is especially useful for coding-agent environments, developer tools, evaluation, durable execution, and research-engineering roles because it explains why the owned systems and cross-repository work belong in one portfolio. Keep individual technical claims tied to their source repositories.
+
+Do not overstate: Stensibly still describes a guarded pilot boundary, Cultist is an early prototype, and the broader method has several strong cases rather than a general proof that agent-heavy engineering works everywhere.
+
+---
+
 # Owned systems inventory
 
 ## Stensibly
@@ -341,6 +369,8 @@ Useful project candidates for LinkedIn are Preflight, Stensibly, SmolRunner, and
 ## Interviews
 
 Keep the non-merge stories. BuildKit and runc are especially good because they show the ability to change conclusion after maintainer/project-history evidence. Playwright is useful as an accepted diagnosis where upstream chose a smaller repair boundary. FEX is useful for systems depth if described as research rather than contribution. Zustand is useful for explaining substantive authorship when GitHub landing mechanics obscure it.
+
+The cross-repository method is useful when an interviewer asks how AI changes the work itself. Keep the answer concrete: agents expand search and execution capacity; durable evidence, exact review boundaries, external maintainers, and selective human attention keep the work answerable to reality. Use Preflight, Stensibly, Fieldwork/Linux Fieldwork, and Cultist as distinct examples rather than presenting them as one finished platform.
 
 ## Applications
 

--- a/work/records/working-style.md
+++ b/work/records/working-style.md
@@ -1,6 +1,6 @@
 # Working style and retrieval model
 
-Updated: 2026-08-11
+Updated: 2026-08-20
 
 This record captures how Leo currently works and why `work/` exists. It is descriptive, not a claim that every future task should use the same process.
 
@@ -27,6 +27,31 @@ The human loop is intentionally asymmetric. Leo supplies direction, judgment, cu
 - what gaps are real versus artifacts of forgetting the existing evidence?
 
 without reconstructing the answer from chat history.
+
+## Capture first, retrieve on demand
+
+This working style predates the current agent-heavy period.
+
+For years, Leo treated many notes as effectively append-only and close to write-only: capture the thought while it is alive, use or synthesize it when useful, and rarely spend time maintaining a perfectly organized archive. Strong baseline recall made that workable. Important ideas usually stayed available long enough to be applied; low-value material could fade without demanding another review pass.
+
+The tradeoff was retrieval. Handwritten notes could be dense, abbreviated, or intentionally difficult for anyone else to parse, and sometimes difficult for Leo to parse later. Digital notes accumulated in similar ways. The system favored thinking now over making every fragment pleasant for a hypothetical future reader.
+
+High-quality speech-to-text changed that tradeoff. Dictation makes it cheap to leave far more searchable language behind without interrupting the thought to type, format, classify, or file it. The raw material still arrives messily, but text gives later tools a much better substrate for search, comparison, summarization, and resurfacing.
+
+Agents change the economics again. A large archive no longer requires Leo to remember where everything lives or personally review it on a schedule. When a concrete question arrives, an agent can search the residue, recover the useful parts, compare them with current evidence, and return the small subset that deserves attention.
+
+The resulting ethos is deliberately selective:
+
+- capture generously when capture is cheap;
+- organize only when organization earns its cost;
+- retrieve when a real decision creates demand;
+- distill conclusions that survive repeated use or scrutiny;
+- practice the skills that benefit from embodied recall;
+- automate or forget the administrative remainder.
+
+Different knowledge deserves different treatment. Some things belong in muscle memory or unaided recall. Some should live as durable searchable evidence. Some only need to exist long enough to complete one task. Treating all three categories as equally worthy of rehearsal wastes attention.
+
+The goal is therefore less "be organized" than **keep important knowledge recoverable while spending as little life as possible tending low-value administration**.
 
 ## Identity: slope over domain ownership
 
@@ -71,6 +96,26 @@ They also serve as an externalized retrieval layer:
 6. leave the durable record better than they found it when new evidence materially changes the picture.
 
 This is the motivation for keeping factual work records separate from churny resume/application rankings.
+
+## The mess became an operating model
+
+The current repositories increasingly make the old personal habit explicit instead of trying to replace it with exhaustive personal organization.
+
+- [Preflight](https://github.com/teamleaderleo/preflight) tests whether agent-heavy execution can sustain a deep product whose claims are tied to measurement, compatibility gates, fallback behavior, and real runtime evidence.
+- [Fieldwork](https://github.com/teamleaderleo/fieldwork) and [Linux Fieldwork](https://github.com/teamleaderleo/linux-fieldwork) test whether the same investigation method transfers across unfamiliar codebases, with negative results and upstream review preserved as evidence instead of treated as wasted motion.
+- [Stensibly](https://github.com/teamleaderleo/stensibly) externalizes responsibility and authority so work can survive worker restarts, stale sessions, retries, handoffs, and replacement.
+- [Cultist](https://github.com/teamleaderleo/cultist) attacks rediscovery directly: recover bounded repository evidence before a worker edits, keep provenance/counterexamples/unknowns visible, and preserve earned rationale for the next worker. Its current behavioral pressure test asks whether selected evidence actually changes the next justified action or prevents a repeated wrong turn.
+- Scrapbook remains the synthesis and retrieval layer across those systems: what happened, what survived scrutiny, what belongs in public narrative, and what deserves to be brought back into active memory later.
+
+The common problem is human attention. Agent output can grow much faster than one person can read line by line, and a large archive can grow much faster than one person can periodically review. The response here is to move more of the burden into recoverability: exact evidence, bounded context, tests, handoffs, provenance, external checks, and selective retrieval at the moment a decision needs them.
+
+That gives a more useful question than "does Leo understand every line?":
+
+> Can a fresh competent worker recover the facts, rationale, uncertainty, and evidence needed for the next consequential decision at an acceptable cost?
+
+The method is still being tested. Preflight provides one deep owned-system case; Fieldwork and Linux Fieldwork broaden the domain sample and expose work to outside maintainers; Cultist's held-out-task evaluation is explicitly aimed at measuring whether repository memory changes worker behavior. The portfolio should keep those evidence levels separate.
+
+The underlying personal habit remains recognizable: **capture the useful residue, trust synthesis, let low-value detail fall away, and build retrieval around the moments where forgetting would become expensive**.
 
 ## Recall practice / "Monkeytype but code"
 


### PR DESCRIPTION
## Summary

- extend the working-style record from the older append-first note habit into the current retrieval-on-demand model
- connect Preflight, Fieldwork/Linux Fieldwork, Stensibly, Cultist, and Scrapbook as distinct responses to execution, coordination, rediscovery, and synthesis costs
- add a restrained portfolio-level synthesis so future resume/interview work can recover the cross-repository story without turning it into a standalone prestige claim

## Review

- documentation-only change under `work/`
- inspected both exact commit diffs and the complete two-file compare against current `main`
- no product/runtime behavior changed; no automated checks required for the Markdown-only update