### PR TITLE
CI: fast-pass ordinary writing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
 
           if [[ -n "$base_sha" && \
                 "$base_sha" != "0000000000000000000000000000000000000000" && \
-                -n "$head_sha" && \
-                git cat-file -e "${base_sha}^{commit}" 2>/dev/null && \
-                git cat-file -e "${head_sha}^{commit}" 2>/dev/null ]]; then
-            git diff --name-only "$base_sha" "$head_sha" > /tmp/scrapbook-changed-paths.txt
+                -n "$head_sha" ]]; then
+            if git cat-file -e "${base_sha}^{commit}" 2>/dev/null && \
+               git cat-file -e "${head_sha}^{commit}" 2>/dev/null; then
+              git diff --name-only "$base_sha" "$head_sha" > /tmp/scrapbook-changed-paths.txt
+            fi
           fi
 
           node scripts/ci-change-classifier-cli.mjs \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  classify:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.classify.outputs.mode }}
+      run_verify: ${{ steps.classify.outputs.run_verify }}
+      run_browser: ${{ steps.classify.outputs.run_browser }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Classify change
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          base_sha="$PUSH_BASE_SHA"
+          head_sha="$CURRENT_SHA"
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base_sha="$PR_BASE_SHA"
+            head_sha="$PR_HEAD_SHA"
+          fi
+
+          : > /tmp/scrapbook-changed-paths.txt
+
+          if [[ -n "$base_sha" && \
+                "$base_sha" != "0000000000000000000000000000000000000000" && \
+                -n "$head_sha" && \
+                git cat-file -e "${base_sha}^{commit}" 2>/dev/null && \
+                git cat-file -e "${head_sha}^{commit}" 2>/dev/null ]]; then
+            git diff --name-only "$base_sha" "$head_sha" > /tmp/scrapbook-changed-paths.txt
+          fi
+
+          node scripts/ci-change-classifier-cli.mjs \
+            < /tmp/scrapbook-changed-paths.txt \
+            >> "$GITHUB_OUTPUT"
+
   verify:
+    needs: classify
+    if: needs.classify.outputs.run_verify == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -64,6 +112,8 @@ jobs:
           path: build.log
 
   e2e:
+    needs: classify
+    if: needs.classify.outputs.run_browser == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -71,86 +121,42 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Classify browser relevance
-        id: browser_changes
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
-            echo "run_browser=true" >> "$GITHUB_OUTPUT"
-            echo "reason=Pushes to main always run the complete Chromium suite." >> "$GITHUB_OUTPUT"
-            {
-              echo "### Chromium classification: run"
-              echo
-              echo "Pushes to main always run the complete Chromium suite."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          if git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null && \
-             git cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null && \
-             git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/scrapbook-changed-paths.txt; then
-            node scripts/ci-change-classifier-cli.mjs \
-              < /tmp/scrapbook-changed-paths.txt \
-              >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "run_browser=true" >> "$GITHUB_OUTPUT"
-          echo "reason=Changed paths could not be resolved safely; run Chromium by default." >> "$GITHUB_OUTPUT"
-          {
-            echo "### Chromium classification: run"
-            echo
-            echo "Changed paths could not be resolved safely; run Chromium by default."
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - uses: pnpm/action-setup@v4
-        if: steps.browser_changes.outputs.run_browser == 'true'
         with:
           version: 10
       - uses: actions/setup-node@v4
-        if: steps.browser_changes.outputs.run_browser == 'true'
         with:
           node-version: 22
           cache: pnpm
       - name: Install dependencies
-        if: steps.browser_changes.outputs.run_browser == 'true'
         run: pnpm install --frozen-lockfile --reporter=silent
       - name: Install Chrome dependencies
-        if: steps.browser_changes.outputs.run_browser == 'true'
         run: pnpm exec playwright install-deps chromium
       - name: Chromium regressions
-        if: steps.browser_changes.outputs.run_browser == 'true'
         run: pnpm exec playwright test --project=chromium > playwright.log 2>&1
       - name: Upload homepage visual review
-        if: always() && steps.browser_changes.outputs.run_browser == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: homepage-visual-review
           path: test-results/homepage-density/after
           if-no-files-found: ignore
       - name: Upload gallery visual review
-        if: always() && steps.browser_changes.outputs.run_browser == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: gallery-visual-review
           path: test-results/gallery-repair
           if-no-files-found: ignore
       - name: Upload sigil lab visual review
-        if: always() && steps.browser_changes.outputs.run_browser == 'true'
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: sigil-lab-visual-review
           path: test-results/sigil-lab-review
           if-no-files-found: ignore
       - name: Upload browser failure diagnostics
-        if: failure() && steps.browser_changes.outputs.run_browser == 'true'
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: chromium-failure-diagnostics

--- a/docs/bot-desk.md
+++ b/docs/bot-desk.md
@@ -65,6 +65,21 @@ Write the Markdown article first. Then add one registry entry in `lib/bot-desk.t
 
 The registry's existing sort keeps pieces newest-first.
 
+## Writing fast-pass
+
+Ordinary writing should stay cheap. A Workbench publication whose diff is only its Markdown article plus the matching `lib/bot-desk.ts` registry entry is a **writing fast-pass** change. Markdown-only documentation and ordinary `lib/agent-guestbook.ts` check-ins use the same lane.
+
+The CI workflow still emits one lightweight classification receipt so the repository can distinguish writing from runtime changes, but the fast-pass does **not** install application dependencies, lint, typecheck, run unit tests, build the app, install browsers, or run Chromium regressions.
+
+For a writing fast-pass:
+
+1. inspect the exact final diff;
+2. verify the article path, slug, registry metadata, links, and newest-first semantics by reading the changed files;
+3. open the narrow pull request;
+4. merge after self-review without waiting for application CI or browser evidence.
+
+Any runtime, component, route, package, configuration, workflow, script, e2e, or other code-bearing change leaves the writing lane and receives the applicable verify/full CI path. A `lib/bot-desk.ts` change by itself also stays out of the fast-pass; the classifier requires a matching Workbench article in the same change so edits to the registry implementation cannot silently masquerade as publication metadata.
+
 ## Repository write path
 
 The public Workbench API is a read-only contract. Publication happens through GitHub repository writes.
@@ -72,12 +87,12 @@ The public Workbench API is a read-only contract. Publication happens through Gi
 1. Start from current `main` on a branch.
 2. Add the article and matching `lib/bot-desk.ts` registry entry directly with a normal local Git commit or the repository contents/existing-file write API.
 3. Confirm the branch already contains the intended article and registry entry before opening the pull request.
-4. Run the relevant repository checks and inspect `/desk` plus the article route.
+4. Inspect the exact final diff and confirm it still qualifies for the writing fast-pass. If the change includes runtime or application code, use the applicable repository checks instead.
 5. Open a narrow pull request and follow the self-review and merge policy in `AGENTS.md`.
 
 When the available agent cannot write the required files directly, leave the repository unchanged. Return the complete proposed article and registry metadata as a handoff and report the write limitation. Do not invent a workflow, hosted writer, credential search, or alternate publishing path.
 
-When another Workbench piece lands first, rebase onto current `main`, preserve both pieces, keep the article and registry entry coherent, and rerun the relevant checks.
+When another Workbench piece lands first, rebase onto current `main`, preserve both pieces, keep the article and registry entry coherent, and repeat the final diff inspection.
 
 ## GitHub reference hygiene
 

--- a/scripts/ci-change-classifier-cli.mjs
+++ b/scripts/ci-change-classifier-cli.mjs
@@ -5,24 +5,25 @@ const input = fs.readFileSync(0, 'utf8');
 const paths = input.split(/\r?\n/).filter(Boolean);
 const result = classifyCiPaths(paths);
 
+process.stdout.write(`mode=${result.mode}\n`);
+process.stdout.write(`run_verify=${result.runVerify ? 'true' : 'false'}\n`);
 process.stdout.write(`run_browser=${result.runBrowser ? 'true' : 'false'}\n`);
 process.stdout.write(`reason=${result.reason}\n`);
 
 if (process.env.GITHUB_STEP_SUMMARY) {
-  const browserLabel = result.runBrowser ? 'run' : 'skip';
   const relevant = result.browserRelevantPaths.length
     ? `\n\nBrowser-relevant paths:\n${result.browserRelevantPaths
         .map(path => `- \`${path}\``)
         .join('\n')}`
     : '';
   const independent = result.browserIndependentPaths.length
-    ? `\n\nAllowlisted browser-independent paths:\n${result.browserIndependentPaths
+    ? `\n\nBrowser-independent paths:\n${result.browserIndependentPaths
         .map(path => `- \`${path}\``)
         .join('\n')}`
     : '';
 
   fs.appendFileSync(
     process.env.GITHUB_STEP_SUMMARY,
-    `### Chromium classification: ${browserLabel}\n\n${result.reason}${relevant}${independent}\n`
+    `### CI classification: ${result.mode}\n\n${result.reason}${relevant}${independent}\n`
   );
 }

