### PR TITLE
Add Lightsail usage to proxy dashboard

### DIFF
--- a/components/proxy/lightsail-usage-card.tsx
+++ b/components/proxy/lightsail-usage-card.tsx
@@ -163,7 +163,15 @@ function UsageRing({ percent }: { percent: number | null }) {
   );
 }
 
-function Stat({ label, value, detail }: { label: string; value: string; detail: string }) {
+function Stat({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
   return (
     <div className="px-4 py-4">
       <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
@@ -195,10 +203,13 @@ export function LightsailUsageCard({
     isFiniteNumber(used) && isFiniteNumber(limit)
       ? Math.max(0, limit - used)
       : null;
+  const checkedAt = usage.lastRawAt ?? status.checkedAt ?? status.updatedAt;
+  const checkedTime = Date.parse(checkedAt);
   const resetTime = usage.resetAt ? Date.parse(usage.resetAt) : Number.NaN;
-  const daysLeft = Number.isFinite(resetTime)
-    ? Math.max(1, Math.ceil((resetTime - Date.now()) / DAY_MS))
-    : null;
+  const daysLeft =
+    Number.isFinite(resetTime) && Number.isFinite(checkedTime)
+      ? Math.max(1, Math.ceil((resetTime - checkedTime) / DAY_MS))
+      : null;
   const dailyRoom =
     isFiniteNumber(remaining) && isFiniteNumber(daysLeft)
       ? remaining / daysLeft
@@ -209,8 +220,8 @@ export function LightsailUsageCard({
   const errors = Array.isArray(status.payload.errors)
     ? status.payload.errors.filter(error => typeof error === 'string')
     : [];
-  const healthy = xray === 'active' && hysteria === 'active' && errors.length === 0;
-  const checkedAt = usage.lastRawAt ?? status.updatedAt;
+  const healthy =
+    xray === 'active' && hysteria === 'active' && errors.length === 0;
 
   return (
     <section className="overflow-hidden rounded-[1.5rem] border border-border/70 bg-background/78">

--- a/components/proxy/lightsail-usage-card.tsx
+++ b/components/proxy/lightsail-usage-card.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import type {
+  ProxyHealthSample,
+  StoredProxyHealth,
+} from '@/app/lib/proxy-health-store';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type LightsailUsage = {
+  usedBytes: number | null;
+  limitBytes: number | null;
+  resetAt: string | null;
+  lastRawAt: string | null;
+  source: string | null;
+};
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function formatBytes(value: number | null | undefined) {
+  if (!isFiniteNumber(value)) return '—';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = value;
+  let unit = 0;
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024;
+    unit += 1;
+  }
+  return `${size.toFixed(unit === 0 ? 0 : 2)} ${units[unit]}`;
+}
+
+function formatPercent(value: number | null | undefined) {
+  if (!isFiniteNumber(value)) return '—';
+  if (value > 0 && value < 1) return '<1%';
+  return `${Math.round(value)}%`;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function formatRelativeTime(value: string | null | undefined) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  const diffMs = Date.now() - date.getTime();
+  const absolute = Math.abs(diffMs);
+  const suffix = diffMs >= 0 ? 'ago' : 'from now';
+  if (absolute < 60_000) return 'just now';
+  if (absolute < 60 * 60 * 1000)
+    return `${Math.round(absolute / 60_000)}m ${suffix}`;
+  if (absolute < DAY_MS)
+    return `${Math.round(absolute / (60 * 60 * 1000))}h ${suffix}`;
+  return `${Math.round(absolute / DAY_MS)}d ${suffix}`;
+}
+
+function readUsage(status: StoredProxyHealth): LightsailUsage | null {
+  const usage = status.payload.provider?.usage;
+  if (!usage || usage.source === 'disabled') return null;
+  return {
+    usedBytes: isFiniteNumber(usage.used_bytes) ? usage.used_bytes : null,
+    limitBytes: isFiniteNumber(usage.limit_bytes) ? usage.limit_bytes : null,
+    resetAt: typeof usage.reset_at === 'string' ? usage.reset_at : null,
+    lastRawAt:
+      typeof usage.last_raw_at === 'string' ? usage.last_raw_at : null,
+    source: typeof usage.source === 'string' ? usage.source : null,
+  };
+}
+
+function sampleTotal(sample: ProxyHealthSample) {
+  if (!isFiniteNumber(sample.rxBytes) || !isFiniteNumber(sample.txBytes))
+    return null;
+  return sample.rxBytes + sample.txBytes;
+}
+
+function trafficSince(samples: ProxyHealthSample[], windowMs: number) {
+  const counters = samples
+    .map(sample => ({
+      checkedAt: new Date(sample.checkedAt),
+      total: sampleTotal(sample),
+    }))
+    .filter(
+      (sample): sample is { checkedAt: Date; total: number } =>
+        isFiniteNumber(sample.total) && !Number.isNaN(sample.checkedAt.getTime())
+    )
+    .sort((left, right) => left.checkedAt.getTime() - right.checkedAt.getTime());
+
+  const latest = counters.at(-1)?.checkedAt;
+  if (!latest) return 0;
+  const cutoff = latest.getTime() - windowMs;
+  let total = 0;
+
+  for (let index = 1; index < counters.length; index += 1) {
+    const previous = counters[index - 1];
+    const current = counters[index];
+    if (current.checkedAt.getTime() < cutoff) continue;
+    total +=
+      current.total >= previous.total
+        ? current.total - previous.total
+        : current.total;
+  }
+
+  return total;
+}
+
+function serviceState(status: StoredProxyHealth, service: string) {
+  const value = status.payload.services?.[service];
+  return typeof value === 'string' ? value : 'unknown';
+}
+
+function UsageRing({ percent }: { percent: number | null }) {
+  const value = Math.min(100, Math.max(0, percent ?? 0));
+  const radius = 44;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - value / 100);
+
+  return (
+    <div className="relative h-28 w-28 shrink-0 sm:h-32 sm:w-32">
+      <svg
+        className="h-full w-full -rotate-90"
+        viewBox="0 0 120 120"
+        role="img"
+        aria-label="Lightsail transfer usage progress"
+      >
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-muted"
+          strokeWidth="8"
+        />
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          className="stroke-[#8d8af1]"
+          strokeWidth="8"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-xl font-semibold tracking-tight">
+          {formatPercent(percent)}
+        </span>
+        <span className="font-mono text-[8px] uppercase tracking-[0.14em] text-muted-foreground">
+          used
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, detail }: { label: string; value: string; detail: string }) {
+  return (
+    <div className="px-4 py-4">
+      <div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-2 text-xl font-semibold tracking-tight">{value}</div>
+      <div className="mt-1 text-xs leading-5 text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+export function LightsailUsageCard({
+  status,
+  samples,
+}: {
+  status: StoredProxyHealth;
+  samples: ProxyHealthSample[];
+}) {
+  const usage = readUsage(status);
+  if (!usage) return null;
+
+  const used = usage.usedBytes;
+  const limit = usage.limitBytes;
+  const percent =
+    isFiniteNumber(used) && isFiniteNumber(limit) && limit > 0
+      ? (used / limit) * 100
+      : null;
+  const remaining =
+    isFiniteNumber(used) && isFiniteNumber(limit)
+      ? Math.max(0, limit - used)
+      : null;
+  const resetTime = usage.resetAt ? Date.parse(usage.resetAt) : Number.NaN;
+  const daysLeft = Number.isFinite(resetTime)
+    ? Math.max(1, Math.ceil((resetTime - Date.now()) / DAY_MS))
+    : null;
+  const dailyRoom =
+    isFiniteNumber(remaining) && isFiniteNumber(daysLeft)
+      ? remaining / daysLeft
+      : null;
+  const traffic24h = trafficSince(samples, DAY_MS);
+  const xray = serviceState(status, 'xray');
+  const hysteria = serviceState(status, 'hysteria-server');
+  const errors = Array.isArray(status.payload.errors)
+    ? status.payload.errors.filter(error => typeof error === 'string')
+    : [];
+  const healthy = xray === 'active' && hysteria === 'active' && errors.length === 0;
+  const checkedAt = usage.lastRawAt ?? status.updatedAt;
+
+  return (
+    <section className="overflow-hidden rounded-[1.5rem] border border-border/70 bg-background/78">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/60 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-foreground">
+            Lightsail Oregon
+          </span>
+          <span
+            className={`rounded-full border px-2 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-[0.12em] ${healthy ? 'border-[#8d8af1]/50 bg-[#8d8af1]/12' : 'border-amber-400/50 bg-amber-400/12'}`}
+          >
+            {healthy ? 'Online' : 'Check services'}
+          </span>
+        </div>
+        <div className="font-mono text-[9px] uppercase tracking-[0.1em] text-muted-foreground">
+          checked{' '}
+          <span className="font-semibold text-foreground">
+            {formatRelativeTime(checkedAt)}
+          </span>
+        </div>
+      </div>
+
+      <div className="grid lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <div className="relative flex min-h-48 items-center gap-4 overflow-hidden border-b border-border/60 bg-[radial-gradient(circle_at_18%_25%,rgba(141,138,241,0.16),transparent_52%)] p-4 lg:border-b-0 lg:border-r sm:p-6">
+          <UsageRing percent={percent} />
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Current cycle
+            </div>
+            <div className="mt-2 text-xl font-semibold tracking-[-0.025em] sm:text-3xl">
+              {formatBytes(used)} / {formatBytes(limit)}
+            </div>
+            <div className="mt-1.5 text-xs text-muted-foreground">
+              Reset · {formatDate(usage.resetAt)} · us-west-2
+            </div>
+            <div className="mt-3 font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground">
+              {usage.source === 'lightsail-local-counter'
+                ? 'local interface counter'
+                : usage.source ?? 'usage source unavailable'}
+            </div>
+          </div>
+        </div>
+
+        <div className="grid sm:grid-cols-2 xl:grid-cols-4">
+          <div className="border-b border-border/60 sm:border-r xl:border-b-0">
+            <Stat
+              label="Remaining"
+              value={formatBytes(remaining)}
+              detail="of this month's allowance"
+            />
+          </div>
+          <div className="border-b border-border/60 xl:border-b-0 xl:border-r">
+            <Stat
+              label="24h traffic"
+              value={formatBytes(traffic24h)}
+              detail="ingress + egress observed"
+            />
+          </div>
+          <div className="border-b border-border/60 sm:border-b-0 sm:border-r">
+            <Stat
+              label="Daily room"
+              value={formatBytes(dailyRoom)}
+              detail={daysLeft ? `${daysLeft}d until reset` : 'reset unavailable'}
+            />
+          </div>
+          <div>
+            <Stat
+              label="Services"
+              value={`${xray === 'active' ? 'Xray ✓' : 'Xray ?'} · ${hysteria === 'active' ? 'HY2 ✓' : 'HY2 ?'}`}
+              detail={errors.length > 0 ? `${errors.length} reporter warning${errors.length === 1 ? '' : 's'}` : 'TCP + UDP endpoints'}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/proxy/usage-dashboard-container.tsx
+++ b/components/proxy/usage-dashboard-container.tsx
@@ -1,12 +1,23 @@
-import type { ProxyHealthPayload, ProxyHealthSample } from '@/app/lib/proxy-health-store';
+import type {
+  ProxyHealthPayload,
+  ProxyHealthReadResult,
+  ProxyHealthSample,
+} from '@/app/lib/proxy-health-store';
 import { readProxyHealth } from '@/app/lib/proxy-health-store';
 import { unstable_cache } from 'next/cache';
+import { LightsailUsageCard } from './lightsail-usage-card';
 import { UsageDashboard } from './usage-dashboard';
 
 const readCachedProxyHealth = unstable_cache(
   () => readProxyHealth('bandwagon-la', 35),
   ['proxy-dashboard-bandwagon-la-v2'],
-  { revalidate: 60 },
+  { revalidate: 60 }
+);
+
+const readCachedLightsailHealth = unstable_cache(
+  () => readProxyHealth('lightsail-oregon', 35),
+  ['proxy-dashboard-lightsail-oregon-v1'],
+  { revalidate: 60 }
 );
 
 function usageLimitBytes() {
@@ -19,7 +30,9 @@ function numberOrNull(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
-function latestStatusSample(payload: ProxyHealthPayload): ProxyHealthSample | null {
+function latestStatusSample(
+  payload: ProxyHealthPayload
+): ProxyHealthSample | null {
   const checkedAt = payload.checked_at;
   if (typeof checkedAt !== 'string') return null;
 
@@ -35,20 +48,43 @@ function latestStatusSample(payload: ProxyHealthPayload): ProxyHealthSample | nu
   };
 }
 
-function StateCard({ title, body, requestId }: { title: string; body: string; requestId?: string }) {
+function visibleSamples(result: Extract<ProxyHealthReadResult, { status: 'ok' }>) {
+  const fallbackSample = latestStatusSample(result.report.payload);
+  return result.samples.length > 0 || !fallbackSample
+    ? result.samples
+    : [fallbackSample];
+}
+
+function StateCard({
+  title,
+  body,
+  requestId,
+}: {
+  title: string;
+  body: string;
+  requestId?: string;
+}) {
   return (
-    <section className="rounded-2xl border bg-background p-5 shadow-sm" role="status">
+    <section
+      className="rounded-2xl border bg-background p-5 shadow-sm"
+      role="status"
+    >
       <h2 className="text-xl font-bold">{title}</h2>
       <p className="mt-2 text-sm text-muted-foreground">{body}</p>
       {requestId ? (
-        <p className="mt-3 font-mono text-xs text-muted-foreground">Request {requestId}</p>
+        <p className="mt-3 font-mono text-xs text-muted-foreground">
+          Request {requestId}
+        </p>
       ) : null}
     </section>
   );
 }
 
 export async function UsageDashboardContainer() {
-  const result = await readCachedProxyHealth();
+  const [result, lightsailResult] = await Promise.all([
+    readCachedProxyHealth(),
+    readCachedLightsailHealth(),
+  ]);
 
   if (result.status === 'configuration-error') {
     return (
@@ -62,7 +98,11 @@ export async function UsageDashboardContainer() {
 
   if (result.status === 'error') {
     return (
-      <StateCard title="Proxy data unavailable" body={result.message} requestId={result.requestId} />
+      <StateCard
+        title="Proxy data unavailable"
+        body={result.message}
+        requestId={result.requestId}
+      />
     );
   }
 
@@ -75,9 +115,23 @@ export async function UsageDashboardContainer() {
     );
   }
 
-  const { report, samples } = result;
-  const fallbackSample = latestStatusSample(report.payload);
-  const visibleSamples = samples.length > 0 || !fallbackSample ? samples : [fallbackSample];
+  const bandwagonSamples = visibleSamples(result);
+  const lightsailCard =
+    lightsailResult.status === 'ok' ? (
+      <LightsailUsageCard
+        status={lightsailResult.report}
+        samples={visibleSamples(lightsailResult)}
+      />
+    ) : null;
 
-  return <UsageDashboard samples={visibleSamples} status={report} limitBytes={usageLimitBytes()} />;
+  return (
+    <div className="grid gap-3">
+      <UsageDashboard
+        samples={bandwagonSamples}
+        status={result.report}
+        limitBytes={usageLimitBytes()}
+      />
+      {lightsailCard}
+    </div>
+  );
 }

--- a/docs/lightsail-usage-dashboard.md
+++ b/docs/lightsail-usage-dashboard.md
@@ -1,0 +1,93 @@
+# Lightsail usage reporter
+
+The proxy dashboard can show the Oregon Lightsail instance alongside the existing Bandwagon provider data.
+
+The Lightsail reporter reads the primary Linux interface counters and posts them through the existing proxy-health ingest endpoint. Lightsail counts both incoming and outgoing instance transfer toward the monthly allowance, so `rx + tx` is a useful operational estimate. The local counter begins when the reporter is installed unless `LIGHTSAIL_USAGE_SEED_GB` is supplied.
+
+## Install on Oregon
+
+Copy the reporter from a local clone:
+
+```bash
+scp scripts/lightsail-health-report.py oregon:/tmp/lightsail-health-report.py
+ssh oregon 'sudo install -m 755 /tmp/lightsail-health-report.py /usr/local/sbin/lightsail-health-report'
+```
+
+Create `/etc/lightsail-health.env` with the existing dashboard ingest secret:
+
+```bash
+sudo tee /etc/lightsail-health.env >/dev/null <<'EOF'
+PROXY_HEALTH_INGEST_URL=https://teamleaderleo.com/api/proxy-health/ingest
+PROXY_HEALTH_TOKEN=replace-with-the-existing-ingest-secret
+PROXY_HEALTH_HOST=lightsail-oregon
+LIGHTSAIL_INTERFACE=ens5
+LIGHTSAIL_TRANSFER_LIMIT_GB=3072
+LIGHTSAIL_USAGE_SEED_GB=0
+EOF
+sudo chmod 600 /etc/lightsail-health.env
+```
+
+The `$12` Oregon bundle has a 3072 GB monthly transfer allowance. If you have an existing month-to-date transfer estimate when installing the reporter, put that value in `LIGHTSAIL_USAGE_SEED_GB`. The seed is used only when a new UTC calendar month starts or when the local state file is first created.
+
+Create the service:
+
+```bash
+sudo tee /etc/systemd/system/lightsail-health-report.service >/dev/null <<'EOF'
+[Unit]
+Description=Report Lightsail proxy usage to scrapbook
+After=network-online.target xray.service hysteria-server.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/lightsail-health.env
+ExecStart=/usr/local/sbin/lightsail-health-report
+EOF
+```
+
+Create the timer:
+
+```bash
+sudo tee /etc/systemd/system/lightsail-health-report.timer >/dev/null <<'EOF'
+[Unit]
+Description=Run Lightsail proxy usage reporter every 5 minutes
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+```
+
+Enable it and send the first sample:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now lightsail-health-report.timer
+sudo systemctl start lightsail-health-report.service
+sudo journalctl -u lightsail-health-report.service -n 30 --no-pager
+```
+
+A successful report looks like:
+
+```json
+{ "ok": true, "host": "lightsail-oregon", "checked_at": "...", "request_id": "..." }
+```
+
+The dashboard caches each host for 60 seconds, so the Lightsail card can take about a minute to appear after the first successful report.
+
+## Counter behavior
+
+The reporter stores its monthly running total in:
+
+```text
+/var/lib/proxy-health/lightsail-usage.json
+```
+
+It handles Linux interface-counter resets after a reboot by treating the new counter value as traffic observed since the reset. At the first sample of a new UTC calendar month, it starts a new cycle and applies `LIGHTSAIL_USAGE_SEED_GB` if configured.
+
+The resulting number is an operational estimate from the instance interface. AWS billing remains authoritative for chargeable transfer and may differ slightly from the local counter.

--- a/docs/lightsail-usage-dashboard.md
+++ b/docs/lightsail-usage-dashboard.md
@@ -27,7 +27,7 @@ EOF
 sudo chmod 600 /etc/lightsail-health.env
 ```
 
-The `$12` Oregon bundle has a 3072 GB monthly transfer allowance. If you have an existing month-to-date transfer estimate when installing the reporter, put that value in `LIGHTSAIL_USAGE_SEED_GB`. The seed is used only when a new UTC calendar month starts or when the local state file is first created.
+The `$12` Oregon bundle has a 3072 GB monthly transfer allowance. If you have an existing month-to-date transfer estimate when installing the reporter, put that value in `LIGHTSAIL_USAGE_SEED_GB`. The seed is applied only when the local state file is first created; later UTC calendar-month resets start at zero automatically.
 
 Create the service:
 
@@ -88,6 +88,6 @@ The reporter stores its monthly running total in:
 /var/lib/proxy-health/lightsail-usage.json
 ```
 
-It handles Linux interface-counter resets after a reboot by treating the new counter value as traffic observed since the reset. At the first sample of a new UTC calendar month, it starts a new cycle and applies `LIGHTSAIL_USAGE_SEED_GB` if configured.
+It handles Linux interface-counter resets after a reboot by treating the new counter value as traffic observed since the reset. At the first sample of each new UTC calendar month, it starts a fresh zero-based cycle.
 
 The resulting number is an operational estimate from the instance interface. AWS billing remains authoritative for chargeable transfer and may differ slightly from the local counter.

--- a/scripts/lightsail-health-report.py
+++ b/scripts/lightsail-health-report.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Report Lightsail proxy traffic and service health to the scrapbook dashboard.
+
+Required environment variables:
+  PROXY_HEALTH_INGEST_URL=https://teamleaderleo.com/api/proxy-health/ingest
+  PROXY_HEALTH_TOKEN=...
+
+Optional:
+  PROXY_HEALTH_HOST=lightsail-oregon
+  LIGHTSAIL_INTERFACE=ens5
+  LIGHTSAIL_TRANSFER_LIMIT_GB=3072
+  LIGHTSAIL_USAGE_SEED_GB=0
+  LIGHTSAIL_STATE_FILE=/var/lib/proxy-health/lightsail-usage.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HOST = os.environ.get("PROXY_HEALTH_HOST", "lightsail-oregon")
+INGEST_URL = os.environ.get("PROXY_HEALTH_INGEST_URL")
+TOKEN = os.environ.get("PROXY_HEALTH_TOKEN")
+INTERFACE = os.environ.get("LIGHTSAIL_INTERFACE", "ens5")
+TRANSFER_LIMIT_GB = float(os.environ.get("LIGHTSAIL_TRANSFER_LIMIT_GB", "3072"))
+USAGE_SEED_GB = float(os.environ.get("LIGHTSAIL_USAGE_SEED_GB", "0"))
+STATE_FILE = Path(
+    os.environ.get(
+        "LIGHTSAIL_STATE_FILE", "/var/lib/proxy-health/lightsail-usage.json"
+    )
+)
+
+
+def now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def month_key(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m")
+
+
+def next_month(value: datetime) -> datetime:
+    value = value.astimezone(timezone.utc)
+    if value.month == 12:
+        return datetime(value.year + 1, 1, 1, tzinfo=timezone.utc)
+    return datetime(value.year, value.month + 1, 1, tzinfo=timezone.utc)
+
+
+def as_nonnegative_int(value: Any, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, number)
+
+
+def read_counter(name: str) -> int:
+    path = Path("/sys/class/net") / INTERFACE / "statistics" / name
+    return as_nonnegative_int(path.read_text().strip())
+
+
+def read_state() -> dict[str, Any]:
+    try:
+        value = json.loads(STATE_FILE.read_text())
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def write_state(value: dict[str, Any]) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    temporary = STATE_FILE.with_suffix(".tmp")
+    temporary.write_text(json.dumps(value, separators=(",", ":")))
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, STATE_FILE)
+
+
+def current_usage(rx_bytes: int, tx_bytes: int, checked_at: datetime) -> int:
+    state = read_state()
+    current_month = month_key(checked_at)
+    seed = max(0, int(USAGE_SEED_GB * 1024**3))
+
+    if state.get("month") != current_month:
+        used_bytes = seed
+    else:
+        used_bytes = as_nonnegative_int(state.get("used_bytes"), seed)
+        last_rx = as_nonnegative_int(state.get("last_rx"), rx_bytes)
+        last_tx = as_nonnegative_int(state.get("last_tx"), tx_bytes)
+
+        # Interface counters reset after a reboot. In that case, the current
+        # counter value is traffic observed since the reset, so keep it.
+        rx_delta = rx_bytes - last_rx if rx_bytes >= last_rx else rx_bytes
+        tx_delta = tx_bytes - last_tx if tx_bytes >= last_tx else tx_bytes
+        used_bytes += max(0, rx_delta) + max(0, tx_delta)
+
+    write_state(
+        {
+            "month": current_month,
+            "last_rx": rx_bytes,
+            "last_tx": tx_bytes,
+            "used_bytes": used_bytes,
+            "checked_at": iso(checked_at),
+        }
+    )
+    return used_bytes
+
+
+def service_status(name: str) -> str:
+    try:
+        completed = subprocess.run(
+            ["systemctl", "is-active", name],
+            timeout=5,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except Exception:
+        return "unknown"
+
+    output = (completed.stdout or completed.stderr).strip()
+    if output:
+        return output[:128]
+    return "active" if completed.returncode == 0 else "unknown"
+
+
+def build_payload() -> dict[str, Any]:
+    checked_at = now()
+    errors: list[str] = []
+
+    try:
+        rx_bytes = read_counter("rx_bytes")
+        tx_bytes = read_counter("tx_bytes")
+    except Exception as exc:  # noqa: BLE001 - reporter errors are dashboard data
+        rx_bytes = 0
+        tx_bytes = 0
+        errors.append(f"interface counter read failed: {exc}")
+
+    used_bytes = current_usage(rx_bytes, tx_bytes, checked_at)
+    limit_bytes = max(0, int(TRANSFER_LIMIT_GB * 1024**3))
+    services = {
+        "xray": service_status("xray"),
+        "hysteria-server": service_status("hysteria-server"),
+    }
+    mode = (
+        "normal"
+        if services["xray"] == "active" and services["hysteria-server"] == "active"
+        else "degraded"
+    )
+
+    return {
+        "host": HOST,
+        "checked_at": iso(checked_at),
+        "mode": mode,
+        "services": services,
+        "provider": {
+            "usage": {
+                "source": "lightsail-local-counter",
+                "used_bytes": used_bytes,
+                "limit_bytes": limit_bytes,
+                "reset_at": iso(next_month(checked_at)),
+                "suspended": False,
+                "policy_violation": False,
+                "last_raw_at": iso(checked_at),
+            }
+        },
+        # The existing dashboard sample table stores these two counters. For
+        # Lightsail they represent the primary interface, rather than WireGuard.
+        "wireguard": {
+            "rx_bytes": rx_bytes,
+            "tx_bytes": tx_bytes,
+        },
+        "errors": errors,
+    }
+
+
+def post_payload(payload: dict[str, Any]) -> None:
+    if not INGEST_URL:
+        raise SystemExit("PROXY_HEALTH_INGEST_URL is not set")
+    if not TOKEN:
+        raise SystemExit("PROXY_HEALTH_TOKEN is not set")
+
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        INGEST_URL,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Content-Type": "application/json",
+            "User-Agent": "lightsail-proxy-health/1.0",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            sys.stdout.write(response.read().decode("utf-8") + "\n")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"POST failed: HTTP {exc.code}: {body}") from exc
+
+
+def main() -> None:
+    post_payload(build_payload())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lightsail-health-report.py
+++ b/scripts/lightsail-health-report.py
@@ -141,16 +141,18 @@ def service_status(name: str) -> str:
 def build_payload() -> dict[str, Any]:
     checked_at = now()
     errors: list[str] = []
+    state = read_state()
 
     try:
         rx_bytes = read_counter("rx_bytes")
         tx_bytes = read_counter("tx_bytes")
+        used_bytes = current_usage(rx_bytes, tx_bytes, checked_at)
     except Exception as exc:  # noqa: BLE001 - reporter errors are dashboard data
-        rx_bytes = 0
-        tx_bytes = 0
+        rx_bytes = as_nonnegative_int(state.get("last_rx"))
+        tx_bytes = as_nonnegative_int(state.get("last_tx"))
+        used_bytes = as_nonnegative_int(state.get("used_bytes"))
         errors.append(f"interface counter read failed: {exc}")
 
-    used_bytes = current_usage(rx_bytes, tx_bytes, checked_at)
     limit_bytes = max(0, int(TRANSFER_LIMIT_GB * 1024**3))
     services = {
         "xray": service_status("xray"),

--- a/scripts/lightsail-health-report.py
+++ b/scripts/lightsail-health-report.py
@@ -91,7 +91,8 @@ def write_state(value: dict[str, Any]) -> None:
 def current_usage(rx_bytes: int, tx_bytes: int, checked_at: datetime) -> int:
     state = read_state()
     current_month = month_key(checked_at)
-    seed = max(0, int(USAGE_SEED_GB * 1024**3))
+    first_sample = not state
+    seed = max(0, int(USAGE_SEED_GB * 1024**3)) if first_sample else 0
 
     if state.get("month") != current_month:
         used_bytes = seed


### PR DESCRIPTION
Adds a Lightsail Oregon usage card to the existing proxy dashboard and a lightweight reporter for the Oregon instance.

The card shows current-cycle transfer usage against the 3 TB allowance, remaining transfer, 24h observed traffic, daily room until the next UTC month reset, and Xray/Hysteria service state.

The reporter uses the instance's primary interface RX+TX counters and posts through the existing proxy-health ingest endpoint, so no AWS credentials are required on the website. The local counter starts when the reporter is installed (or from an optional seed) and is intended as a close operational estimate of Lightsail transfer usage.