### PR TITLE
Reuse ESLint cache across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,13 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline --reporter=silent
+      - name: Restore ESLint cache
+        uses: actions/cache@v4
+        with:
+          path: .eslintcache
+          key: ${{ runner.os }}-eslint-${{ hashFiles('pnpm-lock.yaml', 'eslint.config.mjs') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-eslint-${{ hashFiles('pnpm-lock.yaml', 'eslint.config.mjs') }}-
       - name: Lint
         run: pnpm lint
       - name: Unit tests

--- a/docs/ci-scope.md
+++ b/docs/ci-scope.md
@@ -15,6 +15,8 @@ Do not add a separate hosted `pnpm typecheck` step beside `next build`. Next.js 
 
 The build lane restores `.next/cache` across commits with a key scoped to the pnpm lockfile. Next.js 16.3's `turbopackFileSystemCacheForBuild` then reuses production Turbopack compilation state. A lockfile change intentionally starts a fresh cache lineage; ordinary source edits reuse the latest compatible cache. The flag is experimental, so if a cached build ever produces stale or otherwise suspect output, remove the flag and the `.next/cache` Actions step first and rebuild cold.
 
+The quality lane restores `.eslintcache` across commits, keyed by the pnpm lockfile and ESLint configuration. ESLint uses its content-hash cache strategy so unchanged files remain reusable after a fresh Git checkout even though filesystem timestamps changed.
+
 Hosted CI does not install a browser, start Playwright, upload screenshot artifacts, classify UI surfaces, or replay browser checks after merge.
 
 ## Browser checks are author-side

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prettier": "prettier --write --ignore-unknown .",
     "prettier:check": "prettier --check --ignore-unknown .",
     "start": "next start",
-    "lint": "eslint . --cache --cache-location .eslintcache",
+    "lint": "eslint . --cache --cache-strategy content --cache-location .eslintcache",
     "typecheck": "next typegen && tsc --noEmit -p tsconfig.verify.json",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary

- switch ESLint caching to content hashes so fresh Git checkouts can reuse prior results
- persist `.eslintcache` across GitHub Actions quality runs
- document the quality-cache lineage

## Measured result

Cold seed run `32673685716`:
- ESLint: about **10.3s**
- Vitest: **8.0s**
- quality job: about **35s**
- `.eslintcache` written: about **22 KB**

Warm run `32673781386` restored that cache:
- ESLint: about **2.3s**
- Vitest: **12.17s** on this runner
- quality job: about **32s**

The cache itself restores in well under a second, so this saves lint work without introducing a meaningful transfer tax. Across this broader performance pass, ordinary PR feedback has moved from roughly **100s** to **~66s** after parallelizing verification and now into the **low-30s** range with warm Next + ESLint caches.

## Validation

- warm ESLint cache restored by lockfile/config prefix
- lint passed with the same existing 38 warnings and zero errors
- 69 Vitest files / 419 tests passed
- production build lane passed using the persistent Next cache
- final diff is three small files and has been self-reviewed

No browser run is relevant because this changes CI/cache behavior only.