### PR TITLE
Shorten routine verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,14 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
+
 jobs:
-  verify:
+  quality:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -33,9 +34,22 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline --reporter=silent
       - name: Lint
         run: pnpm lint
-      - name: Typecheck
-        run: pnpm typecheck
       - name: Unit tests
         run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline --reporter=silent
       - name: Production build
         run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # misc
 .DS_Store
 *.pem
+/.eslintcache
 /drizzle/*
 !/drizzle/*.sql
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@
 
 ## Verification and browser evidence
 
-- Keep routine verification cheap and broad: lint, typecheck, Vitest, and a production build. `pnpm ci:local` mirrors that lane and must stay browser-free.
+- Keep routine verification cheap and broad: lint, Vitest, and a production build. The Next.js production build owns the project-wide TypeScript validation; do not serialize a second full `pnpm typecheck` beside it in routine CI. Use `pnpm typecheck` directly when a focused type-only feedback loop is useful.
+- `pnpm ci:local` mirrors that principle and must stay browser-free. Hosted CI may run independent quality and build lanes in parallel to shorten wall-clock time.
 - Treat Playwright as an authoring and diagnostic tool, not a default merge gate. Hosted CI should not install or launch Chromium, Chrome, WebKit, or another browser unless the human explicitly asks for a hosted browser workflow.
 - Do not add or run browser tests for facts that can be derived from source, covered by Vitest, checked at an API boundary, or proven by the production build.
 - Use a browser only when the question genuinely depends on browser behavior: rendered geometry, responsive overflow, CSS/computed styles, focus, pointer or keyboard interaction, browser storage/APIs, canvas, hydration, or deliberate visual review.

--- a/docs/ci-scope.md
+++ b/docs/ci-scope.md
@@ -1,17 +1,17 @@
 # CI scope
 
-Scrapbook keeps hosted CI boring: install, lint, typecheck, unit tests, and a production build.
+Scrapbook keeps hosted CI boring and short: lint plus unit tests in one job, and the production build in another. The jobs run in parallel.
 
 ## Hosted verification
 
-For ordinary code changes, GitHub Actions runs:
+For ordinary code changes, GitHub Actions runs two independent lanes:
 
-- ESLint
-- TypeScript
-- the full Vitest suite
-- a production Next.js build
+- **quality** — ESLint and the full Vitest suite;
+- **build** — the production Next.js build, including Next.js' TypeScript validation.
 
-Pure Markdown changes skip the workflow. Pushes to `main` use the same verification job as pull requests.
+Pure Markdown changes skip the workflow. Pushes to `main` use the same lanes as pull requests.
+
+Do not add a separate hosted `pnpm typecheck` step beside `next build`. Next.js already runs TypeScript during the production build, so serializing another full TypeScript pass adds wall-clock time without adding a second independent gate. `pnpm typecheck` remains available when a focused type-only check is useful during authoring.
 
 Hosted CI does not install a browser, start Playwright, upload screenshot artifacts, classify UI surfaces, or replay browser checks after merge.
 
@@ -41,7 +41,7 @@ Do not run the complete Playwright suite by habit. Do not add a browser test for
 
 ## What belongs where
 
-Prefer Vitest for data transforms, registries, labels, API behavior, state transitions that do not depend on browser layout, and reusable component logic. Prefer the production build for route compilation, server/client boundaries, and Next.js integration failures.
+Prefer Vitest for data transforms, registries, labels, API behavior, state transitions that do not depend on browser layout, and reusable component logic. Prefer the production build for TypeScript validation, route compilation, server/client boundaries, and Next.js integration failures.
 
 Use Playwright when the assertion depends on actual browser behavior. Good examples include layout overflow, real focus behavior, media-query behavior, pointer interaction, browser storage, computed CSS, canvas interaction, and a small end-to-end hydration canary.
 
@@ -49,4 +49,6 @@ The default browser smoke file is intentionally tiny. The larger specs under `te
 
 ## Local verification
 
-`pnpm ci:local` mirrors hosted verification and stays browser-free. Browser work is a separate deliberate command, so an agent can build and verify the application without accidentally paying for the whole Playwright suite.
+`pnpm ci:local` runs install, lint, Vitest, the production build, and `git diff --check`. The build owns TypeScript validation here too, so local verification does not immediately repeat the same project-wide type analysis with a separate command.
+
+Use `pnpm typecheck` directly when a type-only feedback loop is what you want. Browser work is a separate deliberate command.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prettier": "prettier --write --ignore-unknown .",
     "prettier:check": "prettier --check --ignore-unknown .",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --cache --cache-location .eslintcache",
     "typecheck": "next typegen && tsc --noEmit -p tsconfig.verify.json",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/local-ci.mjs
+++ b/scripts/local-ci.mjs
@@ -47,9 +47,12 @@ if (!argumentsSet.has('--skip-install')) {
 
 steps.push(
   { label: 'Lint', command: 'pnpm', args: ['lint'] },
-  { label: 'Typecheck', command: 'pnpm', args: ['typecheck'] },
   { label: 'Unit tests', command: 'pnpm', args: ['test'] },
-  { label: 'Production build', command: 'pnpm', args: ['build'] },
+  {
+    label: 'Production build (includes TypeScript)',
+    command: 'pnpm',
+    args: ['build'],
+  },
   {
     label: 'Reject whitespace errors',
     command: 'git',


### PR DESCRIPTION
## Summary

- run GitHub Actions quality and production-build lanes in parallel
- let `next build` own routine TypeScript validation instead of serializing a second project-wide typecheck
- keep `pnpm typecheck` as an explicit authoring command
- make repeated local ESLint runs reuse `.eslintcache`
- document the timing-oriented verification policy for future agents

## Measured result

The pre-change PR job took about 100 seconds. Its explicit typecheck cost roughly 12 seconds, then `next build` performed another project-wide TypeScript phase.

The parallel benchmark completed in about 66 seconds: quality finished first and the production build became the only critical path. That is roughly a one-third reduction in ordinary PR feedback time without dropping lint, Vitest, build, or Next's TypeScript validation.

## Validation

- rebased onto current `main` after concurrent Workbench edits; changed files did not overlap
- CI run `32672945206` passed both `quality` and `build`
- prior benchmark run `32672351380` measured the ~100s → ~66s wall-clock reduction
- full diff self-reviewed

No browser run is relevant because this changes verification plumbing only.