### PR TITLE
Restore Luna stunt/prototype parallelism

### DIFF
--- a/docs/bot-desk.md
+++ b/docs/bot-desk.md
@@ -161,6 +161,7 @@ For Leo-directed writing in particular:
 - Treat overlearned pet words as a warning sign. `bounded` is useful when a literal limit is the point; otherwise name the limit, describe the thing, or use language with more life.
 - Be wary of `Worse, ...` as a sentence opener. It often announces escalation instead of delivering it. State the consequence or react to it; keep `Worse` for moments where the comparison itself carries the sentence.
 - Use semicolons when two complete clauses share the same pulse and belong in one breath; do not automatically chop them into separate declarative sentences. `A bob has an edge; it ends somewhere definite.` is the kind of cadence to preserve.
+- Avoid decorative `X with Y` tags that dress up a noun after it has already landed, such as `a stunt with receipts`. If the noun is stronger bare, leave it bare; preserve clean parallelism when it is already sitting there.
 - Watch `almost` and habitual `And yeah`. `Almost` should signal a real near-case instead of softening a claim by reflex; `And yeah` usually wants deletion or a more specific turn.
 - Watch vague placeholders such as `some`, `something`, `somehow`, `there is`, and `there are`. When the referent is already clear, name it or state the claim directly; keep the vagueness when the speaker genuinely means an indefinite thing.
 - Make adverbs earn their place. Smoothing words such as `just`, `genuinely`, `deliberately`, `slightly`, or `really` often make a sentence tidier while making the voice less specific.

--- a/lib/bot-desk.ts
+++ b/lib/bot-desk.ts
@@ -86,9 +86,9 @@ const entries: BotDeskEntry[] = [
     publicationState: 'Published',
     kind: 'Essay',
     topics: ['AI', 'retail', 'community', 'agents'],
-    revision: 2,
+    revision: 3,
     revisionSummary:
-      'Leo-directed revision: cut explanatory glue, tightened vague phrasing, kept the neighborhood scenes, and made the local-shop argument more direct.',
+      'Parallelism pass: removed an ornamental `with` phrase and restored the cleaner stunt/prototype contrast.',
     sourcePath: 'desk/oh-thats-luna-she-runs-the-shop.md',
     sourceRepository: 'teamleaderleo/scrapbook',
   },

--- a/public/desk/oh-thats-luna-she-runs-the-shop.md
+++ b/public/desk/oh-thats-luna-she-runs-the-shop.md
@@ -14,7 +14,7 @@ Okay, now the joke gets weird.
 
 The store sits inside a cursed fork: if Luna burns through the money, everybody gets to laugh because AI got a real storefront and still lost money; if she actually keeps making money, the reaction becomes something closer to, okay bro, what the fuck?
 
-A money-losing AI boutique is a stunt with receipts; a profitable one starts looking like a prototype.
+A money-losing AI boutique is a stunt; a profitable one is a prototype.
 
 The version I find endearing is local; I don't particularly care whether Luna becomes a brilliant autonomous capitalist.
 


### PR DESCRIPTION
Small Leo-directed cleanup in “Oh, That’s Luna. She Runs the Shop.” Replaces `a stunt with receipts` with the cleaner parallel sentence `A money-losing AI boutique is a stunt; a profitable one is a prototype.`

Also records the broader Workbench preference against decorative `X with Y` noun tags when the noun already lands cleanly, and bumps Luna to revision 3.

Self-review: branch is current with `main`; diff is limited to one article line, one registry revision update, and one Markdown voice-guidance line.