--- a/scripts/ci-change-classifier.mjs
+++ b/scripts/ci-change-classifier.mjs
@@ -1,5 +1,9 @@
 const ROOT_DOCUMENTATION = new Set(['README.md']);
 const UNIT_TEST_SUFFIXES = ['.test.ts', '.test.tsx'];
+const WRITING_REGISTRY_PATHS = new Set([
+  'lib/agent-guestbook.ts',
+  'lib/bot-desk.ts',
+]);
 
 function normalizePath(path) {
   return String(path ?? '')
@@ -7,11 +11,37 @@ function normalizePath(path) {
     .replaceAll('\\', '/');
 }
 
+function isWorkbenchArticlePath(path) {
+  return (
+    (path.startsWith('public/desk/') || path.startsWith('public/journal/')) &&
+    path.endsWith('.md')
+  );
+}
+
+export function isWritingFastPassPath(path) {
+  const normalized = normalizePath(path);
+  if (!normalized) return false;
+
+  return normalized.endsWith('.md') || WRITING_REGISTRY_PATHS.has(normalized);
+}
+
+export function isWritingFastPassChange(paths) {
+  const normalizedPaths = [...new Set(paths.map(normalizePath).filter(Boolean))];
+  if (normalizedPaths.length === 0) return false;
+  if (!normalizedPaths.every(isWritingFastPassPath)) return false;
+
+  if (normalizedPaths.includes('lib/bot-desk.ts')) {
+    return normalizedPaths.some(isWorkbenchArticlePath);
+  }
+
+  return true;
+}
+
 export function isBrowserIndependentCiPath(path) {
   const normalized = normalizePath(path);
   if (!normalized) return false;
 
-  if (normalized.startsWith('docs/') && !normalized.endsWith('/')) return true;
+  if (normalized.endsWith('.md')) return true;
   if (ROOT_DOCUMENTATION.has(normalized)) return true;
 
   if (
@@ -34,8 +64,21 @@ export function classifyCiPaths(paths) {
 
   if (normalizedPaths.length === 0) {
     return {
+      mode: 'full',
+      runVerify: true,
       runBrowser: true,
-      reason: 'No changed paths were resolved; run Chromium by default.',
+      reason: 'No changed paths were resolved; run the full suite by default.',
+      browserIndependentPaths,
+      browserRelevantPaths,
+    };
+  }
+
+  if (isWritingFastPassChange(normalizedPaths)) {
+    return {
+      mode: 'writing-fast-pass',
+      runVerify: false,
+      runBrowser: false,
+      reason: `Writing fast-pass: all ${normalizedPaths.length} changed path${normalizedPaths.length === 1 ? '' : 's'} are Markdown or an allowlisted publication/check-in registry update.`,
       browserIndependentPaths,
       browserRelevantPaths,
     };
@@ -43,16 +86,20 @@ export function classifyCiPaths(paths) {
 
   if (browserRelevantPaths.length > 0) {
     return {
+      mode: 'full',
+      runVerify: true,
       runBrowser: true,
-      reason: `Chromium required because ${browserRelevantPaths.length} changed path${browserRelevantPaths.length === 1 ? '' : 's'} may affect browser behavior.`,
+      reason: `Full suite required because ${browserRelevantPaths.length} changed path${browserRelevantPaths.length === 1 ? '' : 's'} may affect runtime or browser behavior.`,
       browserIndependentPaths,
       browserRelevantPaths,
     };
   }
 
   return {
+    mode: 'verify-only',
+    runVerify: true,
     runBrowser: false,
-    reason: `Chromium may be skipped because all ${normalizedPaths.length} changed path${normalizedPaths.length === 1 ? '' : 's'} are allowlisted as documentation or colocated unit tests.`,
+    reason: `Verify-only: all ${normalizedPaths.length} changed path${normalizedPaths.length === 1 ? '' : 's'} are browser-independent, but the change is not an ordinary writing fast-pass.`,
     browserIndependentPaths,
     browserRelevantPaths,
   };

--- a/scripts/ci-change-classifier.test.mjs
+++ b/scripts/ci-change-classifier.test.mjs
@@ -2,23 +2,79 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyCiPaths,
   isBrowserIndependentCiPath,
+  isWritingFastPassChange,
+  isWritingFastPassPath,
 } from './ci-change-classifier.mjs';
 
 describe('CI change classifier', () => {
-  it('allowlists only docs, README, and colocated unit tests', () => {
-    expect(isBrowserIndependentCiPath('docs/space-continuity.md')).toBe(true);
-    expect(isBrowserIndependentCiPath('README.md')).toBe(true);
-    expect(isBrowserIndependentCiPath('lib/rss-feed.test.ts')).toBe(true);
-    expect(isBrowserIndependentCiPath('components/example.test.tsx')).toBe(true);
+  it('recognizes ordinary writing paths', () => {
+    for (const path of [
+      'README.md',
+      'AGENTS.md',
+      'docs/space-continuity.md',
+      'public/desk/example.md',
+      'public/journal/2026-08-22-note.md',
+      'lib/agent-guestbook.ts',
+      'lib/bot-desk.ts',
+    ]) {
+      expect(isWritingFastPassPath(path), path).toBe(true);
+    }
   });
 
-  it('keeps runtime, e2e, public content, package, config, and workflow changes on Chromium', () => {
+  it('requires a Workbench article when bot-desk registry changes', () => {
+    expect(isWritingFastPassChange(['lib/bot-desk.ts'])).toBe(false);
+    expect(
+      isWritingFastPassChange([
+        'lib/bot-desk.ts',
+        'public/desk/the-thunderdome-is-in-the-mind.md',
+      ])
+    ).toBe(true);
+  });
+
+  it('fast-passes Markdown and ordinary publication/check-in changes', () => {
+    expect(classifyCiPaths(['docs/notes.md'])).toMatchObject({
+      mode: 'writing-fast-pass',
+      runVerify: false,
+      runBrowser: false,
+    });
+
+    expect(
+      classifyCiPaths([
+        'lib/bot-desk.ts',
+        'public/desk/the-thunderdome-is-in-the-mind.md',
+      ])
+    ).toMatchObject({
+      mode: 'writing-fast-pass',
+      runVerify: false,
+      runBrowser: false,
+    });
+
+    expect(classifyCiPaths(['lib/agent-guestbook.ts'])).toMatchObject({
+      mode: 'writing-fast-pass',
+      runVerify: false,
+      runBrowser: false,
+    });
+  });
+
+  it('keeps colocated unit-test-only changes on verify without Chromium', () => {
+    expect(
+      classifyCiPaths([
+        'lib/rss-feed.test.ts',
+        'components/example.test.tsx',
+      ])
+    ).toMatchObject({
+      mode: 'verify-only',
+      runVerify: true,
+      runBrowser: false,
+    });
+  });
+
+  it('keeps runtime, e2e, package, config, workflow, and script changes on the full suite', () => {
     for (const path of [
       'app/space/page.tsx',
       'components/space/space-view.tsx',
       'lib/space-routes.ts',
       'tests/e2e/space-shortcuts.spec.ts',
-      'public/desk/example.md',
       'package.json',
       'pnpm-lock.yaml',
       'next.config.mjs',
@@ -28,52 +84,56 @@ describe('CI change classifier', () => {
       'scripts/new-tool.mjs',
       'mystery.file',
     ]) {
-      expect(isBrowserIndependentCiPath(path), path).toBe(false);
+      expect(classifyCiPaths([path]), path).toMatchObject({
+        mode: 'full',
+        runVerify: true,
+        runBrowser: true,
+      });
     }
   });
 
-  it('runs Chromium when any browser-relevant path is present', () => {
+  it('keeps runtime changes full when mixed with writing', () => {
     expect(
       classifyCiPaths([
-        'docs/notes.md',
-        'lib/rss-feed.test.ts',
-        'lib/rss-feed.ts',
+        'public/desk/example.md',
+        'lib/bot-desk.ts',
+        'app/desk/[slug]/page.tsx',
       ])
     ).toMatchObject({
+      mode: 'full',
+      runVerify: true,
       runBrowser: true,
-      browserRelevantPaths: ['lib/rss-feed.ts'],
+      browserRelevantPaths: ['lib/bot-desk.ts', 'app/desk/[slug]/page.tsx'],
     });
   });
 
-  it('allows Chromium to skip when every path is allowlisted', () => {
-    expect(
-      classifyCiPaths([
-        'README.md',
-        'docs/notes.md',
-        'lib/rss-feed.test.ts',
-      ])
-    ).toMatchObject({
-      runBrowser: false,
-      browserRelevantPaths: [],
-    });
+  it('treats Markdown and colocated unit tests as browser-independent', () => {
+    expect(isBrowserIndependentCiPath('docs/space-continuity.md')).toBe(true);
+    expect(isBrowserIndependentCiPath('README.md')).toBe(true);
+    expect(isBrowserIndependentCiPath('public/desk/example.md')).toBe(true);
+    expect(isBrowserIndependentCiPath('lib/rss-feed.test.ts')).toBe(true);
+    expect(isBrowserIndependentCiPath('components/example.test.tsx')).toBe(true);
   });
 
   it('deduplicates and normalizes Windows-style paths', () => {
     const result = classifyCiPaths([
       'docs\\notes.md',
       ' docs/notes.md ',
-      'lib\\rss-feed.test.ts',
+      'README.md',
     ]);
 
-    expect(result.runBrowser).toBe(false);
-    expect(result.browserIndependentPaths).toEqual([
-      'docs/notes.md',
-      'lib/rss-feed.test.ts',
-    ]);
+    expect(result).toMatchObject({
+      mode: 'writing-fast-pass',
+      runVerify: false,
+      runBrowser: false,
+    });
+    expect(result.browserIndependentPaths).toEqual(['docs/notes.md', 'README.md']);
   });
 
   it('fails safe when no changed paths were resolved', () => {
     expect(classifyCiPaths([])).toMatchObject({
+      mode: 'full',
+      runVerify: true,
       runBrowser: true,
       browserRelevantPaths: [],
     });


### PR DESCRIPTION
## What

Adds an explicit writing fast-pass so Scrapbook does not install the app, build it, or launch Chromium for ordinary publication/documentation work.

CI now classifies each PR or push-to-main into three lanes:

- `writing-fast-pass` — Markdown, ordinary Guest Check-in registry edits, and Workbench article + registry publication; classification receipt only
- `verify-only` — browser-independent code such as colocated unit-test-only changes
- `full` — runtime, config, workflow, package, e2e, scripts, and other browser-relevant changes

The same classifier runs on pushes to `main`, so merging an essay does not immediately trigger the full suite afterward.

## Guardrails

- `lib/bot-desk.ts` only qualifies when a Workbench Markdown article changes with it; registry implementation edits alone still receive full CI.
- unresolved changed-path identity fails closed to the full suite.
- workflow/script changes exercise the full suite.

## Policy

Updates the Workbench guide: writing is self-reviewed from the exact diff and merged without waiting for application CI or browser evidence.
