### PR TITLE
Refresh Scrapbook and linked-repository status

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,20 +104,20 @@ pnpm typecheck
 pnpm test
 pnpm prettier:check
 pnpm build
-pnpm exec playwright test --project=chromium
+pnpm test:e2e
+pnpm test:e2e:full
+pnpm test:e2e:cross-browser
 ```
 
 The public homepage can render without database credentials or a GitHub token. Authentication, saved Space content, and proxy reporting require their corresponding environment variables and services.
 
-## Browser policy
+## Verification policy
 
-Chromium is the normal pull-request browser gate. It runs with two workers to use the available CI cores. WebKit compatibility runs weekly and can also be triggered manually through GitHub Actions:
+Ordinary hosted CI keeps the routine gate small: ESLint and Vitest run in the quality lane while a separate lane performs the production Next.js build. The build and lint caches are restored across Actions runs so repeated verification spends less time redoing unchanged work.
 
-```bash
-pnpm exec playwright test --project=webkit
-```
+Playwright remains an explicit author-side tool for browser-sensitive changes. `pnpm test:e2e` runs the focused Chromium smoke path, `pnpm test:e2e:full` runs the complete Chromium suite, and `pnpm test:e2e:cross-browser` exercises the configured browser matrix. Run the browser scope the change deserves and retain targeted visual evidence when a UI decision needs a durable review artifact.
 
-Failure diagnostics include browser traces and test results. Browser-relevant CI also preserves targeted successful visual-review artifacts for Home, Gallery, and the sigil lab so reviewed UI changes have durable phone/desktop and light/dark evidence without archiving every screenshot from the full suite.
+This keeps browser evidence available without making every ordinary hosted change pay for the complete browser suite.
 
 ## Current direction
 

--- a/lib/github-home.ts
+++ b/lib/github-home.ts
@@ -31,7 +31,7 @@ const FEATURED_REPOSITORIES = [
   {
     name: 'smolrunner',
     url: 'https://github.com/teamleaderleo/smolrunner',
-    note: 'Disposable GitHub Actions runners.',
+    note: 'Trust-tiered Linux execution for coding agents and GitHub Actions.',
   },
   {
     name: 'cultist',

--- a/work/current-state.md
+++ b/work/current-state.md
@@ -1,28 +1,26 @@
-# Current state — 2026-08-22
+# Current state — 2026-08-24
 
 This is the short live-status overlay for the work record.
 
-Read this before `portfolio-inventory.md` or `resume-candidates.md` when **status recency** matters. Those files still own the deeper retrieval and editorial story, but several of their status sentences lagged the repositories during the August Preflight sprint.
+Read this before `portfolio-inventory.md` or `resume-candidates.md` when **status recency** matters. Those files still own the deeper retrieval and editorial story; this file carries the freshest cross-repository position while active engineering continues to move ahead of the longer records.
 
-Source repositories and upstream threads remain authoritative. This file records the current cross-repository position without turning every active project into a resume candidate.
+Source repositories and upstream threads remain authoritative. Prefer durable product boundaries here over moving branch SHAs, short-lived queue states, or one rehearsal that may finish before this file is read again.
 
-## Preflight — release execution
+## Preflight — operational candidate execution
 
 Repository: https://github.com/teamleaderleo/preflight
 
 Live release board: https://github.com/teamleaderleo/preflight/issues/652
 
-State: **the broad product/refinement sprint is landed; first-beta release execution is active**.
+State: **source and rendered-UI convergence are complete; first-beta work is operational candidate execution**.
 
-Current accepted `main` at this refresh is `ff479a685def730b7119bd06316617b6388fd237`, which merged Preflight PR #1056 after the first private signed Distribution rehearsal exposed portable Linux and Windows test-fixture defects. The canonical six-image public screenshot set had already landed through PR #1055.
+The private signing and package rehearsals have completed successfully across Linux, macOS, and Windows. The remaining beta gate is tied to one maintainer-authorized immutable tagged candidate generation: choose the release source, exercise the frozen package on native Windows and x86-64 Linux with licensed installations, collect package-bound startup/lifecycle/update/report evidence, and complete the hands-on report-intake canary. Final candidate creation and public release remain separate maintainer decisions.
 
-The release board now says there is no active general product-hardening wave. The ordinary open-PR queue is back to explicitly parked research/hardening carriers, which stay parked unless a candidate failure or maintainer decision promotes them.
+Release-facing maintenance continued after the rehearsals. Compact is now the normal prepared texture layout; startup entry points and benchmark shutdown were tightened; desktop navigation and common Home controls were made immediate; dependency and support behavior were simplified; package jobs were kept at the verified Rust floor; and repository CI was narrowed so desktop-only work stops paying unrelated package/Maven cost.
 
-The first private signed Distribution rehearsal reached the real release machinery and exposed the now-repaired fixture defects before package assembly. A second private signed rehearsal is running against the repaired accepted `main` at the time of this refresh. These rehearsals prove release machinery; final package claims still belong to the retained tagged candidate generation and its native/package evidence.
+**Performance note:** the current repository evidence includes a **13.69s best observed startup** and **14.04s five-run median** for the reviewed G1/deferred-heap-commit candidate condition on the 83-mod M5 MacBook Air profile. Later current-engine observations retained the fourteen-second regime, including 14.49s, 14.84s, and a fresh Balanced→Compact 14.79s run, while other same-machine observations landed around 15.5s. Treat 13.69s as a best observation rather than a new release-candidate campaign. The 2026-08-15 **89.00s ordinary → 15.53s Preflight** controlled same-session comparison remains the clean public before/after campaign, and packaged-candidate evidence is still pending.
 
-**Performance note refreshed 2026-08-24:** the current headline is **13.69s best observed startup** on the 83-mod M5 MacBook Air profile. For live perspective, use the freshest best observed run; current repeat behavior is tightly clustered enough that run-to-run differences are on the order of tens of milliseconds, with no meaningful lucky-cache regime. The 2026-08-15 **89.00s → 15.53s** same-profile campaign remains useful historical evidence, not the current performance headline.
-
-Career interpretation: Preflight remains the strongest owned engineering artifact, but its current phase should now be described as **release execution / candidate evidence**, not broad product convergence.
+Career interpretation: Preflight remains the strongest owned engineering artifact. Its current phase is **release execution / candidate evidence**, with product work converged enough that the remaining claims increasingly belong to frozen package bytes and native acceptance.
 
 ## External open-source validation
 
@@ -42,31 +40,31 @@ No status correction from this refresh displaces that cluster.
 
 State: **two merged upstream fixes, with a third correctness follow-on still open**.
 
-The older work record is stale here.
-
 - https://redirect.github.com/vitejs/vite/pull/23207 — merged optimizer resource-lifecycle repair: closes temporary custom-extension analysis bundles on success and error.
-- https://redirect.github.com/vitejs/vite/pull/23165 — **merged on 2026-08-21**: preserves the Rollup/Rolldown lifecycle contract by passing a `buildEnd` failure into `closeBundle(error)` before rethrowing it.
-- https://redirect.github.com/vitejs/vite/pull/23208 — open and mergeable: keeps repeated `resolveConfig()` calls idempotent so resolver-generated environment state does not duplicate optimizer plugins and invalidate a warm optimizer cache.
+- https://redirect.github.com/vitejs/vite/pull/23165 — merged on 2026-08-21: preserves the Rollup/Rolldown lifecycle contract by passing a `buildEnd` failure into `closeBundle(error)` before rethrowing it.
+- https://redirect.github.com/vitejs/vite/pull/23208 — open: keeps repeated `resolveConfig()` calls idempotent so resolver-generated environment state does not duplicate optimizer plugins and invalidate a warm optimizer cache.
 
-Career interpretation: Vite is now a real **two-merge lifecycle/correctness cluster** rather than one merge plus one approved pending patch.
+GitHub currently reports #23208 as non-mergeable. Keep the durable claim at **open correctness follow-on** and let the upstream PR own transient mergeability state.
+
+Career interpretation: Vite is a real **two-merge lifecycle/correctness cluster** with an additional unresolved config-idempotence thread.
 
 ### Cloud Hypervisor
 
 State: **three merged upstream Rust/VMM fixes, with the deeper QCOW ownership repair still open**.
 
-The older work record is stale here too.
-
-Merged work now includes:
+Merged work:
 
 1. https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8699 — exact VMM shutdown events replace SSH disappearance as the lifecycle gate before VM/disk reuse.
 2. https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8709 — ACPI construction failures propagate through typed VM boot errors instead of panicking.
-3. https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8734 — **merged on 2026-08-20**: VFIO DMA ranges that fit a logical BAR but cross a gap between separately mmap'd sparse areas are rejected unless one mapping covers the complete requested range.
+3. https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8734 — merged on 2026-08-20: VFIO DMA ranges that fit a logical BAR but cross a gap between separately mmap'd sparse areas are rejected unless one mapping covers the complete requested range.
 
-The QCOW follow-on remains open and mergeable:
+The QCOW follow-on remains open:
 
 - https://redirect.github.com/cloud-hypervisor/cloud-hypervisor/pull/8721 — gives replacement L2 tables ownership before L1 publication and makes the relocation handoff local instead of deferring the old-table release beyond the switch.
 
-Career interpretation: Cloud Hypervisor now demonstrates repeat acceptance across **VM lifecycle, boot/error propagation, PCI/VFIO mapping semantics**, plus a deeper persistent-metadata review story.
+GitHub currently reports #8721 as non-mergeable. Preserve the durable technical/review story and defer mergeability to the live PR.
+
+Career interpretation: Cloud Hypervisor demonstrates repeat acceptance across **VM lifecycle, boot/error propagation, and PCI/VFIO mapping semantics**, plus a deeper persistent-metadata ownership review thread.
 
 ### Cloudflare Workers SDK
 
@@ -80,17 +78,15 @@ Repository: https://github.com/teamleaderleo/cultist
 
 State: **active research prototype in sustained dogfood**.
 
-The older portfolio wording that treated Cultist as an early prototype is materially stale.
-
 Current `cargo-cultist` work includes deterministic local/read-only analyzers for repository conventions and change-time evidence, concurrent-change preflight, historical companion analysis, CI selector analysis, bounded evidence packets, claim/provenance handling, and decision-memory research.
 
-The central product test has also become empirical: whether selected repository evidence changes the next justified action, prevents a wrong turn, or saves a later worker from repeating investigation. The repository now retains behavioral episodes for both action-changing and quiet cases instead of leaving that question as a future evaluation idea.
+The central product test is empirical: whether selected repository evidence changes the next justified action, prevents a wrong turn, or saves a later worker from repeating investigation. The repository retains behavioral episodes for both action-changing and quiet cases.
 
-Recent August work has pushed further into selected-evidence survival under byte budgets, behavioral-trial comparability, promotion-receipt reuse, concurrent-base movement, divergent lineage, and preserving counterexamples when evidence has to be compressed.
+Recent work has moved deeper into provider-snapshot correctness: explicit provider-current identity, active-work CI bound to the observed provider snapshot, pagination and bounded-coverage uncertainty kept visible, and one-response file coverage proven only when the provider evidence actually supports it. That sits beside the ongoing selected-evidence budget, behavioral-trial, promotion-receipt, concurrent-lineage, and counterexample work.
 
-This is now a substantive research/program thread in the owned-work map. It should no longer be summarized as merely a small speculative repository-memory prototype.
+This is a substantive research/program thread in the owned-work map. The older small speculative repository-memory description has expired.
 
-## Stensibly — live coordination system
+## Stensibly — live coordination and continuation system
 
 Repository: https://github.com/teamleaderleo/stensibly
 
@@ -98,25 +94,51 @@ State: **live hosted system in ongoing dogfood**.
 
 The hosted Convex + Cloudflare Worker path, REST v1, remote MCP, browser sessions, bearer clients, project/workspace scoping, durable claims/runs/reservations, idempotent writes, handoffs, and guarded GitHub publication remain active.
 
-The current product boundary has moved beyond the original question of whether work can survive a disposable worker session. Real work now crosses worker replacement through durable handoffs and provider-backed continuation. Current engineering is increasingly about compiled worker briefs, provider-outage continuity and reconciliation, human Control Room projections, cross-model recovery drills, exact-CI evidence reuse, unattended settlement, and ambiguity recovery while keeping consequential effects behind explicit server-owned authority.
+Real work now crosses disposable worker sessions through durable handoffs and provider-backed continuation. Recent production work also composes repository attention into mail: material GitHub states can become deterministic mail checkpoints, project-owned continuation handles survive the handoff, webhook observations feed the publisher, and the Quarry dogfood mapping has automatic Gmail delivery active in the Worker. A bounded read-only public GitHub Events fallback can supply observations for that explicit dogfood mapping when the richer provider path is unavailable.
 
-## SmolRunner — disposable worker path in physical acceptance
+The larger direction remains compiled worker briefs, provider-outage continuity and reconciliation, human Control Room projections, cross-model recovery drills, exact-CI evidence reuse, unattended intake/continuation/settlement, and ambiguity recovery while consequential effects stay behind explicit server-owned authority.
+
+## SmolRunner — trust-tiered hot Linux execution
 
 Repository: https://github.com/teamleaderleo/smolrunner
 
-State: **pre-alpha, with the disposable GitHub Actions path already in repeated physical Apple-silicon acceptance**.
+State: **pre-alpha in live Apple-silicon systems acceptance, with both strict disposable execution and trusted persistent execution under active development**.
 
-The repository has exercised prepared Lima/VZ workers, the official GitHub Runner Scale Set bridge, durable assignment/clone/JIT/teardown composition, LaunchAgent supervision, controller-death recovery, and repeated pilot runs. Recent work also hardened same-UID JIT/listener secret exposure and Git checkout-state handling.
+The strict disposable path includes prepared Lima/VZ generations, the official GitHub Runner Scale Set bridge, Keychain credential acquisition, durable assignment/no-replay handling, clone/JIT/teardown composition, LaunchAgent supervision, controller-death evidence, exact worker ownership, and repeated physical Quarry pilots.
 
-The current engineering boundary is post-composition reliability: finish the dependable installed-service one-job lifecycle, close restart/replay ambiguity, extend physical recovery through cancellation/sleep/reboot/outage/teardown cases, and then enforce the hostile-CI network boundary before arbitrary repository code is treated as a production workload.
+The product direction has widened from a disposable-runner controller into trust-tiered Linux execution for coding agents and GitHub Actions. Trusted work can keep valuable state resident where policy permits; recent accepted work includes the first persistent runner lane, warm pause/resume and auto-idle behavior, hot-state path policy, immutable Git object-pool primitives and fixed generation markers, plus trusted OverlayFS plan/descriptor checks for reusable Linux state.
 
-## Quarry — engineering context, not a public portfolio headline
+The production boundary still includes the dependable installed-service one-job disposable journey, restart-safe ownership for in-flight Lima mutations, wider sleep/reboot/outage/teardown recovery, and the hostile-worker network boundary. Hot execution progresses in parallel while those isolation and recovery guarantees remain explicit.
 
-Quarry has real ongoing engineering work behind it and is useful as an internal/alpha workload and dogfood context.
+## Quarry — private engineering and dogfood context
 
-The public SmolRunner record already mentions repeated Quarry pilot runs because those runs have produced concrete controller/recovery evidence. That is enough for the current career record.
+Repository: private `teamleaderleo/quarry`.
 
-Do **not** promote Quarry into a standalone public-facing portfolio specimen from this file. Keep it as engineering context unless its own shareable evidence later earns a separate public record.
+State: **active private trading-research lab with broad execution/accounting machinery and live-order permission disabled**.
+
+Quarry now carries materially more engineering than the older “alpha workload” shorthand suggests: immutable dataset/research identities, deterministic backtests and tournaments, causal execution policy, futures/options accounting, exact risk/restart state, verification receipts, read-only broker observation, offline statement evidence, continuation handoffs, and sustained provider/data-fidelity work. Financial evidence remains deliberately stricter than engineering readiness; the repository currently says execution readiness is ahead of scored prospective strategy evidence.
+
+Keep Quarry as internal engineering context in the public career record today. Its strongest public relevance remains the concrete dogfood it provides to SmolRunner and Stensibly plus the engineering techniques it exercises. A separate public portfolio headline should wait for shareable evidence and an explicit publication decision.
+
+## Proofwake — revision evidence index
+
+Repository: https://github.com/teamleaderleo/proofwake
+
+State: **working local evidence index with Proofwake now the primary product identity**.
+
+The repository includes a durable local ledger, Git and GitHub collectors, reports, diagnostics, a local dashboard, read-only MCP, and the existing optional AI-usage estimate module inherited from the Shadowbill phase. Compatibility remains for Shadowbill command/environment/storage identities while clean installs use Proofwake naming.
+
+The product boundary stays observational: collect content-minimised evidence by repository/revision, preserve source freshness/failure/recovery signals, and leave scheduling, runner operation, deployment, mutation approval, and developer ranking to other systems.
+
+## Renderprove — browser evidence tool
+
+Repository: https://github.com/teamleaderleo/renderprove
+
+State: **early-stage working browser-evidence tool with multiple bounded evidence paths already implemented**.
+
+Current capabilities include local or deployed Chromium review receipts, screenshots and hashes, diagnostics, a bounded local MCP surface, disposable rootless-Podman renderer/repeatability probes, bounded interaction plans, deterministic PNG comparison, and optional Cloudflare Gemma advisory artifacts that stay explicitly non-authoritative.
+
+Renderprove fits the broader toolchain as the browser/rendered-output evidence producer: SmolRunner can own execution, Renderprove can see and verify the result, Proofwake can retain the evidence trail, and Stensibly can coordinate the next action.
 
 ## FEX — validated owned-fork runtime research
 
@@ -135,7 +157,7 @@ Hosted ARM64 controls and an x86/FEX matrix validate the candidate, including na
 
 The remaining recorded hardware confirmation is the Apple M5 + Venus path.
 
-Upstream FEX still states `No AI/ML/LLM/etc code contributions.` in `CONTRIBUTING.md`. Keep the distinction explicit: the current work is strong runtime/ABI/Vulkan research in an owned fork. Any future upstream path has to respect upstream's contribution policy.
+Upstream FEX still states `No AI/ML/LLM/etc code contributions.` in `CONTRIBUTING.md`. Keep the distinction explicit: the current work is runtime/ABI/Vulkan research in an owned fork. Any future upstream path has to respect upstream's contribution policy.
 
 ## Fieldwork and Linux Fieldwork — investigation engines
 
@@ -144,11 +166,11 @@ Repositories:
 - https://github.com/teamleaderleo/fieldwork
 - https://github.com/teamleaderleo/linux-fieldwork
 
-State: **active research/investigation machinery rather than primary public portfolio centerpieces**.
+State: **active research/investigation machinery whose value is mostly visible through the external work it produces**.
 
-Fieldwork has recently fed native game/platform scouting, FEX/Vulkan investigation, and browser/session experiments. Linux Fieldwork has carried Cloud Hypervisor work and preserved review lessons, exact live-PR handling, regression-fixture lessons, and other reusable investigation residue.
+Fieldwork remains the code-first public research workbench for programmes, target maps, experiments, integration trials, exact-head review, and deliberate upstream delivery. Linux Fieldwork carries the Linux/Debian variant with exact source imports, investigations, current-fieldwork status, and a growing set of review/process lessons from Cloud Hypervisor and related systems work.
 
-Their current portfolio value is mostly visible through the external work they help produce and through the repeatable code-first investigation method they preserve.
+Keep their portfolio value attached to the accepted upstream fixes, retained experiments, and repeatable investigation method rather than treating either repo as a generic portfolio centerpiece.
 
 ## Elatura — active prototype and dogfood
 
@@ -156,23 +178,35 @@ Repository: https://github.com/teamleaderleo/elatura
 
 State: **active prototype/dogfood beyond the original observation-only M0**.
 
-The current repository includes observe-only Firefox measurement, a guarded fail-open slim mode, bounded live DOM discovery/windowing and restoration work, a preflighted DOM executor/browser host, Android completion-notification experiments, generic adapter/conformance contracts, deterministic oversized fixtures, bounded local representations, and broader offload experiments.
+The repository includes observe-only Firefox measurement, a locked fail-open slim mode, bounded live DOM discovery/windowing/restoration, a preflighted DOM executor/browser host, local Android completion-notification experiments, generic adapter/conformance contracts, deterministic oversized fixtures, bounded local representations, cache/provenance controls, and broader resource/offload experiments.
 
-The open product question remains which intervention layer earns its complexity in real use: suppress/window live page state, use a cheaper local representation, or move execution elsewhere while preserving the native service experience.
+The open product question is which intervention layer earns its complexity in real use: suppress/window live page state, use a cheaper local representation, or move execution elsewhere while preserving the native service experience.
+
+## Scrapbook / teamleaderleo.com — live site and publication lab
+
+Repository: https://github.com/teamleaderleo/scrapbook
+
+State: **active personal site, private knowledge workspace, and repository-backed publication/evidence lab**.
+
+Current main is on Next.js 16.3.2 / React 19.2.1. Routine hosted CI is intentionally compact: ESLint + Vitest in one lane and the production Next.js build in another, with persistent lint/build caches. Playwright remains an explicit author-side browser tool instead of an ordinary hosted PR gate.
+
+The live product still spans the Operator console, Space notes/review workspace, Time, Gallery/agent guestbook, proxy dashboard, Workbench, Journal, machine-readable agent access/contribution contracts, GitHub activity integration, and isolated visual/interaction experiments.
 
 ## Portfolio-level correction from the previous snapshot
 
-The August sprint did **not** leave the rest of the body of work frozen around Preflight.
+The August work is distributed across several active systems. The important status corrections at this refresh are:
 
-The most important status corrections are:
+- Preflight is in operational candidate execution: private signing rehearsals are complete, source/UI convergence is complete, and remaining beta claims belong to one frozen candidate generation plus native/package evidence.
+- Preflight’s current performance record includes a 13.69s best observation and 14.04s five-run candidate-condition median, while 89.00s → 15.53s remains the clean controlled public comparison and packaged-candidate timing is pending.
+- Vite is a two-merge upstream cluster; the third idempotence follow-on remains open, with live mergeability owned by the upstream PR.
+- Cloud Hypervisor is a three-merge upstream cluster; the deeper QCOW ownership repair remains open, with live mergeability owned by the upstream PR.
+- Cultist has matured into sustained dogfood with provider-snapshot correctness, deterministic evidence surfaces, and retained behavioral research.
+- Stensibly now has production GitHub-attention → mail continuation in its Quarry dogfood path plus a bounded public GitHub observation fallback.
+- SmolRunner is now best described as trust-tiered hot Linux execution: strict disposable work remains central while persistent trusted residency and M6 reusable-state primitives are landing.
+- Quarry has substantial private trading-research, accounting, execution, broker-observation, and evidence machinery while live-order permission remains disabled and prospective financial promotion remains deliberately strict.
+- Proofwake and Renderprove belong in the current owned-system map as the evidence-memory and rendered/browser-evidence components of the wider toolchain.
+- Elatura is well beyond observation-only M0.
+- Scrapbook’s routine CI no longer uses Playwright as the ordinary hosted PR gate; browser checks are explicit author-side tools.
+- FEX remains validated owned-fork runtime research with upstream-policy boundaries kept explicit.
 
-- Preflight has crossed from broad convergence into first-beta release execution, with #1056 already merged and signed rehearsal work active.
-- Vite is now a two-merge upstream cluster.
-- Cloud Hypervisor is now a three-merge upstream cluster, with QCOW still supplying the deeper review story.
-- Cultist has matured into sustained dogfood with a real CLI, multiple deterministic evidence surfaces, and retained behavioral research.
-- Stensibly and SmolRunner both continued substantive August engineering.
-- Elatura is further beyond observation-only M0 than the older inventory says.
-- FEX remains strong validated runtime research, with upstream-policy boundaries kept explicit.
-- Quarry belongs in the internal engineering context and dogfood map, not the public headline pool today.
-
-Until the larger durable records are individually rewritten, treat this file as the current status overlay when an older status sentence conflicts with the live repositories.
+Treat this file as the recency overlay when a longer portfolio sentence conflicts with a live repository. Rewrite the longer record when a durable product boundary has changed; leave one-day queue state here only when it affects what can truthfully be claimed.

--- a/work/portfolio-inventory.md
+++ b/work/portfolio-inventory.md
@@ -1,10 +1,14 @@
 # Portfolio inventory
 
+**Last broad refresh:** 2026-08-24
+
 This is the retrieval index for career-facing engineering evidence.
 
 It exists so a future resume, LinkedIn rewrite, portfolio page, interview packet, or application does not have to reconstruct the body of work from GitHub memory. It is deliberately broader than `resume-candidates.md` and much shorter than the source repositories.
 
-The source repositories, upstream issues/pull requests, benchmark packets, review threads, and CI receipts remain authoritative. This file records **what each body of work currently proves, what state the evidence is in, and where it belongs in a career narrative**.
+The source repositories, upstream issues/pull requests, benchmark packets, review threads, and CI receipts remain authoritative. This file records **what each body of work proves, what state the evidence is in, and where it belongs in a career narrative**.
+
+For moving release queues and current engineering emphasis, read [`current-state.md`](current-state.md) first. This inventory should prefer durable product/evidence boundaries over one-day branch SHAs or transient mergeability states.
 
 ## Evidence classes used here
 
@@ -14,9 +18,9 @@ Keep these distinctions explicit:
 - **maintainer-approved / accepted** — substantive upstream acceptance exists even if merge is separate;
 - **finding adopted through another landing path** — the diagnosis or repair mechanism was taken upstream, but the final PR/commit belongs to another author or automation path;
 - **finding accepted, repair boundary changed** — maintainers agreed there was a real problem but chose a different project-native repair;
-- **submitted / awaiting disposition** — public issue or PR exists, but external acceptance is not yet established;
+- **submitted / awaiting disposition** — public issue or PR exists, but external acceptance is still open;
 - **owned product / system** — evidence comes from a repository Leo controls rather than third-party review;
-- **research investigation** — mechanism and experiments are substantial, but it must not be represented as an upstream contribution.
+- **research investigation** — mechanism and experiments are substantial, with contribution claims reserved for work that actually crosses the upstream boundary.
 
 Merge count is useful evidence, not the ontology.
 
@@ -30,17 +34,20 @@ Repository: https://github.com/teamleaderleo/preflight
 
 Detailed Scrapbook record: [`records/preflight.md`](records/preflight.md)
 
-State: **owned performance system; strongest current independent-engineering artifact**.
+State: **owned performance/product system in operational first-beta candidate execution; strongest current independent-engineering artifact**.
 
-Current controlled timing evidence is the 2026-08-15 same-profile campaign merged through Preflight PR 440: 89.00s baseline median versus 15.53s accelerated median on one 83-mod profile, five accepted runs per condition, interleaved in one session, no exclusions.
+The clean controlled timing campaign remains the 2026-08-15 same-profile comparison: 89.00s ordinary-launch median versus 15.53s Preflight median on one 83-mod profile, five accepted runs per condition, interleaved in one session, no exclusions. Later development evidence retained a fourteen-second regime: a reviewed G1/deferred-heap-commit condition produced a 14.04s five-run median and 13.69s best observation. The repository deliberately keeps those later observations separate from the controlled before/after campaign and from the still-pending benchmark against the exact accepted package bytes.
+
+Source and rendered-UI convergence are complete. Private signing/package rehearsals have succeeded across Linux, macOS, and Windows. The remaining first-beta gate is operational: one maintainer-authorized immutable candidate, native Windows/Linux licensed-install acceptance, package-bound startup/lifecycle/update/report evidence, and the hands-on report-intake canary.
 
 What it proves:
 
 - Java runtime and bytecode instrumentation in a codebase/ecosystem Leo does not own;
-- performance investigation using JFR, seam timing, replay harnesses, controlled A/B campaigns, and evidence archives;
-- exact compatibility identities and fail-open fallback rather than assuming cached/prepared work remains valid;
+- performance investigation using JFR, seam timing, replay harnesses, controlled A/B campaigns, and retained evidence;
+- exact compatibility identities and fail-open fallback instead of assuming prepared work remains valid;
+- storage/layout optimization, including learned Compact texture packs where physical access order affects startup;
 - willingness to discard or reframe attractive optimization theories when better measurement disproves them;
-- packaging, diagnostics, rollback/update work, and productization beyond a benchmark script.
+- native desktop packaging, signed-update machinery, privacy-bounded support, diagnostics, profiles, settings, recovery, and release evidence beyond a benchmark script.
 
 Career use: **resume lock**. Largest owned-project allocation in a general, Valve/runtime, performance, or evaluation-oriented cut.
 
@@ -56,25 +63,31 @@ What it proves:
 
 - subtle TypeScript/runtime state and lifecycle correctness;
 - focused regression design around repeated calls, cleanup, failure precedence, and caller-owned state;
-- ability to produce work that survives a fast-moving AI-tooling repository's own maintenance workflow.
+- ability to produce work that survives a high-throughput AI-tooling repository's maintenance workflow.
 
-Career use: **resume lock**, especially for Vercel, AI tooling, developer tools, coding-agent infrastructure, and evaluation work.
+Career use: **resume lock**, especially for Vercel, AI tooling, developer tools, coding-agent systems, and evaluation work.
 
 ### Cloud Hypervisor
 
 Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
 
-State: **two merged upstream Rust/VMM contributions; deeper QCOW metadata-ownership repair under substantive maintainer review**.
+State: **three merged upstream Rust/VMM contributions; deeper QCOW metadata-ownership repair still open**.
 
-The merged work replaces SSH disappearance as a shutdown-completion proxy with the VMM's exact shutdown event, and replaces ACPI construction panic paths with typed boot errors. The QCOW follow-on reaches persistent metadata ownership/refcount ordering and failure/reopen safety.
+Merged work covers three distinct boundaries:
+
+1. exact VMM shutdown events replace SSH disappearance as the lifecycle gate before VM/disk reuse;
+2. ACPI construction failures propagate through typed VM boot errors instead of panicking;
+3. VFIO DMA ranges crossing gaps between separately mmap'd sparse BAR areas are rejected unless one mapping covers the complete request.
+
+The open QCOW follow-on reaches persistent metadata ownership/refcount ordering: replacement L2 tables gain ownership before L1 publication, and relocation releases the previous table at the local handoff instead of deferring ownership changes beyond the switch.
 
 What it proves:
 
-- low-level systems work in a real VMM rather than only application/library code;
-- lifecycle synchronization, error propagation, architecture/feature validation, and persistent-state reasoning;
-- productive review iteration, including accepting and incorporating a deeper maintainer objection.
+- low-level systems work in a real VMM;
+- lifecycle synchronization, error propagation, PCI/VFIO mapping semantics, and persistent-state ownership;
+- productive review iteration across several independent accepted fixes.
 
-Career use: **resume lock** for systems/infra and strong breadth proof elsewhere.
+Career use: **resume lock** for systems/platform work and strong breadth proof elsewhere.
 
 ### Vite and Cloudflare Workers SDK
 
@@ -82,8 +95,10 @@ Detailed Scrapbook record: [`records/open-source.md`](records/open-source.md)
 
 State:
 
-- Vite: one merged optimizer resource-lifecycle fix, a second lifecycle repair approved by two maintainers, and a config-idempotence follow-on in review;
-- Cloudflare Workers SDK: two merged repairs covering Miniflare teardown ordering and Cloudflare Access credential freshness/cache semantics.
+- Vite: **two merged lifecycle/correctness fixes**, plus an open repeated-`resolveConfig()` idempotence follow-on;
+- Cloudflare Workers SDK: **two merged repairs** covering Miniflare teardown ordering and Cloudflare Access credential freshness/cache semantics.
+
+The Vite merges cover temporary optimizer analysis-bundle cleanup and propagation of `buildEnd` failure into `closeBundle(error)` before rethrow. The open follow-on prevents resolver-generated environment state from duplicating optimizer plugins across repeated config resolution.
 
 What they prove:
 
@@ -91,13 +106,13 @@ What they prove:
 - resource cleanup, repeated-resolution idempotence, credential freshness, and teardown error semantics;
 - responsiveness to maintainer feedback without widening the patch unnecessarily.
 
-Career use: strong selected OSS specimens. Do not turn the resume into a logo wall when AI SDK + Cloud Hypervisor already establish the larger point.
+Career use: strong selected OSS specimens. Prefer a few mechanism-rich examples over a logo wall.
 
 ---
 
 ## Accepted findings where the final landing path differed
 
-These are important because they demonstrate technical diagnosis and project-boundary judgment even when the final GitHub badge is not `merged` on Leo's PR.
+These demonstrate technical diagnosis and project-boundary judgment even when Leo's original PR is not the final merged artifact.
 
 ### Zustand — stale async hydration after `clearStorage()`
 
@@ -109,9 +124,9 @@ State: **reported with a concrete repair; upstream subsequently merged the same 
 
 The report identified that `clearStorage()` could remove persisted state while an older async hydration remained authorized to publish afterward. Zustand already had a `hydrationVersion` generation for stale hydration; the proposed core repair was to advance that generation when clearing storage. Upstream PR 3555 merged that mechanism and broader regression coverage.
 
-Career interpretation: stronger than "filed a bug" and weaker/different than "my PR merged." Safe wording is that Leo **identified the race and supplied the generation-invalidation repair subsequently implemented upstream**.
+Career interpretation: Leo **identified the race and supplied the generation-invalidation repair subsequently implemented upstream**.
 
-Resume value: technically clean but usually bench material because stronger landed specimens already prove async/state correctness.
+Resume value: technically clean bench material because stronger landed specimens already prove async/state correctness.
 
 ### BuildKit — rootless/rootful mount-point reproducibility
 
@@ -123,7 +138,7 @@ State: **real divergence identified and submitted; maintainer replaced the repai
 
 The underlying problem was rootless/rootful output divergence caused by mount points removed during rootless spec conversion. Leo's candidate cleaned the finalized runtime-created mount stubs after rootless conversion. The maintainer replacement kept the diagnosis but chose to restore the missing rootless mount points instead, preserving existing rootful output and avoiding a compatibility-version change.
 
-Career interpretation: this is a strong systems review story because the important disagreement is **which side of the compatibility boundary should move**, not whether the bug existed.
+Career interpretation: strong systems review story because the important disagreement is **which side of the compatibility boundary should move**.
 
 Resume value: strong alternate for systems/container roles; usually interview/portfolio material in a general cut.
 
@@ -139,7 +154,7 @@ State: **real off-by-one relationship identified; maintainer preferred repairing
 
 Leo's patch made the reset-mask allocation match the then-documented inclusive `MaxCPU` meaning. Maintainer review showed repository history supported making `MaxCPU` exclusive instead, which made the existing allocation expression correct and restored one meaning across the codebase.
 
-Career interpretation: excellent evidence of review judgment. The win is recognizing the symptom, understanding the historical boundary after review, and preferring the cleaner project-native repair over personal merge count.
+Career interpretation: excellent evidence of review judgment: identify the symptom, recover the historical contract, and prefer the cleaner project-native repair over personal merge count.
 
 Resume value: interview story, not headline bullet.
 
@@ -153,11 +168,11 @@ State: **finding accepted; maintainer-owned fix merged; report closed as complet
 
 The report showed that the production MCP HTTP server exposed a fixed-header `/killkillkill` route that allowed an ordinary reachable HTTP client to trigger the server's graceful `SIGINT` shutdown path. It traced the route to a Windows lifecycle test, distinguished CSRF mitigation from caller/process ownership, and included a prepared parent-stdin alternative.
 
-Upstream agreed with the authority problem but chose a smaller project-native boundary: PR 42133 gates `/killkillkill` on `isUnderTest()` so production MCP HTTP servers do not expose the test-only shutdown hook. That merged and closed the report.
+Upstream chose a smaller project-native boundary: PR 42133 gates `/killkillkill` on `isUnderTest()` so production MCP HTTP servers do not expose the test-only shutdown hook.
 
-Career interpretation: accepted diagnosis with a different final repair. The strong part is locating the lifecycle-authority leak and providing a reproducible report; do not claim the prepared stdin design as the upstream implementation.
+Career interpretation: accepted diagnosis with a different final repair. The strong part is locating the lifecycle-authority leak and providing a reproducible report.
 
-Resume value: solid accepted-finding/interview material, but usually below the merged Vite/Cloudflare/Cloud Hypervisor specimens on a one-page cut.
+Resume value: solid accepted-finding/interview material, usually below the merged Vite/Cloudflare/Cloud Hypervisor specimens on a one-page cut.
 
 ---
 
@@ -167,16 +182,20 @@ Primary Linux Fieldwork investigation: https://github.com/teamleaderleo/linux-fi
 
 Continuation: https://github.com/teamleaderleo/linux-fieldwork/issues/672
 
-State: **deep research investigation with owned-fork implementations and real runtime evidence; upstream FEX remains read-only/no-contact under its AI-generated-code policy**.
+Owned fork: https://github.com/teamleaderleo/FEX
+
+State: **deep research investigation with owned-fork implementations and real runtime evidence; upstream contribution claims remain outside the current boundary**.
 
 The investigation began from Apple M5 → ARM Linux VM → FEX → x86 Vulkan/Wine execution and separated into two findings:
 
 1. a Vulkan dynamic proc-address routing hole that could bypass FEX's existing callback-safe custom path;
 2. a deeper generated-thunk executable-lifetime problem where a native function pointer remains valid while its guest-side generated adapter belongs to an unloaded wrapper generation.
 
-The lifetime work went beyond pinning as a workaround. It forced moved wrapper reloads, separated future-dispatch invalidation from already-selected executable code, reproduced the selected-before-unmap race, and compared ownership architectures. The strongest demonstrated long-term direction is a generated process-resident bridge containing only escaped executable glue while ordinary wrapper code/state remains unloadable. Real generated Vulkan and GL tests cover dynamic function pointers, host→guest callbacks, moved reloads, and a real amd64 `vulkaninfo --summary` under ARM64 FEX.
+The lifetime work forced moved wrapper reloads, separated future-dispatch invalidation from already-selected executable code, reproduced the selected-before-unmap race, and compared ownership architectures. The strongest demonstrated long-term direction is a generated process-resident bridge containing only escaped executable glue while ordinary wrapper code/state remains unloadable. Real generated Vulkan and GL tests cover dynamic function pointers, host→guest callbacks, moved reloads, and a real amd64 `vulkaninfo --summary` under ARM64 FEX.
 
-What it proves if/when the human-owned implementation is prepared for external use:
+The owned fork also retains a Vulkan candidate around callback-sensitive dynamic proc-address routing and native GIPA/GDPA availability semantics, plus a metadata/inventory consistency check. Hosted ARM64 controls and x86/FEX runs validate the candidate boundary. The remaining recorded hardware confirmation is the Apple M5 + Venus path.
+
+What it proves:
 
 - dynamic-loader and executable-lifetime reasoning;
 - cross-ISA thunk/ABI mediation;
@@ -184,9 +203,9 @@ What it proves if/when the human-owned implementation is prepared for external u
 - concurrency/reclamation boundaries;
 - experimental design that lets plausible architectures lose.
 
-Career use **today**: private/internal portfolio and interview context only. Do not represent research code as upstream FEX contribution. If a compliant human-derived submission eventually exists, reclassify it then.
+Career use **today**: research/interview context. Describe the owned fork and runtime evidence directly; reserve “upstream contribution” language for work that actually crosses that boundary under upstream policy.
 
-For Valve/runtime/platform roles this is a particularly useful frame beside Preflight and Cloud Hypervisor because it makes the common thread unmistakably runtime/compatibility/systems work rather than one unusually deep game project.
+For Valve/runtime/platform roles this is especially useful beside Preflight and Cloud Hypervisor because it makes the common thread unmistakably runtime/compatibility/systems work rather than one unusually deep game project.
 
 ---
 
@@ -194,27 +213,27 @@ For Valve/runtime/platform roles this is a particularly useful frame beside Pref
 
 Detailed Scrapbook record: [`records/working-style.md`](records/working-style.md)
 
-State: **active working model; increasingly explicit across several owned systems and upstream research lanes**.
+State: **active working model implemented across several owned systems and upstream research lanes**.
 
-The portfolio-level point is narrower than "AI makes Leo faster." The stronger evidence is that a recurring method now spans several kinds of work:
+The portfolio-level point is narrower than “AI makes Leo quicker.” The stronger evidence is a recurring method across different work:
 
 - [Preflight](https://github.com/teamleaderleo/preflight) uses agents inside one deep product while tying performance and compatibility claims to runtime evidence, controlled measurement, exact identities, and fallback behavior;
 - [Fieldwork](https://github.com/teamleaderleo/fieldwork) and [Linux Fieldwork](https://github.com/teamleaderleo/linux-fieldwork) move the same code-first investigation method across unfamiliar repositories, preserve negative results, and expose selected work to independent maintainer review;
-- [Stensibly](https://github.com/teamleaderleo/stensibly) externalizes responsibility, authority, leases, handoffs, and continuation so work can survive worker replacement and stale sessions;
-- [Cultist](https://github.com/teamleaderleo/cultist) explores repository memory and just-enough evidence so a fresh worker can recover useful precedent, counterexamples, current work, and reviewed rationale before repeating manual archaeology.
+- [Stensibly](https://github.com/teamleaderleo/stensibly) externalizes responsibility, authority, leases, handoffs, provider observations, continuation, and recovery so work can survive worker replacement and provider ambiguity;
+- [Cultist](https://github.com/teamleaderleo/cultist) recovers bounded repository evidence, current-work snapshots, counterexamples, provenance, and decision memory, then measures whether selected evidence changes what a fresh worker does next;
+- [SmolRunner](https://github.com/teamleaderleo/smolrunner) turns operator-owned Apple-silicon compute into trust-tiered Linux execution, keeping hostile work disposable while allowing reviewed trusted state to remain resident where it earns the latency win;
+- [Renderprove](https://github.com/teamleaderleo/renderprove) and [Proofwake](https://github.com/teamleaderleo/proofwake) separate browser/rendered evidence production from durable revision-evidence memory.
 
 What it currently supports:
 
-- human attention is increasingly allocated to problem selection, contract choice, evidence quality, review boundaries, and consequential decisions while agents supply search, implementation, experimentation, and retrieval capacity;
-- the workflow treats worker/session loss as normal and tries to preserve enough durable state for another actor to continue from evidence rather than chat memory;
-- domain transfer is visible across Java/JVM performance, TypeScript SDKs/tooling, Rust virtualization, Linux/container work, browser systems, and agent coordination;
-- several outputs have encountered independent external review, while Cultist is explicitly adding held-out behavioral tests for whether surfaced repository evidence changes what a fresh worker does next.
+- human attention can concentrate on problem selection, contract choice, evidence quality, review boundaries, and consequential decisions while agents supply search, implementation, experimentation, and retrieval capacity;
+- worker/session loss is treated as normal, with durable state and evidence carrying continuation across actors;
+- domain transfer is visible across Java/JVM performance, TypeScript SDKs/tooling, Rust virtualization, Linux/container work, browser systems, agent coordination, execution, and evidence systems;
+- several outputs have encountered independent external review, while owned systems increasingly test their own continuation, evidence, and recovery claims in dogfood.
 
-This is also the modern version of an older personal habit: capture generously, synthesize quickly, keep useful residue, and revisit it when a real problem creates demand. Speech-to-text and agents make the residue cheaper to create and much cheaper to recover; Stensibly and Cultist attempt to make continuation and retrieval explicit engineering concerns rather than personal-memory tricks.
+This is the modern version of an older personal habit: capture generously, synthesize quickly, keep useful residue, and revisit it when a real problem creates demand. Speech-to-text and agents make residue cheaper to create and recover; Stensibly, Cultist, Proofwake, and the repository work records turn more of that continuity into explicit software and evidence contracts.
 
 Career use: **synthesis narrative rather than a standalone logo/bullet**. It is especially useful for coding-agent environments, developer tools, evaluation, durable execution, and research-engineering roles because it explains why the owned systems and cross-repository work belong in one portfolio. Keep individual technical claims tied to their source repositories.
-
-Do not overstate: Stensibly still describes a guarded pilot boundary, Cultist is an early prototype, and the broader method has several strong cases rather than a general proof that agent-heavy engineering works everywhere.
 
 ---
 
@@ -224,36 +243,35 @@ Do not overstate: Stensibly still describes a guarded pilot boundary, Cultist is
 
 Repository: https://github.com/teamleaderleo/stensibly
 
-State: **live hosted coordination foundation; active product/system development**.
+State: **live hosted coordination/continuation system in sustained dogfood**.
 
 Core thesis: the board shows work; the ledger governs who may do it. Stensibly separates responsibility from authority and keeps shared coordination state outside any particular model/runtime.
 
-Current implemented surface includes Convex-backed state, Cloudflare Worker API, browser sessions, bearer clients, REST v1, remote MCP, claims/renewable leases, events/artifacts/handoffs, idempotent commands, project/workspace scoping, and guarded exact-CAS GitHub publication. Recent work has pushed further into durable worker enrolment/selection, race-safe responsibility acceptance, continuation, mail/provider reconciliation, and explicit authority/effect boundaries.
+Current implemented surface includes Convex-backed state, Cloudflare Worker API, browser sessions, bearer clients, REST v1, dual-era remote MCP, claims/renewable leases, events/artifacts/handoffs, idempotent commands, project/workspace scoping, and guarded exact-CAS GitHub publication. Real work now crosses disposable worker sessions through durable handoffs and provider-backed continuation.
 
-A recent merged example, PR 1532, takes a read-only work-selection recommendation and requires one exact owner-bound worker to atomically accept responsibility against the current item version, claim generation, work fingerprint, WIP budget, and independence rules. Competing workers racing on the same recommendation produce one winner and one refresh-required loser rather than duplicate ownership.
+Recent production dogfood extends that into repository attention and mail: GitHub states can compile into deterministic mail checkpoints, project-owned continuation handles survive the handoff, webhook observations feed the publisher, the Quarry mapping has automatic Gmail delivery active in the Worker, and a bounded read-only public GitHub Events fallback can supply observations for that explicit mapping.
 
 What it proves:
 
 - system invention rather than isolated repair;
 - distributed coordination and race/lease semantics;
 - authn/authz, provenance, replay/idempotency, exact preconditions, and external-effect fencing;
+- continuation through worker replacement and provider ambiguity;
 - ability to keep model behavior separate from server-owned authority.
 
-Career use: **strong owned-system specimen**. One dense line on a general resume; much larger allocation for agent infrastructure, durable execution, coordination, or reliability roles.
-
-Do not overstate: the README still explicitly says guarded single-project pilot, not unattended multi-project autonomy or irreversible effects.
+Career use: **strong owned-system specimen**. One dense line on a general resume; much larger allocation for agent systems, durable execution, coordination, or reliability roles.
 
 ## SmolRunner
 
 Repository: https://github.com/teamleaderleo/smolrunner
 
-State: **pre-alpha; substantial durable controller foundations; no complete unattended disposable JIT-runner loop yet**.
+State: **pre-alpha trust-tiered Linux execution system in live Apple-silicon acceptance**.
 
-The product aims to turn an operator-owned Mac into bounded disposable GitHub Actions capacity using fresh Lima/VZ Linux workers while GitHub remains scheduler/status/log owner.
+The project began around bounded disposable GitHub Actions capacity from an operator-owned Mac using Lima/VZ Linux workers while GitHub remains the ordinary workflow surface. That strict disposable lane now includes prepared worker generations, official Runner Scale Set integration, Keychain credential acquisition, durable assignment/no-replay handling, clone/JIT/teardown composition, LaunchAgent supervision, controller-death evidence, exact worker ownership, and repeated physical Quarry pilots.
 
-The repository already contains durable attempts/catalogs, resource admission, exact worker/template/source identities, shell-free bounded process execution, ownership proofs, crash recovery, staged/atomic persistence, and fail-closed mutation rules. Current M3 work now consumes retained GitHub Runner Scale Set lifecycle evidence using exact request/job/runner identities rather than event ordering or mutable names.
+The product direction now includes trusted hot execution as a first-class programme. A trusted persistent lane, warm pause/resume, auto-idle behavior, hot-state path policy, immutable Git object-pool primitives/fixed generation markers, and trusted OverlayFS plan/descriptor checks allow valuable Linux state to remain resident where trust and measured value permit.
 
-PRs 448–452 are a useful current slice: typed retained Scale Set events, exact job/request lookup, durable runner-request binding, fail-closed lifecycle reconciliation, and finally a paired durable catalog/delivery transaction that can atomically advance catalog revisions while binding crash recovery to exact prior/target bytes.
+The active boundary still includes finishing the installed-service one-job disposable journey, restart-safe ownership for in-flight Lima mutations, broader sleep/reboot/outage/teardown recovery, and the hostile-worker network boundary.
 
 What it proves:
 
@@ -261,81 +279,128 @@ What it proves:
 - crash-consistent local state and recovery;
 - identity/ownership before destructive mutation;
 - CI runner/sandbox threat modeling;
-- careful separation of observation, authorization, planning, persistence, and execution.
+- trust-tiered residency and reusable-state validity;
+- careful separation of observation, authorization, planning, persistence, execution, and teardown.
 
-Career use: **strong for infra/systems/security/coding-agent execution roles**. Keep the pre-alpha boundary visible.
+Career use: **strong for systems/security/coding-agent execution roles**. Keep the pre-alpha boundary visible while describing the substantial physical controller and hot-state work that already exists.
+
+## Cultist
+
+Repository: https://github.com/teamleaderleo/cultist
+
+State: **active repository-evidence research prototype in sustained dogfood**.
+
+The installed Rust distribution is `cargo-cultist`. Public analyzers are deterministic, local, and read-only: repository convention recovery, change-time check/diff evidence, concurrent-change preflight, historical companion analysis, and CI selector analysis. Research lanes add bounded evidence packets, C1 representation, decision memory, active-work/provider adapters, and behavioral trials.
+
+The core research question is empirical: does selected evidence change the next justified action, prevent an expensive wrong turn, or save a later worker from repeating manual investigation? Recent work also tightens provider-snapshot identity, bounded file-coverage proofs, pagination uncertainty, and active-work CI against the exact provider state it observed.
+
+What it proves:
+
+- provenance-bearing deterministic analysis;
+- conservative `UNKNOWN` semantics where evidence cannot justify absence or independence;
+- evidence selection under bounded attention/byte budgets;
+- behavioral evaluation of whether repository context changes work;
+- a research discipline that retains counterexamples, quiet cases, and demotion evidence.
+
+Career use: **research/devtools supporting specimen**, especially for coding-agent context, evaluation, review intelligence, and repository-aware tooling.
 
 ## Elatura
 
 Repository: https://github.com/teamleaderleo/elatura
 
-State: **M0 evidence/observation on main; conceptually broad, live transformation still intentionally disabled**.
+State: **active prototype and dogfood beyond the original observation-only M0**.
 
-Elatura is a local-first adaptive browser sidecar for oversized interactive applications. ChatGPT conversations large enough to freeze/crash a normal browser are the first workload, but the architecture is deliberately adapter-driven rather than ChatGPT-specific.
+Elatura is a local-first adaptive browser sidecar for oversized interactive applications. ChatGPT conversations large enough to freeze/crash a normal browser are the first workload, while the adapter boundary stays broader than one site.
 
-Main already contains observe-only Firefox transport, content-free benchmark reports, generic adapter contracts/conformance, graph-shape inspection, synthetic oversized/malformed fixtures, active-path planning, fail-open orchestration, structural fingerprints, synthetic-only cache/materialization, representation/provenance contracts, and transform emergency controls.
+Current main includes observe-only Firefox measurement; a locked fail-open slim mode with bounded live DOM discovery, render suppression, latest-window planning, placeholders, restoration, and drift handling; a preflighted DOM executor/browser host; local Android completion-notification sensing and diagnostics; generic adapter/conformance contracts; schema-drift rules; deterministic oversized/malformed fixtures; bounded fingerprints/cache/provenance; and broader resource/offload experiments.
 
-An open Firefox slimming stack explores bounded DOM discovery, latest-window planning, fail-open drift handling, content-free fixtures, preflight-before-mutation execution, and a browser host that records whether destructive mutation actually started so partial failure can force the existing Stock recovery path. These branches are experiments, not landed main behavior.
+The current product question is which intervention layer earns its complexity in real use: window/suppress live state, use a cheaper local representation, or move execution elsewhere while preserving the native service experience.
 
 What it proves:
 
-- a generalized product idea around **adaptive representation of oversized authenticated web applications**;
-- browser interception, privacy-preserving measurement, schema drift, fail-open transforms, cache/provenance contracts, and conservative authority gating;
-- a willingness to keep destructive behavior disabled until evidence and recovery semantics are strong enough.
+- a generalized product idea around adaptive representation of oversized authenticated applications;
+- browser interception and DOM control with explicit fail-open recovery;
+- privacy-preserving measurement, schema drift, cache/provenance contracts, and conservative authority gating;
+- physical-device/browser dogfood feeding implementation choices.
 
-Career use: **high-concept owned-project bench**. Potentially strong for browser/runtime/product-infrastructure roles once a real live workload crosses the current safety gate. Do not present open slimming stacks as shipped behavior.
+Career use: **high-concept owned-project bench** and a plausible larger specimen for browser/runtime/product-systems roles.
 
 ## Renderprove
 
 Repository: https://github.com/teamleaderleo/renderprove
 
-State: **early-stage but working evidence tool**.
+State: **early-stage but working browser-evidence tool**.
 
-Renderprove starts a trusted local app or inspects an existing deployment in Chromium and emits versioned browser evidence: screenshots and hashes, navigation/page facts, diagnostics, and policy disposition. It also has bounded local MCP, repeatability probes in fresh containers, bounded interaction plans, deterministic visual comparison, and optional advisory AI artifacts that remain explicitly non-authoritative.
+Renderprove starts a trusted local app or inspects an existing deployment in Chromium and emits versioned browser evidence: screenshots and hashes, navigation/page facts, diagnostics, and policy disposition. It also has bounded local MCP, repeatability probes in fresh rootless Podman containers, bounded interaction plans, deterministic visual comparison, and optional Cloudflare Gemma advisory artifacts that remain explicitly non-authoritative.
 
 What it proves:
 
 - browser evidence contracts and deterministic/reproducible visual review;
 - security boundaries around agent-driven browser interaction;
 - separation of deterministic browser evidence from optional model advice;
-- a coherent place in the larger SmolRunner → Renderprove → Proofwake → Stensibly toolchain.
+- a coherent role in the SmolRunner → Renderprove → Proofwake → Stensibly toolchain.
 
-Career use: supporting project, particularly for coding-agent evaluation, developer tooling, visual QA, and agent infrastructure. Usually below Preflight/Stensibly/SmolRunner on a one-page resume.
+Career use: supporting project, particularly for coding-agent evaluation, developer tooling, visual QA, and agent systems.
 
 ## Proofwake
 
 Repository: https://github.com/teamleaderleo/proofwake
 
-State: **working local evidence index with durable ledger, collectors, reports/dashboard, diagnostics, Git/GitHub observation, and read-only MCP**.
+State: **working local revision-evidence index; Proofwake is now the primary product/command identity, with Shadowbill compatibility retained**.
 
-Proofwake stores content-minimised observations by repository/revision so humans and agents can ask what changed, which revisions have convincing evidence, what is failing/stale/silent, and what recovered. It explicitly does not schedule work, approve mutations, operate runners, deploy, or rank developers from raw activity.
+Proofwake stores content-minimised observations by repository/revision so humans and agents can ask what changed, which revisions have convincing evidence, what is failing/stale/silent, and what recovered. The repository includes a durable local ledger, Git and GitHub collectors, reports, dashboard, diagnostics, and read-only MCP. The inherited Shadowbill AI-usage reckoner remains an optional module inside the broader product.
 
-Recent merged work adds strict appendable evaluation observations, deterministic evaluation-evidence projections, and a read-only MCP view over those projections. An opt-in evaluation-write MCP transport remains separately gated/in review.
+Its boundary is deliberately observational: Proofwake does not schedule CI, operate runners, deploy software, assign work, approve mutations, ingest arbitrary logs, or rank developers by raw activity.
 
 What it proves:
 
 - append-oriented durable evidence modeling;
 - strict privacy/content-minimisation boundaries;
-- deterministic projections that preserve sparse/partial evidence instead of manufacturing a score;
-- useful systems composition with Renderprove/SmolRunner/Stensibly without collapsing their authority boundaries.
+- source identity, freshness, failure, and recovery as explicit evidence dimensions;
+- useful systems composition with Renderprove/SmolRunner/Stensibly without collapsing authority boundaries.
 
-Career use: supporting agent/evaluation/reliability project. More interesting as part of the broader toolchain than as a generic standalone resume bullet today.
+Career use: supporting agent/evaluation/reliability project; strongest as part of the broader execution/evidence/coordination story.
+
+## Quarry
+
+Repository: private `teamleaderleo/quarry`.
+
+State: **active private trading-research lab; live-order permission disabled; execution/accounting readiness is ahead of prospective financial evidence**.
+
+Quarry carries substantial engineering: immutable dataset and experiment identities, deterministic backtests/tournaments/walk-forward work, causal execution policy, futures/options accounting, exact risk/restart state, verification receipts, read-only broker observation, offline statement evidence, continuation handoffs, and sustained provider/data-fidelity work.
+
+Career use today: **private/internal engineering and dogfood context**, especially where it supplies real workloads to SmolRunner and Stensibly. Keep public claims scoped to shareable engineering evidence and defer a standalone public portfolio headline until the repository's publication boundary changes.
 
 ## Scrapbook / teamleaderleo.com
 
 Repository: https://github.com/teamleaderleo/scrapbook
 
-State: **live personal site, knowledge workspace, and agent-facing publication/evidence lab**.
+State: **live personal site, private knowledge workspace, and agent-facing publication/evidence lab**.
 
-The current repository includes the private Supabase-backed Space workspace, public tools/experiments, Workbench publishing, repository-backed agent check-ins, an Agent Journal evidence ledger, machine-readable access/contribution contracts, GitHub activity integration, browser/native-history work, and explicit retirement of obsolete surfaces.
+The current repository includes the private Supabase-backed Space workspace, Operator console, public tools/experiments, Workbench publishing, repository-backed agent check-ins, an Agent Journal evidence ledger, machine-readable access/contribution contracts, GitHub activity integration, and explicit retirement of obsolete surfaces.
+
+Routine hosted CI is intentionally compact: ESLint + Vitest and a separate production build, with persistent lint/build caches. Playwright remains an explicit author-side browser tool for changes that need browser evidence.
 
 What it proves:
 
-- long-lived product stewardship and willingness to delete/deprecate obsolete architecture;
-- a fairly unusual agent/human collaboration surface with explicit provenance and repository-backed publication;
-- frontend/product breadth alongside the lower-level systems work.
+- long-lived product stewardship and willingness to delete/deprecate obsolete code;
+- an unusual agent/human collaboration surface with explicit provenance and repository-backed publication;
+- frontend/product breadth alongside lower-level systems work.
 
-Career use: useful supporting proof and a public container for the rest of the portfolio. It should not displace stronger technical specimens on a one-page systems/devtools resume.
+Career use: useful supporting proof and the public container for much of the portfolio. It should not displace stronger technical specimens on a one-page systems/devtools resume.
+
+## Fieldwork and Linux Fieldwork
+
+Repositories:
+
+- https://github.com/teamleaderleo/fieldwork
+- https://github.com/teamleaderleo/linux-fieldwork
+
+State: **active code-first investigation/research workbenches**.
+
+Fieldwork organizes public programmes, target maps, experiments, owned-repository integration trials, exact-head review, and deliberate upstream delivery. Linux Fieldwork carries the Linux/Debian variant with source imports, reproducible investigations, live-fieldwork status, and reusable review/process lessons.
+
+Career use: method/evidence supporting systems. Their strongest value appears through the accepted upstream work and retained investigations they help produce.
 
 ## Glossless and other owned projects
 
@@ -355,32 +420,33 @@ The one-page resume should remain ruthless. Current default hierarchy is roughly
 2. Vercel AI SDK;
 3. Cloud Hypervisor;
 4. the best role-specific Vite/Cloudflare/system specimen;
-5. one or two owned systems selected for the target: Stensibly, SmolRunner, Elatura, Glossless;
+5. one or two owned systems selected for the target: Stensibly, SmolRunner, Cultist, Elatura, Glossless;
 6. compact IBM corroboration and education.
 
-Do not list Zustand, BuildKit, runc, Playwright, FEX, Renderprove, Proofwake, and Scrapbook all at once. Their existence strengthens the body of evidence even when they lose the one-page space competition.
+Zustand, BuildKit, runc, Playwright, FEX, Renderprove, Proofwake, Quarry, Fieldwork, Linux Fieldwork, and Scrapbook strengthen the body of evidence even when they lose the one-page space competition.
 
 ## LinkedIn
 
 LinkedIn does not need to mimic conventional employment history. A later rewrite can use a small number of project entries or a consolidated independent/open-source engineering section with concrete mechanisms and evidence links.
 
-Useful project candidates for LinkedIn are Preflight, Stensibly, SmolRunner, and potentially Elatura once its product boundary advances. Renderprove/Proofwake/Scrapbook fit better as supporting links or portfolio context unless a target audience specifically values them.
+Useful project candidates are Preflight, Stensibly, SmolRunner, and role-dependent Elatura/Cultist. Renderprove/Proofwake/Scrapbook fit well as supporting links or portfolio context unless the target audience specifically values them.
 
 ## Interviews
 
 Keep the non-merge stories. BuildKit and runc are especially good because they show the ability to change conclusion after maintainer/project-history evidence. Playwright is useful as an accepted diagnosis where upstream chose a smaller repair boundary. FEX is useful for systems depth if described as research rather than contribution. Zustand is useful for explaining substantive authorship when GitHub landing mechanics obscure it.
 
-The cross-repository method is useful when an interviewer asks how AI changes the work itself. Keep the answer concrete: agents expand search and execution capacity; durable evidence, exact review boundaries, external maintainers, and selective human attention keep the work answerable to reality. Use Preflight, Stensibly, Fieldwork/Linux Fieldwork, and Cultist as distinct examples rather than presenting them as one finished platform.
+The cross-repository method is useful when an interviewer asks how AI changes the work itself. Keep the answer concrete: agents expand search and execution capacity; durable evidence, exact review boundaries, external maintainers, and selective human attention keep the work answerable to reality. Use Preflight, Stensibly, SmolRunner, Cultist, Fieldwork/Linux Fieldwork, Renderprove, and Proofwake as distinct examples rather than presenting them as one finished platform.
 
 ## Applications
 
 Tailor by actual work:
 
 - **Valve / runtime / performance:** Preflight, Cloud Hypervisor, FEX research, SmolRunner, selected graphics/browser breadth;
-- **Vercel / devtools / AI runtime:** AI SDK, Vite, Cloudflare, Preflight, Stensibly;
-- **coding-agent evaluation / environments:** Preflight, AI SDK, SmolRunner, Renderprove, Proofwake, Stensibly, cross-repository OSS repair record;
-- **systems / infrastructure:** Cloud Hypervisor, BuildKit story, Preflight runtime work, SmolRunner, FEX research;
-- **agent coordination / durable execution:** Stensibly, SmolRunner, Proofwake, Renderprove, AI SDK.
+- **Vercel / devtools / AI runtime:** AI SDK, Vite, Cloudflare, Preflight, Stensibly, Cultist;
+- **coding-agent evaluation / environments:** Preflight, AI SDK, SmolRunner, Renderprove, Proofwake, Stensibly, Cultist, cross-repository OSS repair record;
+- **systems / platform:** Cloud Hypervisor, BuildKit story, Preflight runtime work, SmolRunner, FEX research;
+- **agent coordination / durable execution:** Stensibly, SmolRunner, Proofwake, Renderprove, Cultist, AI SDK;
+- **browser / adaptive-client systems:** Elatura, Renderprove, Scrapbook, selected Vite/Playwright work.
 
 ## Refresh rule
 
@@ -390,4 +456,5 @@ Before exporting any claim to a resume, LinkedIn, application, or public portfol
 2. distinguish merged, approved, adopted, replaced, submitted, and research-only status;
 3. use the smallest mechanism/result that demonstrates the work;
 4. preserve project-specific review reversals instead of laundering them into merge claims;
-5. prefer current controlled measurements over prettier chronological endpoints.
+5. prefer current controlled measurements over prettier chronological endpoints;
+6. keep transient queue state in `current-state.md` and durable product/evidence boundaries here.


### PR DESCRIPTION
## Summary

- align the Scrapbook README with the current hosted CI and explicit browser-check policy
- refresh the homepage SmolRunner card from the old disposable-runner description to its current trust-tiered Linux execution direction
- refresh `work/current-state.md` against the live owned repositories and current upstream PR state
- rewrite stale durable inventory entries for Preflight, Stensibly, SmolRunner, Cultist, Elatura, Proofwake, Renderprove, Quarry, Scrapbook, Fieldwork, and Linux Fieldwork
- correct Vite and Cloud Hypervisor follow-on status language so transient mergeability belongs to the live upstream PR
- separate Preflight's controlled 89.00s → 15.53s comparison from the later 14.04s median / 13.69s best development evidence

## Verification

Claims were checked against the current repository READMEs, recent commits, Preflight release/evidence documents, current Scrapbook CI/package scripts, and the live Vite #23208 / Cloud Hypervisor #8721 PR metadata.

The only runtime-source change is one featured-repository display string in `lib/github-home.ts`; the remainder is documentation.