### PR TITLE
Tune homepage activity and navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -195,15 +195,6 @@ function HomeActivitySkeleton() {
           </div>
         </section>
 
-        <section className="min-h-[24rem] rounded-[1.25rem] border border-border/70 bg-card p-5 shadow-[0_16px_38px_rgba(24,24,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] lg:col-start-2 lg:row-span-2 lg:row-start-1">
-          <Skeleton className="h-3 w-24" />
-          <Skeleton className="mt-8 h-16 w-3/5 rounded-xl" />
-          <div className="mt-6 grid grid-cols-2 gap-2">
-            <Skeleton className="h-14 rounded-xl" />
-            <Skeleton className="h-14 rounded-xl" />
-          </div>
-        </section>
-
         <section className="min-h-[13rem] rounded-[1.1rem] border border-border/70 bg-card p-4 shadow-[0_10px_24px_rgba(35,31,26,0.07)] dark:shadow-[0_12px_28px_rgba(0,0,0,0.22)] lg:col-start-1 lg:row-start-2">
           <div className="flex items-center justify-between gap-3">
             <Skeleton className="h-2.5 w-24" />
@@ -211,6 +202,15 @@ function HomeActivitySkeleton() {
           </div>
           <Skeleton className="mx-auto mt-4 h-24 w-36 rounded-2xl" />
           <Skeleton className="mt-3 h-3 w-2/3" />
+        </section>
+
+        <section className="min-h-[24rem] rounded-[1.25rem] border border-border/70 bg-card p-5 shadow-[0_16px_38px_rgba(24,24,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] lg:col-start-2 lg:row-span-2 lg:row-start-1">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="mt-8 h-16 w-3/5 rounded-xl" />
+          <div className="mt-6 grid grid-cols-2 gap-2">
+            <Skeleton className="h-14 rounded-xl" />
+            <Skeleton className="h-14 rounded-xl" />
+          </div>
         </section>
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,11 +8,11 @@ import { homeRoomNavigationItems } from '@/lib/site-navigation';
 import {
   ArrowRight,
   ArrowUpRight,
-  Brain,
   Compass,
   Hammer,
   Images,
   NotebookPen,
+  Orbit,
   Palette,
   Snowflake,
   type LucideIcon,
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
 };
 
 const homeRoomIcons: Record<string, LucideIcon> = {
-  space: Brain,
+  space: Orbit,
   work: Hammer,
   gallery: Images,
   journal: NotebookPen,
@@ -179,13 +179,8 @@ function HomeActivitySkeleton() {
       role="status"
       data-home-activity-skeleton
     >
-      <div className="grid min-w-0 gap-3.5 sm:gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(21rem,0.65fr)]">
-        <section className="min-h-[30.5rem] rounded-[1.25rem] border border-border/70 bg-card p-5 shadow-[0_16px_38px_rgba(24,24,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] lg:min-h-[28rem]">
-          <Skeleton className="h-3 w-24" />
-          <Skeleton className="mt-5 h-16 w-3/5 rounded-xl" />
-          <Skeleton className="mt-4 h-28 w-full rounded-2xl" />
-        </section>
-        <section className="min-h-[27.25rem] rounded-[1.25rem] border border-border/70 bg-card p-4 shadow-[0_12px_28px_rgba(35,31,26,0.08)] dark:shadow-[0_14px_32px_rgba(0,0,0,0.25)]">
+      <div className="grid min-w-0 gap-3.5 sm:gap-4 lg:grid-cols-[minmax(21rem,0.65fr)_minmax(0,1.35fr)] lg:grid-rows-[auto_auto]">
+        <section className="min-h-[18rem] rounded-[1.25rem] border border-border/70 bg-card p-4 shadow-[0_12px_28px_rgba(35,31,26,0.08)] dark:shadow-[0_14px_32px_rgba(0,0,0,0.25)] lg:col-start-1 lg:row-start-1">
           <div className="flex items-center justify-between gap-4">
             <Skeleton className="h-2.5 w-20" />
             <Skeleton className="h-2.5 w-28" />
@@ -198,6 +193,24 @@ function HomeActivitySkeleton() {
               />
             ))}
           </div>
+        </section>
+
+        <section className="min-h-[24rem] rounded-[1.25rem] border border-border/70 bg-card p-5 shadow-[0_16px_38px_rgba(24,24,26,0.08)] dark:shadow-[0_16px_38px_rgba(0,0,0,0.28)] lg:col-start-2 lg:row-span-2 lg:row-start-1">
+          <Skeleton className="h-3 w-24" />
+          <Skeleton className="mt-8 h-16 w-3/5 rounded-xl" />
+          <div className="mt-6 grid grid-cols-2 gap-2">
+            <Skeleton className="h-14 rounded-xl" />
+            <Skeleton className="h-14 rounded-xl" />
+          </div>
+        </section>
+
+        <section className="min-h-[13rem] rounded-[1.1rem] border border-border/70 bg-card p-4 shadow-[0_10px_24px_rgba(35,31,26,0.07)] dark:shadow-[0_12px_28px_rgba(0,0,0,0.22)] lg:col-start-1 lg:row-start-2">
+          <div className="flex items-center justify-between gap-3">
+            <Skeleton className="h-2.5 w-24" />
+            <Skeleton className="h-2.5 w-16" />
+          </div>
+          <Skeleton className="mx-auto mt-4 h-24 w-36 rounded-2xl" />
+          <Skeleton className="mt-3 h-3 w-2/3" />
         </section>
       </div>
 
@@ -243,15 +256,12 @@ export default function Page() {
         <div className="flex min-w-0 flex-col gap-4 sm:gap-5">
           <section aria-labelledby="home-activity-title" className="min-w-0">
             <div className="mb-3 px-0.5">
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+              <p
+                id="home-activity-title"
+                className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+              >
                 Activity
               </p>
-              <h2
-                id="home-activity-title"
-                className="mt-1 text-xl font-black tracking-tight"
-              >
-                GitHub, still here
-              </h2>
             </div>
             <Suspense fallback={<HomeActivitySkeleton />}>
               <HomeActivityContent />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,7 +220,7 @@ function HomeActivitySkeleton() {
           <Skeleton className="h-3 w-10" />
         </div>
         <div className="grid overflow-hidden rounded-xl border border-border/65 bg-card/70 sm:grid-cols-2">
-          {Array.from({ length: 4 }, (_, index) => (
+          {Array.from({ length: 2 }, (_, index) => (
             <div
               key={index}
               className="flex min-h-16 items-center gap-3 border-border/55 px-3 py-2.5 [&:nth-child(n+2)]:border-t sm:[&:nth-child(2)]:border-t-0 sm:[&:nth-child(even)]:border-l"

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -230,28 +230,28 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
         <UnavailableActivity />
       ) : (
         <>
-          <ActivityGrid
-            className="lg:col-start-1 lg:row-start-1"
-            days={activity.days}
-            unit={activity.unit}
-            generatedAt={activity.generatedAt}
-            selectedDate={resolvedSelectedDate}
-            onSelectedDateChange={setSelectedDate}
-            onPreviewDateChange={setPreviewDate}
-          />
-          <ActivityScoreboard
-            className="lg:col-start-2 lg:row-span-2 lg:row-start-1"
-            score={displayDay.count}
-            scoreDate={displayDay.date}
-            scoreLabel={formatScoreDate(displayDay.date, displayIsToday)}
-            weekTotal={activity.weekTotal}
-            yearTotal={activity.yearTotal}
-          />
-          <ScrapbookPet
-            className="lg:col-start-1 lg:row-start-2"
-            activity={activity.today}
-            updating={updating}
-          />
+          <div className="min-w-0 lg:col-start-1 lg:row-start-1">
+            <ActivityGrid
+              days={activity.days}
+              unit={activity.unit}
+              generatedAt={activity.generatedAt}
+              selectedDate={resolvedSelectedDate}
+              onSelectedDateChange={setSelectedDate}
+              onPreviewDateChange={setPreviewDate}
+            />
+          </div>
+          <div className="min-w-0 lg:col-start-2 lg:row-span-2 lg:row-start-1">
+            <ActivityScoreboard
+              score={displayDay.count}
+              scoreDate={displayDay.date}
+              scoreLabel={formatScoreDate(displayDay.date, displayIsToday)}
+              weekTotal={activity.weekTotal}
+              yearTotal={activity.yearTotal}
+            />
+          </div>
+          <div className="min-w-0 lg:col-start-1 lg:row-start-2">
+            <ScrapbookPet activity={activity.today} updating={updating} />
+          </div>
         </>
       )}
     </div>

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -5,6 +5,7 @@ import {
   type ActivityGridDay,
 } from '@/components/home/activity-grid';
 import { ActivityScoreboard } from '@/components/home/activity-scoreboard';
+import { ScrapbookPet } from '@/components/home/scrapbook-pet';
 import { GITHUB_ACTIVITY_CLIENT_REFRESH_SECONDS } from '@/lib/github-activity-policy';
 import { useEffect, useRef, useState } from 'react';
 
@@ -217,7 +218,7 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
 
   return (
     <div
-      className="relative grid min-w-0 items-stretch gap-3.5 sm:gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(21rem,0.65fr)]"
+      className="relative grid min-w-0 items-stretch gap-3.5 sm:gap-4 lg:grid-cols-[minmax(21rem,0.65fr)_minmax(0,1.35fr)] lg:grid-rows-[auto_auto]"
       data-home-activity-dashboard
       data-home-activity-source={activity.source}
     >
@@ -229,22 +230,27 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
         <UnavailableActivity />
       ) : (
         <>
-          <ActivityScoreboard
-            score={displayDay.count}
-            scoreDate={displayDay.date}
-            scoreLabel={formatScoreDate(displayDay.date, displayIsToday)}
-            todayActivity={activity.today}
-            weekTotal={activity.weekTotal}
-            yearTotal={activity.yearTotal}
-            updating={updating}
-          />
           <ActivityGrid
+            className="lg:col-start-1 lg:row-start-1"
             days={activity.days}
             unit={activity.unit}
             generatedAt={activity.generatedAt}
             selectedDate={resolvedSelectedDate}
             onSelectedDateChange={setSelectedDate}
             onPreviewDateChange={setPreviewDate}
+          />
+          <ActivityScoreboard
+            className="lg:col-start-2 lg:row-span-2 lg:row-start-1"
+            score={displayDay.count}
+            scoreDate={displayDay.date}
+            scoreLabel={formatScoreDate(displayDay.date, displayIsToday)}
+            weekTotal={activity.weekTotal}
+            yearTotal={activity.yearTotal}
+          />
+          <ScrapbookPet
+            className="lg:col-start-1 lg:row-start-2"
+            activity={activity.today}
+            updating={updating}
           />
         </>
       )}

--- a/components/home/activity-dashboard.tsx
+++ b/components/home/activity-dashboard.tsx
@@ -240,6 +240,9 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
               onPreviewDateChange={setPreviewDate}
             />
           </div>
+          <div className="min-w-0 lg:col-start-1 lg:row-start-2">
+            <ScrapbookPet activity={activity.today} updating={updating} />
+          </div>
           <div className="min-w-0 lg:col-start-2 lg:row-span-2 lg:row-start-1">
             <ActivityScoreboard
               score={displayDay.count}
@@ -248,9 +251,6 @@ export function ActivityDashboard({ initial }: { initial: ActivitySnapshot }) {
               weekTotal={activity.weekTotal}
               yearTotal={activity.yearTotal}
             />
-          </div>
-          <div className="min-w-0 lg:col-start-1 lg:row-start-2">
-            <ScrapbookPet activity={activity.today} updating={updating} />
           </div>
         </>
       )}

--- a/components/home/activity-scoreboard.tsx
+++ b/components/home/activity-scoreboard.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { ScrapbookPet } from '@/components/home/scrapbook-pet';
 import { motion, useAnimate } from 'framer-motion';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './activity-scoreboard.module.css';
@@ -361,18 +360,14 @@ export function ActivityScoreboard({
   score,
   scoreDate,
   scoreLabel,
-  todayActivity,
   weekTotal,
   yearTotal,
-  updating,
 }: {
   score: number;
   scoreDate: string;
   scoreLabel: string;
-  todayActivity: number;
   weekTotal: number;
   yearTotal: number | null;
-  updating: boolean;
 }) {
   const reduceMotion = useReducedMotionPreference();
   const [countdown, setCountdown] = useState('--:--:--');
@@ -405,8 +400,8 @@ export function ActivityScoreboard({
         </div>
       </div>
 
-      <div className="relative z-10 grid flex-1 gap-4 p-4 sm:p-5 md:grid-cols-[minmax(0,1fr)_minmax(15rem,0.72fr)] md:items-stretch">
-        <div className="flex min-w-0 flex-col justify-center gap-4">
+      <div className="relative z-10 flex flex-1 items-center p-4 sm:p-5 md:p-7">
+        <div className="flex w-full min-w-0 flex-col justify-center gap-6">
           <div>
             <p className="mb-2 font-mono text-[9px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
               Activity on the desk
@@ -426,7 +421,6 @@ export function ActivityScoreboard({
             />
           </div>
         </div>
-        <ScrapbookPet activity={todayActivity} updating={updating} />
       </div>
     </section>
   );

--- a/components/home/home-now-shelf.tsx
+++ b/components/home/home-now-shelf.tsx
@@ -4,6 +4,36 @@ import { publicLearningRecords } from '@/lib/learning-records';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 
+const SWEAR_SPLIT_PATTERN = /(\bfuck(?:ing|ed|er|ers|s)?\b)/gi;
+const SWEAR_WORD_PATTERN = /^fuck(?:ing|ed|er|ers|s)?$/i;
+
+function SwearJarText({ text, enabled }: { text: string; enabled: boolean }) {
+  if (!enabled || !SWEAR_SPLIT_PATTERN.test(text)) return <>{text}</>;
+  SWEAR_SPLIT_PATTERN.lastIndex = 0;
+
+  return (
+    <span aria-label={text}>
+      {text.split(SWEAR_SPLIT_PATTERN).map((part, index) =>
+        SWEAR_WORD_PATTERN.test(part) ? (
+          <span
+            key={`${part}-${index}`}
+            aria-hidden="true"
+            data-swear-spoiler
+            title="swear jar · hover to reveal"
+            className="inline-block rounded-[0.28em] bg-foreground/10 px-[0.14em] text-transparent blur-[2.5px] [text-shadow:0_0_5px_hsl(var(--foreground)/0.48)] transition-[color,filter,text-shadow,background-color] duration-150 hover:bg-transparent hover:text-foreground hover:blur-none hover:[text-shadow:none] group-focus-visible:bg-transparent group-focus-visible:text-foreground group-focus-visible:blur-none group-focus-visible:[text-shadow:none] motion-reduce:transition-none"
+          >
+            {part}
+          </span>
+        ) : (
+          <span key={`${part}-${index}`} aria-hidden="true">
+            {part}
+          </span>
+        )
+      )}
+    </span>
+  );
+}
+
 function latestLearningRecord() {
   return [...publicLearningRecords].sort((left, right) => {
     const leftDate = left.revisions.at(-1)?.createdAt ?? '';
@@ -25,6 +55,7 @@ export function HomeNowShelf() {
           title: workbench.title,
           note: workbench.blurb,
           href: `/desk/${workbench.slug}`,
+          swearJar: true,
         }
       : null,
     learning
@@ -34,6 +65,7 @@ export function HomeNowShelf() {
           title: learning.title,
           note: learning.spark,
           href: learning.canonicalUrl,
+          swearJar: false,
         }
       : null,
     visit
@@ -43,6 +75,7 @@ export function HomeNowShelf() {
           title: visit.name,
           note: visit.note,
           href: `/gallery#visit-${visit.id}`,
+          swearJar: false,
         }
       : null,
   ].filter((item): item is NonNullable<typeof item> => Boolean(item));
@@ -74,10 +107,10 @@ export function HomeNowShelf() {
             <span className="flex min-w-0 items-end justify-between gap-3">
               <span className="min-w-0">
                 <span className="block line-clamp-1 text-sm font-semibold tracking-tight">
-                  {item.title}
+                  <SwearJarText text={item.title} enabled={item.swearJar} />
                 </span>
                 <span className="mt-1 block line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                  {item.note}
+                  <SwearJarText text={item.note} enabled={item.swearJar} />
                 </span>
               </span>
               <ArrowRight

--- a/components/home/home-now-shelf.tsx
+++ b/components/home/home-now-shelf.tsx
@@ -4,12 +4,12 @@ import { publicLearningRecords } from '@/lib/learning-records';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 
+const SWEAR_PATTERN = /\bfuck(?:ing|ed|er|ers|s)?\b/i;
 const SWEAR_SPLIT_PATTERN = /(\bfuck(?:ing|ed|er|ers|s)?\b)/gi;
 const SWEAR_WORD_PATTERN = /^fuck(?:ing|ed|er|ers|s)?$/i;
 
 function SwearJarText({ text, enabled }: { text: string; enabled: boolean }) {
-  if (!enabled || !SWEAR_SPLIT_PATTERN.test(text)) return <>{text}</>;
-  SWEAR_SPLIT_PATTERN.lastIndex = 0;
+  if (!enabled || !SWEAR_PATTERN.test(text)) return <>{text}</>;
 
   return (
     <span aria-label={text}>

--- a/components/home/scrapbook-pet.tsx
+++ b/components/home/scrapbook-pet.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { motion, useReducedMotion } from 'framer-motion';
-import { useState } from 'react';
 import { PaperCreature } from '@/components/paper-creature';
+import { motion, useReducedMotion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+
+const PET_COUNT_STORAGE_KEY = 'scrapbook:scraplet:pets:v1';
 
 const petMessages = [
   'Scraplet rustles happily.',
@@ -10,6 +12,17 @@ const petMessages = [
   'Scraplet does a tiny victory stomp.',
   'Scraplet saves you a seat at the workbench.',
 ] as const;
+
+function parsePetCount(value: string | null) {
+  if (!value) return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function petCountLabel(pets: number) {
+  if (pets === 0) return 'tap to pet';
+  return `${pets.toLocaleString('en-GB')} ${pets === 1 ? 'pet' : 'pets'} total`;
+}
 
 export function ScrapbookPet({
   activity,
@@ -27,16 +40,36 @@ export function ScrapbookPet({
       : petMessages[(pets - 1) % petMessages.length];
   const pose = updating ? 'sniffing' : activity > 0 ? 'idle' : 'napping';
 
+  useEffect(() => {
+    try {
+      setPets(parsePetCount(window.localStorage.getItem(PET_COUNT_STORAGE_KEY)));
+    } catch {
+      // Keep the in-memory counter when storage is unavailable.
+    }
+  }, []);
+
+  const petScraplet = () => {
+    setPets(count => {
+      const next = count + 1;
+      try {
+        window.localStorage.setItem(PET_COUNT_STORAGE_KEY, String(next));
+      } catch {
+        // The interaction still works for this visit when storage is unavailable.
+      }
+      return next;
+    });
+  };
+
   return (
     <motion.button
       type="button"
       data-scrapbook-pet
       data-pets={pets}
-      aria-label={`Pet Scraplet, the scrapbook dinosaur. Scraplet is ${status}.`}
+      aria-label={`Pet Scraplet, the scrapbook dinosaur. Scraplet is ${status}. ${pets} lifetime pets on this browser.`}
       title={`Pet Scraplet · ${status}`}
       whileTap={reduceMotion ? undefined : { scale: 0.96 }}
-      onClick={() => setPets(count => count + 1)}
-      className="group/pet relative flex min-h-56 w-full flex-col overflow-hidden rounded-[1.1rem] border border-border/70 bg-background/48 px-4 py-3 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.24)] transition-colors duration-150 hover:bg-background/68 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none sm:min-h-64"
+      onClick={petScraplet}
+      className="group/pet relative flex min-h-56 w-full flex-col overflow-hidden rounded-[1.1rem] border border-border/70 bg-background/48 px-4 py-3 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.24)] transition-colors duration-150 hover:bg-background/68 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring motion-reduce:transition-none sm:min-h-64 lg:min-h-56"
     >
       <span
         aria-hidden="true"
@@ -44,7 +77,7 @@ export function ScrapbookPet({
       />
       <span className="relative flex items-center justify-between gap-3 font-mono text-[8px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
         <span>Field companion</span>
-        <span>{pets === 0 ? 'tap to pet' : `${pets} pets`}</span>
+        <span>{petCountLabel(pets)}</span>
       </span>
 
       <span

--- a/components/home/scrapbook-pet.tsx
+++ b/components/home/scrapbook-pet.tsx
@@ -41,11 +41,17 @@ export function ScrapbookPet({
   const pose = updating ? 'sniffing' : activity > 0 ? 'idle' : 'napping';
 
   useEffect(() => {
+    let storedPets = 0;
     try {
-      setPets(parsePetCount(window.localStorage.getItem(PET_COUNT_STORAGE_KEY)));
+      storedPets = parsePetCount(
+        window.localStorage.getItem(PET_COUNT_STORAGE_KEY)
+      );
     } catch {
-      // Keep the in-memory counter when storage is unavailable.
+      return;
     }
+
+    const frame = window.requestAnimationFrame(() => setPets(storedPets));
+    return () => window.cancelAnimationFrame(frame);
   }, []);
 
   const petScraplet = () => {

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -69,18 +69,18 @@ export function ThemeToggle({
       <span
         data-theme-sun-spark
         aria-hidden="true"
-        className="absolute left-[7px] top-[8px] h-1 w-1 rotate-45 rounded-[1px] bg-amber-500/65 opacity-80 transition-opacity duration-500 motion-safe:animate-pulse dark:opacity-0 motion-reduce:animate-none"
+        className="absolute left-[7px] top-[8px] h-1 w-1 rotate-45 rounded-[1px] bg-amber-500/65 opacity-80 transition-opacity duration-500 motion-safe:animate-pulse dark:animate-none dark:opacity-0 motion-reduce:animate-none"
       />
       <span
         data-theme-sun-spark
         aria-hidden="true"
-        className="absolute right-[7px] top-[10px] h-0.5 w-0.5 rotate-45 rounded-[1px] bg-amber-400/75 opacity-70 transition-opacity duration-500 motion-safe:animate-pulse dark:opacity-0 motion-reduce:animate-none"
+        className="absolute right-[7px] top-[10px] h-0.5 w-0.5 rotate-45 rounded-[1px] bg-amber-400/75 opacity-70 transition-opacity duration-500 motion-safe:animate-pulse dark:animate-none dark:opacity-0 motion-reduce:animate-none"
         style={{ animationDelay: '600ms' }}
       />
       <span
         data-theme-sun-spark
         aria-hidden="true"
-        className="absolute bottom-[7px] left-[9px] h-0.5 w-0.5 rotate-45 rounded-[1px] bg-orange-400/70 opacity-65 transition-opacity duration-500 motion-safe:animate-pulse dark:opacity-0 motion-reduce:animate-none"
+        className="absolute bottom-[7px] left-[9px] h-0.5 w-0.5 rotate-45 rounded-[1px] bg-orange-400/70 opacity-65 transition-opacity duration-500 motion-safe:animate-pulse dark:animate-none dark:opacity-0 motion-reduce:animate-none"
         style={{ animationDelay: '1.15s' }}
       />
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useTheme } from 'next-themes';
 import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
 
 type ThemeTransitionDocument = Document & {
   startViewTransition?: (update: () => void) => { finished: Promise<unknown> };
@@ -52,6 +52,11 @@ export function ThemeToggle({
       type="button"
     >
       <span
+        data-theme-sun-glow
+        aria-hidden="true"
+        className="absolute h-7 w-7 rounded-full bg-amber-300/10 opacity-90 shadow-[0_0_10px_rgba(245,158,11,0.16)] transition-[opacity,transform] duration-500 dark:scale-50 dark:opacity-0"
+      />
+      <span
         data-theme-corona
         aria-hidden="true"
         className="absolute h-5 w-5 rounded-full border border-amber-400/45 opacity-75 transition-[opacity,transform] duration-500 motion-safe:animate-[spin_18s_linear_infinite] dark:scale-50 dark:opacity-0 motion-reduce:animate-none"
@@ -61,6 +66,23 @@ export function ThemeToggle({
         <span className="absolute left-1/2 -top-1 h-1 w-px bg-amber-500/55" />
         <span className="absolute bottom-[-0.25rem] left-1/2 h-1 w-px bg-amber-500/55" />
       </span>
+      <span
+        data-theme-sun-spark
+        aria-hidden="true"
+        className="absolute left-[7px] top-[8px] h-1 w-1 rotate-45 rounded-[1px] bg-amber-500/65 opacity-80 transition-opacity duration-500 motion-safe:animate-pulse dark:opacity-0 motion-reduce:animate-none"
+      />
+      <span
+        data-theme-sun-spark
+        aria-hidden="true"
+        className="absolute right-[7px] top-[10px] h-0.5 w-0.5 rotate-45 rounded-[1px] bg-amber-400/75 opacity-70 transition-opacity duration-500 motion-safe:animate-pulse dark:opacity-0 motion-reduce:animate-none"
+        style={{ animationDelay: '600ms' }}
+      />
+      <span
+        data-theme-sun-spark
+        aria-hidden="true"
+        className="absolute bottom-[7px] left-[9px] h-0.5 w-0.5 rotate-45 rounded-[1px] bg-orange-400/70 opacity-65 transition-opacity duration-500 motion-safe:animate-pulse dark:opacity-0 motion-reduce:animate-none"
+        style={{ animationDelay: '1.15s' }}
+      />
 
       <Sun
         data-theme-sun

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -178,7 +178,6 @@ function headerInteger(headers: Headers, name: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-export function parseGitHubRateLimit(headers: Headers, name?: never): GitHubRateLimit | null;
 export function parseGitHubRateLimit(headers: Headers): GitHubRateLimit | null {
   const limit = headerInteger(headers, 'x-ratelimit-limit');
   const remaining = headerInteger(headers, 'x-ratelimit-remaining');

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -19,24 +19,14 @@ import { createStaleWhileErrorCache } from './stale-while-error-cache';
 const GITHUB_USERNAME = 'teamleaderleo';
 const FEATURED_REPOSITORIES = [
   {
-    name: 'scrapbook',
-    url: 'https://github.com/teamleaderleo/scrapbook',
-    note: 'Personal site.',
+    name: 'preflight',
+    url: 'https://github.com/teamleaderleo/preflight',
+    note: 'Starsector launch performance.',
   },
   {
-    name: 'fieldwork',
-    url: 'https://github.com/teamleaderleo/fieldwork',
-    note: 'Codebase studies.',
-  },
-  {
-    name: 'linux-fieldwork',
-    url: 'https://github.com/teamleaderleo/linux-fieldwork',
-    note: 'Linux and kernel studies.',
-  },
-  {
-    name: 'smolrunner',
-    url: 'https://github.com/teamleaderleo/smolrunner',
-    note: 'Host-work runner.',
+    name: 'stensibly',
+    url: 'https://github.com/teamleaderleo/stensibly',
+    note: 'Agent coordination system.',
   },
 ] as const;
 
@@ -188,6 +178,7 @@ function headerInteger(headers: Headers, name: string): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+export function parseGitHubRateLimit(headers: Headers, name?: never): GitHubRateLimit | null;
 export function parseGitHubRateLimit(headers: Headers): GitHubRateLimit | null {
   const limit = headerInteger(headers, 'x-ratelimit-limit');
   const remaining = headerInteger(headers, 'x-ratelimit-remaining');
@@ -270,7 +261,7 @@ async function loadGitHubHomeData(): Promise<UpstreamActivity> {
 
 const getCachedUpstreamActivity = unstable_cache(
   () => captureCacheLoad(loadGitHubHomeData),
-  ['github-homepage-v11'],
+  ['github-homepage-v12'],
   { revalidate: GITHUB_ACTIVITY_UPSTREAM_FRESH_SECONDS },
 );
 

--- a/lib/site-navigation.test.ts
+++ b/lib/site-navigation.test.ts
@@ -23,13 +23,17 @@ describe('site navigation registry', () => {
         '/desk',
         '/atelier',
         '/snow-globe',
-        'https://github.com/teamleaderleo/fieldwork',
-        'https://github.com/teamleaderleo/linux-fieldwork',
+        'https://github.com/teamleaderleo/preflight',
+        'https://github.com/teamleaderleo/stensibly',
       ])
     );
     expect(hrefs).not.toContain('/blog');
     expect(hrefs).toContain('/journal');
     expect(hrefs).not.toContain('/resume');
+    expect(hrefs).not.toContain('https://github.com/teamleaderleo/fieldwork');
+    expect(hrefs).not.toContain(
+      'https://github.com/teamleaderleo/linux-fieldwork'
+    );
   });
 
   it('keeps Operator, tools, the evidence journal, and labs out of the primary row', () => {

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -192,37 +192,19 @@ export const siteNavigationGroups: SiteNavigationGroup[] = [
     description: 'Source repositories.',
     items: [
       {
-        id: 'scrapbook-repository',
-        href: 'https://github.com/teamleaderleo/scrapbook',
-        label: 'Scrapbook',
-        description: 'Source for this site.',
+        id: 'preflight-repository',
+        href: 'https://github.com/teamleaderleo/preflight',
+        label: 'Preflight',
+        description: 'Performance launcher for modded Starsector.',
         group: 'repositories',
         surface: 'external',
         external: true,
       },
       {
-        id: 'fieldwork-repository',
-        href: 'https://github.com/teamleaderleo/fieldwork',
-        label: 'Fieldwork',
-        description: 'Codebase investigations and contributions.',
-        group: 'repositories',
-        surface: 'external',
-        external: true,
-      },
-      {
-        id: 'linux-fieldwork-repository',
-        href: 'https://github.com/teamleaderleo/linux-fieldwork',
-        label: 'Linux fieldwork',
-        description: 'Linux and kernel studies.',
-        group: 'repositories',
-        surface: 'external',
-        external: true,
-      },
-      {
-        id: 'smolrunner-repository',
-        href: 'https://github.com/teamleaderleo/smolrunner',
-        label: 'Smolrunner',
-        description: 'Host-work runner.',
+        id: 'stensibly-repository',
+        href: 'https://github.com/teamleaderleo/stensibly',
+        label: 'Stensibly',
+        description: 'Agent coordination system.',
         group: 'repositories',
         surface: 'external',
         external: true,
@@ -285,7 +267,7 @@ export const homeRoomNavigationItems = siteNavigationItems.filter(
 );
 export const indexedNavigationItems = siteNavigationItems.filter(
   (item): item is SiteNavigationItem & { sitemap: SiteSitemapEntry } =>
-    Boolean(item.sitemap)
+  Boolean(item.sitemap)
 );
 export const nonPublicNavigationItems = siteNavigationItems.filter(
   item => item.surface === 'private' || item.surface === 'operational'

--- a/lib/site-navigation.ts
+++ b/lib/site-navigation.ts
@@ -267,7 +267,7 @@ export const homeRoomNavigationItems = siteNavigationItems.filter(
 );
 export const indexedNavigationItems = siteNavigationItems.filter(
   (item): item is SiteNavigationItem & { sitemap: SiteSitemapEntry } =>
-  Boolean(item.sitemap)
+    Boolean(item.sitemap)
 );
 export const nonPublicNavigationItems = siteNavigationItems.filter(
   item => item.surface === 'private' || item.surface === 'operational'

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -141,6 +141,37 @@ for (const viewport of desktopViewports) {
   });
 }
 
+test('keeps the latest Workbench swear behind a hover reveal', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  const response = await page.goto('/');
+  expect(response?.ok()).toBe(true);
+
+  const latestWriting = page.locator('[data-home-now-kind="latest writing"]');
+  await expect(latestWriting).toBeVisible({ timeout: 15_000 });
+  const spoiler = latestWriting.locator('[data-swear-spoiler]').first();
+  await expect(spoiler).toBeVisible();
+  await expect(spoiler).toHaveAttribute(
+    'title',
+    'swear jar · hover to reveal'
+  );
+
+  const concealed = await spoiler.evaluate(element => {
+    const style = getComputedStyle(element);
+    return { color: style.color, filter: style.filter };
+  });
+  await spoiler.hover();
+  await page.waitForTimeout(180);
+  const revealed = await spoiler.evaluate(element => {
+    const style = getComputedStyle(element);
+    return { color: style.color, filter: style.filter };
+  });
+
+  expect(revealed.color).not.toBe(concealed.color);
+  expect(revealed.filter).not.toBe(concealed.filter);
+});
+
 test('moves through the desktop layout transition without inflating the activity cells', async ({
   page,
 }) => {

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -93,6 +93,16 @@ for (const viewport of desktopViewports) {
     await expect(page.locator('[data-contribution-week-grid]')).toBeVisible();
     await expect(page.locator('[data-scrapbook-pet]')).toBeVisible();
     await expect(page.locator('[data-recent-systems]')).toBeVisible();
+    await expect(page.getByText('GitHub, still here', { exact: true })).toHaveCount(
+      0
+    );
+    await expect(page.locator('[data-home-repository]')).toHaveCount(2);
+    await expect(
+      page.locator('[data-home-repository="preflight"]')
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-home-repository="stensibly"]')
+    ).toBeVisible();
 
     const footprint = await readHomepageFootprint(page);
     expect(footprint.document.width).toBeLessThanOrEqual(
@@ -145,16 +155,17 @@ test('moves through the desktop layout transition without inflating the activity
   expect(Math.abs(stacked.scoreboard.x - stacked.activityGrid.x)).toBeLessThan(
     2
   );
-  expect(stacked.activityGrid.y).toBeGreaterThan(stacked.scoreboard.bottom);
+  expect(stacked.scoreboard.y).toBeGreaterThan(stacked.activityGrid.bottom);
+  expect(stacked.pet.y).toBeGreaterThan(stacked.scoreboard.bottom);
 
   await page.setViewportSize({ width: 1040, height: 720 });
   const sideBySide = await readHomepageFootprint(page);
-  expect(sideBySide.activityGrid.x).toBeGreaterThan(
-    sideBySide.scoreboard.right
-  );
+  expect(sideBySide.scoreboard.x).toBeGreaterThan(sideBySide.activityGrid.right);
   expect(
     Math.abs(sideBySide.scoreboard.y - sideBySide.activityGrid.y)
   ).toBeLessThan(2);
+  expect(sideBySide.pet.y).toBeGreaterThanOrEqual(sideBySide.activityGrid.bottom);
+  expect(Math.abs(sideBySide.pet.x - sideBySide.activityGrid.x)).toBeLessThan(2);
   expect(
     Math.abs(stacked.activityCell.width - sideBySide.activityCell.width)
   ).toBeLessThanOrEqual(8);
@@ -163,7 +174,7 @@ test('moves through the desktop layout transition without inflating the activity
   );
 });
 
-test('keeps the scorecard planted and lets the visitor pet Scraplet', async ({
+test('keeps the scorecard planted and lets the visitor pet Scraplet over time', async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
@@ -196,9 +207,6 @@ test('keeps the scorecard planted and lets the visitor pet Scraplet', async ({
     })
   ).toBe(true);
 
-  // The operator console intentionally leads the homepage now. Put the activity
-  // instrument in its interaction viewport before measuring hover motion so the
-  // browser's own scroll-into-view behavior is not mistaken for card movement.
   await scoreboard.scrollIntoViewIfNeeded();
   const scoreboardBefore = await scoreboard.boundingBox();
   expect(scoreboardBefore).not.toBeNull();
@@ -214,4 +222,9 @@ test('keeps the scorecard planted and lets the visitor pet Scraplet', async ({
 
   await pet.click();
   await expect(pet).toHaveAttribute('data-pets', '1');
+
+  await page.reload();
+  const reloadedPet = page.locator('[data-scrapbook-pet]');
+  await expect(reloadedPet).toBeVisible({ timeout: 15_000 });
+  await expect(reloadedPet).toHaveAttribute('data-pets', '1');
 });

--- a/tests/e2e/homepage-density.spec.ts
+++ b/tests/e2e/homepage-density.spec.ts
@@ -186,8 +186,8 @@ test('moves through the desktop layout transition without inflating the activity
   expect(Math.abs(stacked.scoreboard.x - stacked.activityGrid.x)).toBeLessThan(
     2
   );
-  expect(stacked.scoreboard.y).toBeGreaterThan(stacked.activityGrid.bottom);
-  expect(stacked.pet.y).toBeGreaterThan(stacked.scoreboard.bottom);
+  expect(stacked.pet.y).toBeGreaterThan(stacked.activityGrid.bottom);
+  expect(stacked.scoreboard.y).toBeGreaterThan(stacked.pet.bottom);
 
   await page.setViewportSize({ width: 1040, height: 720 });
   const sideBySide = await readHomepageFootprint(page);

--- a/tests/e2e/operator-console.spec.ts
+++ b/tests/e2e/operator-console.spec.ts
@@ -32,7 +32,7 @@ test('homepage keeps operator phrases compact and activity close at hand', async
     element => element.getBoundingClientRect().height
   );
   const activityTop = await page
-    .getByRole('heading', { name: 'GitHub, still here' })
+    .locator('#home-activity-title')
     .evaluate(element => element.getBoundingClientRect().top);
   expect(operatorTop).toBeLessThan(activityTop);
   expect(operatorHeight).toBeLessThanOrEqual(390);

--- a/tests/e2e/site-navigation.spec.ts
+++ b/tests/e2e/site-navigation.spec.ts
@@ -68,16 +68,21 @@ test('site atlas exposes rooms, repositories, experiments, and connections', asy
   await expect(atlas.locator('[data-site-atlas-appearance]')).toBeVisible();
 
   for (const [id, href] of [
-    ['scrapbook-repository', 'https://github.com/teamleaderleo/scrapbook'],
-    ['fieldwork-repository', 'https://github.com/teamleaderleo/fieldwork'],
-    [
-      'linux-fieldwork-repository',
-      'https://github.com/teamleaderleo/linux-fieldwork',
-    ],
+    ['preflight-repository', 'https://github.com/teamleaderleo/preflight'],
+    ['stensibly-repository', 'https://github.com/teamleaderleo/stensibly'],
   ] as const) {
     await expect(
       atlas.locator(`[data-site-atlas-link="${id}"]`)
     ).toHaveAttribute('href', href);
+  }
+
+  for (const id of [
+    'scrapbook-repository',
+    'fieldwork-repository',
+    'linux-fieldwork-repository',
+    'smolrunner-repository',
+  ]) {
+    await expect(atlas.locator(`[data-site-atlas-link="${id}"]`)).toHaveCount(0);
   }
 
   await page.screenshot({

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -105,19 +105,17 @@ test('homepage keeps a factual repository ledger without promotional copy', asyn
     page.getByText('Tools that remember their boundaries')
   ).toHaveCount(0);
   await expect(page.getByText(/not guess/i)).toHaveCount(0);
-  for (const repository of [
-    'scrapbook',
-    'fieldwork',
-    'linux-fieldwork',
-    'smolrunner',
-  ]) {
+  await expect(page.locator('[data-home-repository]')).toHaveCount(2);
+  for (const repository of ['preflight', 'stensibly']) {
     await expect(
       page.locator(`[data-home-repository="${repository}"]`)
     ).toBeVisible();
   }
-  await expect(page.getByText('Personal site.', { exact: true })).toBeVisible();
   await expect(
-    page.getByText('Codebase studies.', { exact: true })
+    page.getByText('Starsector launch performance.', { exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Agent coordination system.', { exact: true })
   ).toBeVisible();
 });
 

--- a/tests/e2e/space-front-door.spec.ts
+++ b/tests/e2e/space-front-door.spec.ts
@@ -69,12 +69,8 @@ test('Home shows a compact factual repository ledger', async ({ page }) => {
 
   const repositories = page.locator('[data-recent-systems]');
   await expect(repositories).toBeVisible({ timeout: 15_000 });
-  for (const repository of [
-    'scrapbook',
-    'fieldwork',
-    'linux-fieldwork',
-    'smolrunner',
-  ]) {
+  await expect(repositories.locator('[data-home-repository]')).toHaveCount(2);
+  for (const repository of ['preflight', 'stensibly']) {
     await expect(
       repositories.locator(`[data-home-repository="${repository}"]`)
     ).toBeVisible();

--- a/tests/e2e/visual-shell.spec.ts
+++ b/tests/e2e/visual-shell.spec.ts
@@ -84,16 +84,22 @@ test('theme aperture softens the root swap and has restrained idle motion', asyn
 
   const toggle = page.locator('[data-theme-toggle]').first();
   const corona = toggle.locator('[data-theme-corona]');
+  const sunSpark = toggle.locator('[data-theme-sun-spark]').first();
   const moon = toggle.locator('[data-theme-moon]');
 
   await expect(toggle).toBeVisible();
+  await expect(sunSpark).toBeVisible();
   const lightMotion = await corona.evaluate(
+    element => getComputedStyle(element).animationName
+  );
+  const sparkMotion = await sunSpark.evaluate(
     element => getComputedStyle(element).animationName
   );
   const transition = await moon.evaluate(
     element => getComputedStyle(element).transitionDuration
   );
   expect(lightMotion).not.toBe('none');
+  expect(sparkMotion).not.toBe('none');
   expect(transition).not.toBe('0s');
 
   await toggle.click();
@@ -110,6 +116,11 @@ test('theme aperture softens the root swap and has restrained idle motion', asyn
       moon.evaluate(element => Number(getComputedStyle(element).opacity))
     )
     .toBeGreaterThan(0.9);
+  await expect
+    .poll(() =>
+      sunSpark.evaluate(element => Number(getComputedStyle(element).opacity))
+    )
+    .toBeLessThan(0.1);
 
   const starMotion = await toggle
     .locator('[data-theme-star]')


### PR DESCRIPTION
## Summary
- simplify the homepage Activity heading and move the four-week calendar ahead of the score instrument
- move Scraplet beneath the calendar and persist pet counts in the browser
- feature Preflight and Stensibly in homepage and atlas repository links
- add a homepage swear-jar reveal for Workbench copy
- swap the Space brain icon for an orbit glyph and give light mode a warmer animated toggle treatment

## Checks
- lint passed
- typecheck passed
- 410 unit tests passed
- production build passed
- Chromium regression suite passed
- final homepage visual review checked at 1280×720 and 1440×900
- full branch diff self-reviewed

## Contribution lane
- neither: the pull request is the useful record for this focused site tune